### PR TITLE
Simplify Conda activate

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,19 +32,12 @@ jobs:
       - name: "get conda"
         uses: "goanpeca/setup-miniconda@v1"
         with:
-          auto-update-conda: true
-
-      - name: "environment for Python ${{ matrix.python-version }}"
-        run: |
-          conda create -n testing python=${{ matrix.python-version }}
-          conda init bash
-          conda config --add channels conda-forge
-          conda info
+          python: ${{ matrix.python-version }}
+          channels: conda-forge
 
       - name: "install most dependencies"
         shell: "bash -l {0}"
         run: |
-          conda activate testing
           conda env list
           conda install numpy pandas pytest flake8
           pip install scikit-hep-testdata
@@ -53,7 +46,6 @@ jobs:
       - name: "install Awkward"
         shell: "bash -l {0}"
         run: |
-          conda activate testing
           conda env list
           pip install awkward1
           conda list
@@ -62,21 +54,14 @@ jobs:
         if: "${{ matrix.python-version != 3.5  &&  !contains(matrix.platform, 'windows') }}"
         shell: "bash -l {0}"
         run: |
-          conda activate testing
           conda env list
           conda install xrootd
           conda list
 
       - name: "flake8"
         shell: "bash -l {0}"
-        run: |
-          conda activate testing
-          conda env list
-          python -m flake8
+        run: python -m flake8
 
       - name: "pytest"
         shell: "bash -l {0}"
-        run: |
-          conda activate testing
-          conda env list
-          python -m pytest -vv tests
+        run: python -m pytest -vv tests


### PR DESCRIPTION
This is the recommended way to activate conda, and does use the built-in conda automatically (for the last few weeks or months). You can also cache a more complex environment now (not done in this cleanup).

It would probably be better to add a (test) environment.yml for testing instead of manual conda and pip installs.