### PR TITLE
Add XRootDVectorReadSource

### DIFF
--- a/tests/test_0001-source-class.py
+++ b/tests/test_0001-source-class.py
@@ -44,6 +44,14 @@ def test_file(tmpdir):
                 b"@@@@@",
             ]
 
+
+def test_file(tmpdir):
+    filename = os.path.join(str(tmpdir), "tmp.raw")
+
+    with open(filename, "wb") as tmp:
+        tmp.write(b"******    ...+++++++!!!!!@@@@@")
+
+    for num_workers in [0, 1, 2]:
         with pytest.raises(Exception):
             uproot4.source.file.FileSource(
                 filename + "-does-not-exist", num_workers=num_workers
@@ -68,6 +76,13 @@ def test_memmap(tmpdir):
             b"@@@@@",
         ]
 
+
+def test_memmap(tmpdir):
+    filename = os.path.join(str(tmpdir), "tmp.raw")
+
+    with open(filename, "wb") as tmp:
+        tmp.write(b"******    ...+++++++!!!!!@@@@@")
+
     with pytest.raises(Exception):
         uproot4.source.file.FileSource(filename + "-does-not-exist")
 
@@ -86,6 +101,8 @@ def test_http():
         chunks = tmp.chunks([(0, 100), (50, 55), (200, 400)])
         assert [x.raw_data.tostring() for x in chunks] == [one, two, three]
 
+
+def test_http():
     source = uproot4.source.http.HTTPMultipartSource(
         "https://wonky.cern/does-not-exist", timeout=0.1
     )
@@ -106,6 +123,9 @@ def test_no_multipart():
             assert len(three) == 200
             assert one[:4] == b"root"
 
+
+def test_no_multipart_fail():
+    for num_workers in [0, 1, 2]:
         source = uproot4.source.http.HTTPSource(
             "https://wonky.cern/does-not-exist", num_workers=num_workers, timeout=0.1
         )
@@ -140,8 +160,30 @@ def test_xrootd():
         assert len(three) == 200
         assert one[:4] == b"root"
 
+
+def test_xrootd_fail():
     with pytest.raises(Exception) as err:
         source = uproot4.source.xrootd.XRootDSource(
+            "root://wonky.cern/does-not-exist", timeout=1
+        )
+
+
+def test_xrootd_vectorread():
+    pytest.importorskip("pyxrootd")
+    with uproot4.source.xrootd.XRootDVectorReadSource(
+        "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root"
+    ) as source:
+        chunks = source.chunks([(0, 100), (50, 55), (200, 400)])
+        one, two, three = [chunk.raw_data.tostring() for chunk in chunks]
+        assert len(one) == 100
+        assert len(two) == 5
+        assert len(three) == 200
+        assert one[:4] == b"root"
+
+
+def test_xrootd_vectorread_fail():
+    with pytest.raises(Exception) as err:
+        source = uproot4.source.xrootd.XRootDVectorReadSource(
             "root://wonky.cern/does-not-exist", timeout=1
         )
 

--- a/uproot4/source/xrootd.py
+++ b/uproot4/source/xrootd.py
@@ -30,6 +30,38 @@ def get_pyxrootd():
         )
 
 
+def get_server_config(file_path):
+    """
+    Query a XRootD server for it's configuration
+
+    Args:
+        file_path (str): The full URl to the requested resource
+
+    Returns:
+        readv_iov_max (int): The maximum number of elements that can be
+            requested in a single vector read
+        readv_ior_max (int): The maximum number of bytes that can be requested
+            per **element** in a vector read
+    """
+    from XRootD.client import FileSystem, URL
+    from XRootD.client.flags import QueryCode
+
+    url = URL(file_path)
+    eos = FileSystem("{}://{}/".format(url.protocol, url.hostid))
+
+    status, readv_iov_max = eos.query(QueryCode.CONFIG, 'readv_iov_max')
+    if not status.ok:
+        raise NotImplementedError(status)
+    readv_iov_max = int(readv_iov_max)
+
+    status, readv_ior_max = eos.query(QueryCode.CONFIG, 'readv_ior_max')
+    if not status.ok:
+        raise NotImplementedError(status)
+    readv_ior_max = int(readv_ior_max)
+
+    return readv_iov_max, readv_ior_max
+
+
 class XRootDResource(uproot4.source.chunk.Resource):
     """
     Resource wrapping a pyxrootd.File.
@@ -110,6 +142,82 @@ class XRootDResource(uproot4.source.chunk.Resource):
         if status.get("error", None):
             raise OSError(status["message"])
         return data
+
+
+class XRootDVectorReadSource(uproot4.source.chunk.Source):
+    """
+    Source managing data access using XRootD vector reads.
+    """
+    __slots__ = ["_file_path", "_max_num_elements", "_resource"]
+
+    def __init__(self, file_path, timeout=None, max_num_elements=None):
+        """
+        Args:
+            file_path (str): URL starting with "root://".
+            timeout (int): Number of seconds (loosely interpreted by XRootD)
+                before giving up on a remote file.
+            max_num_elements (int): Maximum number of reads to batch into a
+                single request. May be reduced to match the server's
+                capabilities.
+        """
+        self._file_path = file_path
+        self._timeout = timeout
+        self._max_num_elements, self._max_element_size = get_server_config(file_path)
+        if max_num_elements:
+            self._max_num_elements = min(self._max_num_elements, max_num_elements)
+        self._resource = XRootDResource(file_path, timeout)
+
+    def __enter__(self):
+        """
+        Does nothing and returns self.
+        """
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        """
+        Closes the HTTP(S) connection and passes `__exit__` to the worker
+        Thread.
+        """
+        pass
+
+    def chunks(self, ranges):
+        """
+        Args:
+            ranges (iterable of (int, int)): The start (inclusive) and stop
+                (exclusive) byte ranges for each desired chunk.
+
+        Returns a list of Chunks that will be filled asynchronously by the
+        one or more XRootD vector reads.
+        """
+        ranges = ranges[:]
+        all_request_ranges = [list()]
+        while ranges:
+            start, stop = ranges.pop()
+            if (stop - start) > self._max_element_size:
+                raise NotImplementedError("TODO: Probably need to fall back to a non-vector read")
+            if len(all_request_ranges[-1]) > self._max_num_elements:
+                all_request_ranges.append(list())
+            all_request_ranges[-1].append((start, stop - start))
+
+        chunks = []
+        for i, request_ranges in enumerate(all_request_ranges):
+            futures = {}
+            for start, size in request_ranges:
+                futures[(start, size)] = future = uproot4.source.futures.TaskFuture(None)
+                chunks.append(uproot4.source.chunk.Chunk(self, start, start + size, future))
+
+            def _callback(status, response, hosts, futures=futures):
+                for chunk in response["chunks"]:
+                    future = futures[(chunk['offset'], chunk['length'])]
+                    future._result = chunk["buffer"]
+                    future._excinfo = getattr(future, "_excinfo", None)
+                    future._finished.set()
+
+            status = self._resource._file.vector_read(chunks=request_ranges, callback=_callback)
+            if not status["ok"]:
+                raise NotImplementedError(status)
+
+        return chunks
 
 
 class XRootDSource(uproot4.source.chunk.MultiThreadedSource):

--- a/uproot4/source/xrootd.py
+++ b/uproot4/source/xrootd.py
@@ -12,12 +12,11 @@ import uproot4.source.chunk
 import uproot4.source.futures
 
 
-def get_pyxrootd():
+def import_pyxrootd():
     os.environ["XRD_RUNFORKHANDLER"] = "1"  # set multiprocessing flag
     try:
         import pyxrootd.client
-
-        return pyxrootd
+        import XRootD.client
 
     except ImportError:
         raise ImportError(
@@ -28,6 +27,9 @@ def get_pyxrootd():
 (or download from http://xrootd.org/dload.html and manually compile with """
             """cmake; setting PYTHONPATH and LD_LIBRARY_PATH appropriately)."""
         )
+
+    else:
+        return pyxrootd, XRootD
 
 
 def get_server_config(file_path):
@@ -43,23 +45,112 @@ def get_server_config(file_path):
         readv_ior_max (int): The maximum number of bytes that can be requested
             per **element** in a vector read
     """
-    from XRootD.client import FileSystem, URL
-    from XRootD.client.flags import QueryCode
+    pyxrootd, XRootD = import_pyxrootd()
 
-    url = URL(file_path)
-    eos = FileSystem("{}://{}/".format(url.protocol, url.hostid))
+    url = XRootD.client.URL(file_path)
+    fs = XRootD.client.FileSystem("{0}://{1}/".format(url.protocol, url.hostid))
 
-    status, readv_iov_max = eos.query(QueryCode.CONFIG, "readv_iov_max")
+    status, readv_iov_max = fs.query(
+        XRootD.client.flags.QueryCode.CONFIG, "readv_iov_max"
+    )
     if not status.ok:
-        raise NotImplementedError(status)
+        raise OSError(status.message)
     readv_iov_max = int(readv_iov_max)
 
-    status, readv_ior_max = eos.query(QueryCode.CONFIG, "readv_ior_max")
+    status, readv_ior_max = fs.query(
+        XRootD.client.flags.QueryCode.CONFIG, "readv_ior_max"
+    )
     if not status.ok:
-        raise NotImplementedError(status)
+        raise OSError(status.message)
     readv_ior_max = int(readv_ior_max)
 
     return readv_iov_max, readv_ior_max
+
+
+class XRootDResource(uproot4.source.chunk.Resource):
+    """
+    Resource wrapping a pyxrootd.File.
+    """
+
+    __slots__ = ["_file_path", "_file"]
+
+    def __init__(self, file_path, timeout):
+        """
+        Args:
+            file_path (str): URL starting with "root://".
+            timeout (int): Number of seconds (loosely interpreted by XRootD)
+                before giving up on a remote file.
+        """
+
+        pyxrootd, XRootD = import_pyxrootd()
+        self._file_path = file_path
+        self._timeout = timeout
+        self._file = pyxrootd.client.File()
+
+        status, dummy = self._file.open(
+            self._file_path, timeout=(0 if timeout is None else timeout)
+        )
+
+        if status.get("error", None):
+            self._file.close(timeout=(0 if self._timeout is None else self._timeout))
+            raise OSError(status["message"])
+
+    @property
+    def file_path(self):
+        """
+        URL starting with "root://".
+        """
+        return self._file_path
+
+    @property
+    def timeout(self):
+        """
+        Number of seconds (loosely interpreted by XRootD) before giving up on a
+        remote file.
+        """
+        return self._timeout
+
+    @property
+    def file(self):
+        """
+        The pyxrootd.File handle.
+        """
+        return self._file
+
+    def __enter__(self):
+        """
+        Does nothing and returns self.
+        """
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        """
+        Closes the pyxrootd.File.
+        """
+        self._file.close(timeout=(0 if self._timeout is None else self._timeout))
+
+    def get(self, start, stop):
+        """
+        Args:
+            start (int): Starting byte position to extract (inclusive, global
+                in Source).
+            stop (int): Stopping byte position to extract (exclusive, global
+                in Source).
+
+        Returns a subinterval of the `raw_data` using global coordinates as a
+        NumPy array with dtype uint8.
+
+        The start and stop must be `Chunk.start <= start <= stop <= Chunk.stop`.
+
+        Calling this function blocks until `raw_data` is filled.
+        """
+        status, data = self._file.read(
+            start, stop - start, timeout=(0 if self._timeout is None else self._timeout)
+        )
+        if status.get("error", None):
+            self._file.close(timeout=(0 if self._timeout is None else self._timeout))
+            raise OSError(status["message"])
+        return data
 
 
 class XRootDVectorReadSource(uproot4.source.chunk.Source):
@@ -81,10 +172,14 @@ class XRootDVectorReadSource(uproot4.source.chunk.Source):
         """
         self._file_path = file_path
         self._timeout = timeout
+
+        # important: construct this first because it raises an error for nonexistent hosts
+        self._resource = XRootDResource(file_path, timeout)
+
+        # this comes after because it HANGS for nonexistent hosts
         self._max_num_elements, self._max_element_size = get_server_config(file_path)
         if max_num_elements:
             self._max_num_elements = min(self._max_num_elements, max_num_elements)
-        self._resource = XRootDResource(file_path, timeout)
 
     def __enter__(self):
         """
@@ -143,88 +238,6 @@ class XRootDVectorReadSource(uproot4.source.chunk.Source):
                 raise OSError("XRootD error: " + status["message"])
 
         return chunks
-
-
-class XRootDResource(uproot4.source.chunk.Resource):
-    """
-    Resource wrapping a pyxrootd.File.
-    """
-
-    __slots__ = ["_file_path", "_file"]
-
-    def __init__(self, file_path, timeout):
-        """
-        Args:
-            file_path (str): URL starting with "root://".
-            timeout (int): Number of seconds (loosely interpreted by XRootD)
-                before giving up on a remote file.
-        """
-        pyxrootd = get_pyxrootd()
-        self._file_path = file_path
-        self._timeout = timeout
-
-        self._file = pyxrootd.client.File()
-        status, dummy = self._file.open(
-            self._file_path, timeout=(0 if timeout is None else timeout)
-        )
-        if status.get("error", None):
-            raise OSError(status["message"])
-
-    @property
-    def file_path(self):
-        """
-        URL starting with "root://".
-        """
-        return self._file_path
-
-    @property
-    def timeout(self):
-        """
-        Number of seconds (loosely interpreted by XRootD) before giving up on a
-        remote file.
-        """
-        return self._timeout
-
-    @property
-    def file(self):
-        """
-        The pyxrootd.File handle.
-        """
-        return self._file
-
-    def __enter__(self):
-        """
-        Does nothing and returns self.
-        """
-        return self
-
-    def __exit__(self, exception_type, exception_value, traceback):
-        """
-        Closes the pyxrootd.File.
-        """
-        self._file.close(timeout=(0 if self._timeout is None else self._timeout))
-
-    def get(self, start, stop):
-        """
-        Args:
-            start (int): Starting byte position to extract (inclusive, global
-                in Source).
-            stop (int): Stopping byte position to extract (exclusive, global
-                in Source).
-
-        Returns a subinterval of the `raw_data` using global coordinates as a
-        NumPy array with dtype uint8.
-
-        The start and stop must be `Chunk.start <= start <= stop <= Chunk.stop`.
-
-        Calling this function blocks until `raw_data` is filled.
-        """
-        status, data = self._file.read(
-            start, stop - start, timeout=(0 if self._timeout is None else self._timeout)
-        )
-        if status.get("error", None):
-            raise OSError(status["message"])
-        return data
 
 
 class XRootDSource(uproot4.source.chunk.MultiThreadedSource):


### PR DESCRIPTION
Adds an XRootD source that uses vector reads. This should probably be the only XRootD source.

By default it takes the number of chunks in a request by querying the server configuration:
```
time_profile(uproot4.source.xrootd.XRootDVectorReadSource(
    "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/data/B2HHH_MagnetDown.root"
), basic_ranges)
```
However for now I've exposed this as a parameter, if only to make the performance studies easier:
```
time_profile(uproot4.source.xrootd.XRootDVectorReadSource(
    "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/data/B2HHH_MagnetDown.root",
    max_num_elements=5
), basic_ranges)
```

Related to #2.