### PR TITLE
Fallback to reading streamer and raise better error messages on true failures.

### DIFF
--- a/tests/test_0023-more-interpretations-1.py
+++ b/tests/test_0023-more-interpretations-1.py
@@ -109,9 +109,7 @@ def test_double32():
     del uproot4.classes["TBranch"]
     del uproot4.classes["TBranchElement"]
 
-    with uproot4.open(
-        skhep_testdata.data_path("uproot-demo-double32.root"),
-    )["T"] as t:
+    with uproot4.open(skhep_testdata.data_path("uproot-demo-double32.root"),)["T"] as t:
 
         print(t["fD64"].interpretation)
         print(t["fF32"].interpretation)

--- a/tests/test_0023-more-interpretations-1.py
+++ b/tests/test_0023-more-interpretations-1.py
@@ -109,7 +109,7 @@ def test_double32():
     del uproot4.classes["TBranch"]
     del uproot4.classes["TBranchElement"]
 
-    with uproot4.open(skhep_testdata.data_path("uproot-demo-double32.root"),)["T"] as t:
+    with uproot4.open(skhep_testdata.data_path("uproot-demo-double32.root"))["T"] as t:
 
         print(t["fD64"].interpretation)
         print(t["fF32"].interpretation)

--- a/tests/test_0028-fallback-to-read-streamer.py
+++ b/tests/test_0028-fallback-to-read-streamer.py
@@ -9,8 +9,13 @@ import skhep_testdata
 import uproot4
 
 
-def test_formula_with_dot():
-    with uproot4.open(skhep_testdata.data_path("uproot-demo-double32.root"),)["T"] as t:
-        print(t)
+def test_fallback_reading():
+    with uproot4.open(
+        skhep_testdata.data_path("uproot-small-evnt-tree-fullsplit.root")
+    ) as f:
+        f["tree:evt/P3/P3.Py"]
+        assert f.file._streamers is None
 
-    raise Exception
+    with uproot4.open(skhep_testdata.data_path("uproot-demo-double32.root")) as f:
+        f["T/fD64"]
+        assert f.file._streamers is not None

--- a/tests/test_0028-fallback-to-read-streamer.py
+++ b/tests/test_0028-fallback-to-read-streamer.py
@@ -9,10 +9,8 @@ import skhep_testdata
 import uproot4
 
 
-# def test_formula_with_dot():
-#     with uproot4.open(
-#         skhep_testdata.data_path("uproot-demo-double32.root"),
-#     )["T"] as t:
-#         print(t)
+def test_formula_with_dot():
+    with uproot4.open(skhep_testdata.data_path("uproot-demo-double32.root"),)["T"] as t:
+        print(t)
 
-#     raise Exception
+    raise Exception

--- a/tests/test_0028-fallback-to-read-streamer.py
+++ b/tests/test_0028-fallback-to-read-streamer.py
@@ -1,0 +1,18 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import numpy
+import pytest
+import skhep_testdata
+
+import uproot4
+
+
+# def test_formula_with_dot():
+#     with uproot4.open(
+#         skhep_testdata.data_path("uproot-demo-double32.root"),
+#     )["T"] as t:
+#         print(t)
+
+#     raise Exception

--- a/uproot4/compression.py
+++ b/uproot4/compression.py
@@ -156,24 +156,24 @@ def decompress(chunk, cursor, context, compressed_bytes, uncompressed_bytes):
         # https://github.com/root-project/root/blob/master/core/lzma/src/ZipLZMA.c#L81
         # https://github.com/root-project/root/blob/master/core/lz4/src/ZipLZ4.cxx#L38
         algo, method, c1, c2, c3, u1, u2, u3 = cursor.fields(
-            chunk, _decompress_header_format
+            chunk, _decompress_header_format, context
         )
         block_compressed_bytes = c1 + (c2 << 8) + (c3 << 16)
         block_uncompressed_bytes = u1 + (u2 << 8) + (u3 << 16)
 
         if algo == b"ZL":
             cls = ZLIB
-            data = cursor.bytes(chunk, block_compressed_bytes)
+            data = cursor.bytes(chunk, block_compressed_bytes, context)
 
         elif algo == b"XZ":
             cls = LZMA
-            data = cursor.bytes(chunk, block_compressed_bytes)
+            data = cursor.bytes(chunk, block_compressed_bytes, context)
 
         elif algo == b"L4":
             cls = LZ4
             block_compressed_bytes -= 8
-            expected_checksum = cursor.field(chunk, _decompress_checksum_format)
-            data = cursor.bytes(chunk, block_compressed_bytes)
+            expected_checksum = cursor.field(chunk, _decompress_checksum_format, context)
+            data = cursor.bytes(chunk, block_compressed_bytes, context)
             try:
                 import xxhash
             except ImportError:
@@ -197,7 +197,7 @@ in file {2}""".format(
 
         elif algo == b"ZS":
             cls = ZSTD
-            data = cursor.bytes(chunk, block_compressed_bytes)
+            data = cursor.bytes(chunk, block_compressed_bytes, context)
 
         elif algo == b"CS":
             raise ValueError(

--- a/uproot4/compression.py
+++ b/uproot4/compression.py
@@ -172,7 +172,9 @@ def decompress(chunk, cursor, context, compressed_bytes, uncompressed_bytes):
         elif algo == b"L4":
             cls = LZ4
             block_compressed_bytes -= 8
-            expected_checksum = cursor.field(chunk, _decompress_checksum_format, context)
+            expected_checksum = cursor.field(
+                chunk, _decompress_checksum_format, context
+            )
             data = cursor.bytes(chunk, block_compressed_bytes, context)
             try:
                 import xxhash

--- a/uproot4/deserialization.py
+++ b/uproot4/deserialization.py
@@ -77,19 +77,27 @@ class DeserializationError(Exception):
                 lines.append("{0}(base): {1}".format(indent, repr(v)))
             for k, v in getattr(obj, "_members", {}).items():
                 lines.append("{0}{1}: {2}".format(indent, k, repr(v)))
+
         in_parent = ""
         if "TBranch" in self.context:
             in_parent = "\nin TBranch {0}".format(self.context["TBranch"].object_path)
         elif "TKey" in self.context:
             in_parent = "\nin object {0}".format(self.context["TKey"].object_path)
-        return """while reading
+
+        if len(lines) == 0:
+            return """{0}
+in file {1}{2}""".format(
+                self.message, self.file_path, in_parent
+            )
+        else:
+            return """while reading
 
 {0}
 
 {1}
 in file {2}{3}""".format(
-            "\n".join(lines), self.message, self.file_path, in_parent
-        )
+                "\n".join(lines), self.message, self.file_path, in_parent
+            )
 
 
 _numbytes_version_1 = struct.Struct(">IH")

--- a/uproot4/deserialization.py
+++ b/uproot4/deserialization.py
@@ -91,7 +91,7 @@ def numbytes_check(start_cursor, stop_cursor, num_bytes, classname, context):
 _map_string_string_format1 = struct.Struct(">I")
 
 
-def map_string_string(chunk, cursor):
+def map_string_string(chunk, cursor, context):
     cursor.skip(12)
     size = cursor.field(chunk, _map_string_string_format1, context)
     cursor.skip(6)

--- a/uproot4/model.py
+++ b/uproot4/model.py
@@ -49,7 +49,7 @@ class Model(object):
         (
             self._num_bytes,
             self._instance_version,
-        ) = uproot4.deserialization.numbytes_version(chunk, cursor)
+        ) = uproot4.deserialization.numbytes_version(chunk, cursor, context)
 
     def read_members(self, chunk, cursor, context):
         pass
@@ -62,7 +62,7 @@ class Model(object):
             cursor,
             self._num_bytes,
             classname_pretty(self.classname, self.class_version),
-            getattr(self._file, "file_path"),
+            context,
         )
 
     def postprocess(self, chunk, cursor, context):
@@ -259,7 +259,7 @@ class DispatchByVersion(object):
         import uproot4.deserialization
 
         num_bytes, version = uproot4.deserialization.numbytes_version(
-            chunk, cursor, move=False
+            chunk, cursor, context, move=False
         )
 
         versioned_cls = cls.known_versions.get(version)

--- a/uproot4/model.py
+++ b/uproot4/model.py
@@ -22,6 +22,9 @@ class Model(object):
         self._num_bytes = None
         self._instance_version = None
 
+        old_breadcrumbs = context.get("breadcrumbs", ())
+        context["breadcrumbs"] = old_breadcrumbs + (self,)
+
         self.hook_before_read(chunk=chunk, cursor=cursor, context=context)
 
         self.read_numbytes_version(chunk, cursor, context)
@@ -36,7 +39,11 @@ class Model(object):
 
         self.hook_before_postprocess(chunk=chunk, cursor=cursor, context=context)
 
-        return self.postprocess(chunk, cursor, context)
+        out = self.postprocess(chunk, cursor, context)
+
+        context["breadcrumbs"] = old_breadcrumbs
+
+        return out
 
     def __repr__(self):
         return "<{0} at 0x{1:012x}>".format(
@@ -61,8 +68,9 @@ class Model(object):
             self._cursor,
             cursor,
             self._num_bytes,
-            classname_pretty(self.classname, self.class_version),
+            self.classname,
             context,
+            getattr(self._file, "file_path"),
         )
 
     def postprocess(self, chunk, cursor, context):

--- a/uproot4/model.py
+++ b/uproot4/model.py
@@ -10,6 +10,40 @@ import uproot4.const
 import uproot4._util
 
 
+bootstrap_classnames = [
+    "TStreamerInfo",
+    "TStreamerElement",
+    "TStreamerArtificial",
+    "TStreamerBase",
+    "TStreamerBasicPointer",
+    "TStreamerBasicType",
+    "TStreamerLoop",
+    "TStreamerObject",
+    "TStreamerObjectAny",
+    "TStreamerObjectAnyPointer",
+    "TStreamerObjectPointer",
+    "TStreamerSTL",
+    "TStreamerSTLstring",
+    "TStreamerString",
+    "TList",
+    "TObjArray",
+    "TObjString",
+]
+
+
+def bootstrap_classes():
+    import uproot4.streamers
+    import uproot4.models.TList
+    import uproot4.models.TObjArray
+    import uproot4.models.TObjString
+
+    custom_classes = {}
+    for classname in bootstrap_classnames:
+        custom_classes[classname] = uproot4.classes[classname]
+
+    return custom_classes
+
+
 class Model(object):
     @classmethod
     def read(cls, chunk, cursor, context, file, parent):
@@ -407,11 +441,15 @@ def classname_pretty(classname, version):
         return "{0} (version {1})".format(classname, version)
 
 
-def has_class_named(classname, version=None, classes=None):
-    if classes is None:
-        classes = uproot4.classes
+def maybe_custom_classes(custom_classes):
+    if custom_classes is None:
+        return uproot4.classes
+    else:
+        return custom_classes
 
-    cls = classes.get(classname)
+
+def has_class_named(classname, version=None, custom_classes=None):
+    cls = maybe_custom_classes(custom_classes).get(classname)
     if cls is None:
         return False
 
@@ -421,10 +459,10 @@ def has_class_named(classname, version=None, classes=None):
         return True
 
 
-def class_named(classname, version=None, classes=None):
-    if classes is None:
+def class_named(classname, version=None, custom_classes=None):
+    if custom_classes is None:
         classes = uproot4.classes
-        where = "the given 'classes' dict"
+        where = "the 'custom_classes' dict"
     else:
         where = "uproot4.classes"
 

--- a/uproot4/models/RNTuple.py
+++ b/uproot4/models/RNTuple.py
@@ -24,7 +24,7 @@ class Model_ROOT_3a3a_Experimental_3a3a_RNTuple(uproot4.model.Model):
             self._members["fNBytesFooter"],
             self._members["fLenFooter"],
             self._members["fReserved"],
-        ) = cursor.fields(chunk, _rntuple_format1)
+        ) = cursor.fields(chunk, _rntuple_format1, context)
 
 
 uproot4.classes[

--- a/uproot4/models/TArray.py
+++ b/uproot4/models/TArray.py
@@ -22,8 +22,8 @@ class Model_TArray(uproot4.model.Model, Sequence):
         pass
 
     def read_members(self, chunk, cursor, context):
-        self._members["fN"] = cursor.field(chunk, _tarray_format1)
-        self._data = cursor.array(chunk, self._members["fN"], self.dtype)
+        self._members["fN"] = cursor.field(chunk, _tarray_format1, context)
+        self._data = cursor.array(chunk, self._members["fN"], self.dtype, context)
 
     def __array__(self):
         return self._data

--- a/uproot4/models/TAtt.py
+++ b/uproot4/models/TAtt.py
@@ -17,7 +17,7 @@ class Model_TAttLine_v1(uproot4.model.VersionedModel):
             self._members["fLineColor"],
             self._members["fLineStyle"],
             self._members["fLineWidth"],
-        ) = cursor.fields(chunk, _tattline1_format1)
+        ) = cursor.fields(chunk, _tattline1_format1, context)
 
     base_names_versions = []
     member_names = ["fLineColor", "fLineStyle", "fLineWidth"]
@@ -32,7 +32,7 @@ class Model_TAttLine_v2(uproot4.model.VersionedModel):
             self._members["fLineColor"],
             self._members["fLineStyle"],
             self._members["fLineWidth"],
-        ) = cursor.fields(chunk, _tattline2_format1)
+        ) = cursor.fields(chunk, _tattline2_format1, context)
 
     base_names_versions = []
     member_names = ["fLineColor", "fLineStyle", "fLineWidth"]
@@ -48,7 +48,7 @@ _tattfill2_format1 = struct.Struct(">hh")
 class Model_TAttFill_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context):
         self._members["fFillColor"], self._members["fFillStyle"] = cursor.fields(
-            chunk, _tattfill1_format1
+            chunk, _tattfill1_format1, context
         )
 
     base_names_versions = []
@@ -61,7 +61,7 @@ class Model_TAttFill_v1(uproot4.model.VersionedModel):
 class Model_TAttFill_v2(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context):
         self._members["fFillColor"], self._members["fFillStyle"] = cursor.fields(
-            chunk, _tattfill2_format1
+            chunk, _tattfill2_format1, context
         )
 
     base_names_versions = []
@@ -80,7 +80,7 @@ class Model_TAttMarker_v2(uproot4.model.VersionedModel):
             self._members["fMarkerColor"],
             self._members["fMarkerStyle"],
             self._members["fMarkerSize"],
-        ) = cursor.fields(chunk, _tattmarker2_format1)
+        ) = cursor.fields(chunk, _tattmarker2_format1, context)
 
     base_names_versions = []
     member_names = ["fMarkerColor", "fMarkerStyle", "fMarkserSize"]

--- a/uproot4/models/TBasket.py
+++ b/uproot4/models/TBasket.py
@@ -38,7 +38,7 @@ class Model_TBasket(uproot4.model.Model):
             self._members["fDatime"],
             self._members["fKeylen"],
             self._members["fCycle"],
-        ) = cursor.fields(chunk, _tbasket_format1)
+        ) = cursor.fields(chunk, _tbasket_format1, context)
 
         # skip the class name, name, and title
         cursor.move_to(
@@ -51,13 +51,13 @@ class Model_TBasket(uproot4.model.Model):
             self._members["fNevBufSize"],
             self._members["fNevBuf"],
             self._members["fLast"],
-        ) = cursor.fields(chunk, _tbasket_format2)
+        ) = cursor.fields(chunk, _tbasket_format2, context)
 
         cursor.skip(1)
 
         if self.is_embedded:
             if self._members["fNevBufSize"] > 8:
-                raw_byte_offsets = cursor.bytes(chunk, 8 + self.num_entries * 4).view(
+                raw_byte_offsets = cursor.bytes(chunk, 8 + self.num_entries * 4, context).view(
                     _tbasket_offsets_dtype
                 )
                 cursor.skip(-4)
@@ -74,7 +74,7 @@ class Model_TBasket(uproot4.model.Model):
             cursor.skip(self._members["fKeylen"])
 
             self._raw_data = None
-            self._data = cursor.bytes(chunk, self.border, copy_if_memmap=True)
+            self._data = cursor.bytes(chunk, self.border, context, copy_if_memmap=True)
 
         else:
             if self.compressed_bytes != self.uncompressed_bytes:
@@ -84,7 +84,7 @@ class Model_TBasket(uproot4.model.Model):
                 self._raw_data = uncompressed.get(0, self.uncompressed_bytes)
             else:
                 self._raw_data = cursor.bytes(
-                    chunk, self.uncompressed_bytes, copy_if_memmap=True
+                    chunk, self.uncompressed_bytes, context, copy_if_memmap=True
                 )
 
             if self.border != self.uncompressed_bytes:

--- a/uproot4/models/TBasket.py
+++ b/uproot4/models/TBasket.py
@@ -81,7 +81,7 @@ class Model_TBasket(uproot4.model.Model):
                 uncompressed = uproot4.compression.decompress(
                     chunk, cursor, {}, self.compressed_bytes, self.uncompressed_bytes,
                 )
-                self._raw_data = uncompressed.get(0, self.uncompressed_bytes)
+                self._raw_data = uncompressed.get(0, self.uncompressed_bytes, context)
             else:
                 self._raw_data = cursor.bytes(
                     chunk, self.uncompressed_bytes, context, copy_if_memmap=True

--- a/uproot4/models/TBasket.py
+++ b/uproot4/models/TBasket.py
@@ -57,9 +57,9 @@ class Model_TBasket(uproot4.model.Model):
 
         if self.is_embedded:
             if self._members["fNevBufSize"] > 8:
-                raw_byte_offsets = cursor.bytes(chunk, 8 + self.num_entries * 4, context).view(
-                    _tbasket_offsets_dtype
-                )
+                raw_byte_offsets = cursor.bytes(
+                    chunk, 8 + self.num_entries * 4, context
+                ).view(_tbasket_offsets_dtype)
                 cursor.skip(-4)
 
                 # subtracting fKeylen makes a new buffer and converts to native endian

--- a/uproot4/models/TBranch.py
+++ b/uproot4/models/TBranch.py
@@ -43,7 +43,7 @@ class Model_TBranch_v10(
             self._members["fEntries"],
             self._members["fTotBytes"],
             self._members["fZipBytes"],
-        ) = cursor.fields(chunk, _tbranch10_format1)
+        ) = cursor.fields(chunk, _tbranch10_format1, context)
         self._members["fBranches"] = self.class_named("TObjArray").read(
             chunk, cursor, context, self._file, self
         )
@@ -52,7 +52,7 @@ class Model_TBranch_v10(
         )
         self._cursor_baskets = cursor.copy()
         if self._file.options["minimal_ttree_metadata"]:
-            cursor.skip_over(chunk)
+            cursor.skip_over(chunk, context)
         else:
             self._members["fBaskets"] = self.class_named("TObjArray").read(
                 chunk, cursor, context, self._file, self
@@ -61,20 +61,20 @@ class Model_TBranch_v10(
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fBasketBytes"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         tmp = _tbranch10_dtype2
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fBasketEntry"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         tmp = _tbranch10_dtype3
         if context.get("speedbump", True):
-            if cursor.bytes(chunk, 1)[0] == 2:
+            if cursor.bytes(chunk, 1, context)[0] == 2:
                 tmp = numpy.dtype(">i8")
         self._members["fBasketSeek"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         if self._file.options["minimal_ttree_metadata"]:
             cursor.skip_after(self)
@@ -149,7 +149,7 @@ class Model_TBranch_v11(
             self._members["fFirstEntry"],
             self._members["fTotBytes"],
             self._members["fZipBytes"],
-        ) = cursor.fields(chunk, _tbranch11_format1)
+        ) = cursor.fields(chunk, _tbranch11_format1, context)
         self._members["fBranches"] = self.class_named("TObjArray").read(
             chunk, cursor, context, self._file, self
         )
@@ -158,7 +158,7 @@ class Model_TBranch_v11(
         )
         self._cursor_baskets = cursor.copy()
         if self._file.options["minimal_ttree_metadata"]:
-            cursor.skip_over(chunk)
+            cursor.skip_over(chunk, context)
         else:
             self._members["fBaskets"] = self.class_named("TObjArray").read(
                 chunk, cursor, context, self._file, self
@@ -167,20 +167,20 @@ class Model_TBranch_v11(
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fBasketBytes"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         tmp = _tbranch11_dtype2
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fBasketEntry"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         tmp = _tbranch11_dtype3
         if context.get("speedbump", True):
-            if cursor.bytes(chunk, 1)[0] == 2:
+            if cursor.bytes(chunk, 1, context)[0] == 2:
                 tmp = numpy.dtype(">i8")
         self._members["fBasketSeek"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         if self._file.options["minimal_ttree_metadata"]:
             cursor.skip_after(self)
@@ -256,7 +256,7 @@ class Model_TBranch_v12(
             self._members["fFirstEntry"],
             self._members["fTotBytes"],
             self._members["fZipBytes"],
-        ) = cursor.fields(chunk, _tbranch12_format1)
+        ) = cursor.fields(chunk, _tbranch12_format1, context)
         self._members["fBranches"] = self.class_named("TObjArray").read(
             chunk, cursor, context, self._file, self
         )
@@ -265,7 +265,7 @@ class Model_TBranch_v12(
         )
         self._cursor_baskets = cursor.copy()
         if self._file.options["minimal_ttree_metadata"]:
-            cursor.skip_over(chunk)
+            cursor.skip_over(chunk, context)
         else:
             self._members["fBaskets"] = self.class_named("TObjArray").read(
                 chunk, cursor, context, self._file, self
@@ -274,20 +274,20 @@ class Model_TBranch_v12(
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fBasketBytes"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         tmp = _tbranch12_dtype2
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fBasketEntry"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         tmp = _tbranch12_dtype3
         if context.get("speedbump", True):
-            if cursor.bytes(chunk, 1)[0] == 2:
+            if cursor.bytes(chunk, 1, context)[0] == 2:
                 tmp = numpy.dtype(">i8")
         self._members["fBasketSeek"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         if self._file.options["minimal_ttree_metadata"]:
             cursor.skip_after(self)
@@ -357,7 +357,7 @@ class Model_TBranch_v13(
             self._members["fEntryOffsetLen"],
             self._members["fWriteBasket"],
             self._members["fEntryNumber"],
-        ) = cursor.fields(chunk, _tbranch13_format1)
+        ) = cursor.fields(chunk, _tbranch13_format1, context)
         self._members["fIOFeatures"] = self.class_named("ROOT::TIOFeatures").read(
             chunk, cursor, context, self._file, self
         )
@@ -369,7 +369,7 @@ class Model_TBranch_v13(
             self._members["fFirstEntry"],
             self._members["fTotBytes"],
             self._members["fZipBytes"],
-        ) = cursor.fields(chunk, _tbranch13_format2)
+        ) = cursor.fields(chunk, _tbranch13_format2, context)
         self._members["fBranches"] = self.class_named("TObjArray").read(
             chunk, cursor, context, self._file, self
         )
@@ -378,7 +378,7 @@ class Model_TBranch_v13(
         )
         self._cursor_baskets = cursor.copy()
         if self._file.options["minimal_ttree_metadata"]:
-            cursor.skip_over(chunk)
+            cursor.skip_over(chunk, context)
         else:
             self._members["fBaskets"] = self.class_named("TObjArray").read(
                 chunk, cursor, context, self._file, self
@@ -387,20 +387,20 @@ class Model_TBranch_v13(
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fBasketBytes"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         tmp = _tbranch13_dtype2
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fBasketEntry"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         tmp = _tbranch13_dtype3
         if context.get("speedbump", True):
-            if cursor.bytes(chunk, 1)[0] == 2:
+            if cursor.bytes(chunk, 1, context)[0] == 2:
                 tmp = numpy.dtype(">i8")
         self._members["fBasketSeek"] = cursor.array(
-            chunk, self.member("fMaxBaskets"), tmp
+            chunk, self.member("fMaxBaskets"), tmp, context
         )
         if self._file.options["minimal_ttree_metadata"]:
             cursor.skip_after(self)
@@ -482,7 +482,7 @@ class Model_TBranchElement_v8(
             self._members["fType"],
             self._members["fStreamerType"],
             self._members["fMaximum"],
-        ) = cursor.fields(chunk, _tbranchelement8_format1)
+        ) = cursor.fields(chunk, _tbranchelement8_format1, context)
         self._members["fBranchCount"] = uproot4.deserialization.read_object_any(
             chunk, cursor, context, self._file, self._parent
         )
@@ -538,7 +538,7 @@ class Model_TBranchElement_v9(
             self._members["fType"],
             self._members["fStreamerType"],
             self._members["fMaximum"],
-        ) = cursor.fields(chunk, _tbranchelement9_format1)
+        ) = cursor.fields(chunk, _tbranchelement9_format1, context)
         self._members["fBranchCount"] = uproot4.deserialization.read_object_any(
             chunk, cursor, context, self._file, self._parent
         )
@@ -594,7 +594,7 @@ class Model_TBranchElement_v10(
             self._members["fType"],
             self._members["fStreamerType"],
             self._members["fMaximum"],
-        ) = cursor.fields(chunk, _tbranchelement10_format1)
+        ) = cursor.fields(chunk, _tbranchelement10_format1, context)
         self._members["fBranchCount"] = uproot4.deserialization.read_object_any(
             chunk, cursor, context, self._file, self._parent
         )

--- a/uproot4/models/TLeaf.py
+++ b/uproot4/models/TLeaf.py
@@ -24,7 +24,7 @@ class Model_TLeaf_v2(uproot4.model.VersionedModel):
             self._members["fOffset"],
             self._members["fIsRange"],
             self._members["fIsUnsigned"],
-        ) = cursor.fields(chunk, _tleaf2_format0)
+        ) = cursor.fields(chunk, _tleaf2_format0, context)
         self._members["fLeafCount"] = uproot4.deserialization.read_object_any(
             chunk, cursor, context, self._file, self._parent
         )
@@ -58,7 +58,7 @@ class Model_TLeafB_v1(uproot4.model.VersionedModel):
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
-            chunk, _tleafb1_format1
+            chunk, _tleafb1_format1, context
         )
 
     base_names_versions = [("TLeaf", 2)]
@@ -83,7 +83,7 @@ class Model_TLeafC_v1(uproot4.model.VersionedModel):
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
-            chunk, _tleafc1_format1
+            chunk, _tleafc1_format1, context
         )
 
     base_names_versions = [("TLeaf", 2)]
@@ -108,7 +108,7 @@ class Model_TLeafD_v1(uproot4.model.VersionedModel):
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
-            chunk, _tleafd1_format1
+            chunk, _tleafd1_format1, context
         )
 
     base_names_versions = [("TLeaf", 2)]
@@ -133,7 +133,7 @@ class Model_TLeafF_v1(uproot4.model.VersionedModel):
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
-            chunk, _tleaff1_format1
+            chunk, _tleaff1_format1, context
         )
 
     base_names_versions = [("TLeaf", 2)]
@@ -158,7 +158,7 @@ class Model_TLeafI_v1(uproot4.model.VersionedModel):
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
-            chunk, _tleafi1_format1
+            chunk, _tleafi1_format1, context
         )
 
     base_names_versions = [("TLeaf", 2)]
@@ -183,7 +183,7 @@ class Model_TLeafL_v1(uproot4.model.VersionedModel):
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
-            chunk, _tleafl1_format0
+            chunk, _tleafl1_format0, context
         )
 
     base_names_versions = [("TLeaf", 2)]
@@ -208,7 +208,7 @@ class Model_TLeafO_v1(uproot4.model.VersionedModel):
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
-            chunk, _tleafO1_format1
+            chunk, _tleafO1_format1, context
         )
 
     base_names_versions = [("TLeaf", 2)]
@@ -233,7 +233,7 @@ class Model_TLeafS_v1(uproot4.model.VersionedModel):
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
-            chunk, _tleafs1_format1
+            chunk, _tleafs1_format1, context
         )
 
     base_names_versions = [("TLeaf", 2)]
@@ -258,7 +258,7 @@ class Model_TLeafElement_v1(uproot4.model.VersionedModel):
             )
         )
         self._members["fID"], self._members["fType"] = cursor.fields(
-            chunk, _tleafelement1_format1
+            chunk, _tleafelement1_format1, context
         )
 
     base_names_versions = [("TLeaf", 2)]

--- a/uproot4/models/TList.py
+++ b/uproot4/models/TList.py
@@ -26,8 +26,8 @@ class Model_TList(uproot4.model.Model, Sequence):
             )
         )
 
-        self._members["fName"] = cursor.string(chunk)
-        self._members["fSize"] = cursor.field(chunk, _tlist_format1)
+        self._members["fName"] = cursor.string(chunk, context)
+        self._members["fSize"] = cursor.field(chunk, _tlist_format1, context)
 
         self._data = []
         for i in range(self._members["fSize"]):
@@ -37,7 +37,7 @@ class Model_TList(uproot4.model.Model, Sequence):
             self._data.append(item)
 
             # ignore "option"
-            n = cursor.field(chunk, _tlist_format2)
+            n = cursor.field(chunk, _tlist_format2, context)
             cursor.skip(n)
 
     def __getitem__(self, where):

--- a/uproot4/models/TNamed.py
+++ b/uproot4/models/TNamed.py
@@ -14,8 +14,8 @@ class Model_TNamed(uproot4.model.Model):
             )
         )
 
-        self._members["fName"] = cursor.string(chunk)
-        self._members["fTitle"] = cursor.string(chunk)
+        self._members["fName"] = cursor.string(chunk, context)
+        self._members["fTitle"] = cursor.string(chunk, context)
 
 
 uproot4.classes["TNamed"] = Model_TNamed

--- a/uproot4/models/TObjArray.py
+++ b/uproot4/models/TObjArray.py
@@ -26,9 +26,9 @@ class Model_TObjArray(uproot4.model.Model, Sequence):
             )
         )
 
-        self._members["fName"] = cursor.string(chunk)
+        self._members["fName"] = cursor.string(chunk, context)
         self._members["fSize"], self._members["fLowerBound"] = cursor.fields(
-            chunk, _tobjarray_format1
+            chunk, _tobjarray_format1, context
         )
 
         self._data = []
@@ -63,9 +63,9 @@ class Model_TObjArrayOfTBaskets(Model_TObjArray):
             )
         )
 
-        self._members["fName"] = cursor.string(chunk)
+        self._members["fName"] = cursor.string(chunk, context)
         self._members["fSize"], self._members["fLowerBound"] = cursor.fields(
-            chunk, _tobjarray_format1
+            chunk, _tobjarray_format1, context
         )
 
         self._data = []

--- a/uproot4/models/TObjString.py
+++ b/uproot4/models/TObjString.py
@@ -13,7 +13,7 @@ class Model_TObjString(uproot4.model.Model, str):
                 chunk, cursor, context, self._file, self._parent
             )
         )
-        self._data = cursor.string(chunk)
+        self._data = cursor.string(chunk, context)
 
     def postprocess(self, chunk, cursor, context):
         out = Model_TObjString(self._data)

--- a/uproot4/models/TObject.py
+++ b/uproot4/models/TObject.py
@@ -19,11 +19,11 @@ class Model_TObject(uproot4.model.Model):
         pass
 
     def read_members(self, chunk, cursor, context):
-        self._instance_version = cursor.field(chunk, _tobject_format1)
+        self._instance_version = cursor.field(chunk, _tobject_format1, context)
         if numpy.int64(self._instance_version) & uproot4.const.kByteCountVMask:
             cursor.skip(4)
         self._members["fUniqueID"], self._members["fBits"] = cursor.fields(
-            chunk, _tobject_format2
+            chunk, _tobject_format2, context
         )
         self._members["fBits"] = (
             numpy.uint32(self._members["fBits"]) | uproot4.const.kIsOnHeap

--- a/uproot4/models/TString.py
+++ b/uproot4/models/TString.py
@@ -10,7 +10,7 @@ class Model_TString(uproot4.model.Model, str):
         pass
 
     def read_members(self, chunk, cursor, context):
-        self._data = cursor.string(chunk)
+        self._data = cursor.string(chunk, context)
 
     def postprocess(self, chunk, cursor, context):
         out = Model_TString(self._data)

--- a/uproot4/models/TTree.py
+++ b/uproot4/models/TTree.py
@@ -50,7 +50,7 @@ class Model_TTree_v16(uproot4.behaviors.TTree.TTree, uproot4.model.VersionedMode
             self._members["fMaxVirtualSize"],
             self._members["fAutoSave"],
             self._members["fEstimate"],
-        ) = cursor.fields(chunk, _ttree16_format1)
+        ) = cursor.fields(chunk, _ttree16_format1, context)
         self._members["fBranches"] = self.class_named("TObjArray").read(
             chunk, cursor, context, self._file, self
         )
@@ -167,7 +167,7 @@ class Model_TTree_v17(uproot4.behaviors.TTree.TTree, uproot4.model.VersionedMode
             self._members["fMaxVirtualSize"],
             self._members["fAutoSave"],
             self._members["fEstimate"],
-        ) = cursor.fields(chunk, _ttree17_format1)
+        ) = cursor.fields(chunk, _ttree17_format1, context)
         self._members["fBranches"] = self.class_named("TObjArray").read(
             chunk, cursor, context, self._file, self
         )
@@ -286,7 +286,7 @@ class Model_TTree_v18(uproot4.behaviors.TTree.TTree, uproot4.model.VersionedMode
             self._members["fAutoSave"],
             self._members["fAutoFlush"],
             self._members["fEstimate"],
-        ) = cursor.fields(chunk, _ttree18_format1)
+        ) = cursor.fields(chunk, _ttree18_format1, context)
         self._members["fBranches"] = self.class_named("TObjArray").read(
             chunk, cursor, context, self._file, self
         )
@@ -410,18 +410,18 @@ class Model_TTree_v19(uproot4.behaviors.TTree.TTree, uproot4.model.VersionedMode
             self._members["fAutoSave"],
             self._members["fAutoFlush"],
             self._members["fEstimate"],
-        ) = cursor.fields(chunk, _ttree19_format1)
+        ) = cursor.fields(chunk, _ttree19_format1, context)
         tmp = _ttree19_dtype1
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fClusterRangeEnd"] = cursor.array(
-            chunk, self.member("fNClusterRange"), tmp
+            chunk, self.member("fNClusterRange"), tmp, context
         )
         tmp = _ttree19_dtype2
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fClusterSize"] = cursor.array(
-            chunk, self.member("fNClusterRange"), tmp
+            chunk, self.member("fNClusterRange"), tmp, context
         )
         self._members["fBranches"] = self.class_named("TObjArray").read(
             chunk, cursor, context, self._file, self
@@ -549,18 +549,18 @@ class Model_TTree_v20(uproot4.behaviors.TTree.TTree, uproot4.model.VersionedMode
             self._members["fAutoSave"],
             self._members["fAutoFlush"],
             self._members["fEstimate"],
-        ) = cursor.fields(chunk, _ttree20_format1)
+        ) = cursor.fields(chunk, _ttree20_format1, context)
         tmp = _ttree20_dtype1
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fClusterRangeEnd"] = cursor.array(
-            chunk, self.member("fNClusterRange"), tmp
+            chunk, self.member("fNClusterRange"), tmp, context
         )
         tmp = _ttree20_dtype2
         if context.get("speedbump", True):
             cursor.skip(1)
         self._members["fClusterSize"] = cursor.array(
-            chunk, self.member("fNClusterRange"), tmp
+            chunk, self.member("fNClusterRange"), tmp, context
         )
         self._members["fIOFeatures"] = self.class_named("ROOT::TIOFeatures").read(
             chunk, cursor, context, self._file, self
@@ -663,7 +663,7 @@ _tiofeatures_format1 = struct.Struct(">B")
 class Model_ROOT_3a3a_TIOFeatures(uproot4.model.Model):
     def read_members(self, chunk, cursor, context):
         cursor.skip(4)
-        self._members["fIOBits"] = cursor.field(chunk, _tiofeatures_format1)
+        self._members["fIOBits"] = cursor.field(chunk, _tiofeatures_format1, context)
 
 
 uproot4.classes["TTree"] = Model_TTree

--- a/uproot4/reading.py
+++ b/uproot4/reading.py
@@ -779,7 +779,8 @@ class ReadOnlyKey(object):
             )
         else:
             uncompressed_chunk = uproot4.source.chunk.Chunk.wrap(
-                chunk.source, chunk.get(data_start, data_stop)
+                chunk.source,
+                chunk.get(data_start, data_stop, {"breadcrumbs": [], "TKey": self}),
             )
 
         return uncompressed_chunk, cursor

--- a/uproot4/reading.py
+++ b/uproot4/reading.py
@@ -809,18 +809,19 @@ class ReadOnlyKey(object):
             "TDirectoryFile",
         ):
             out = ReadOnlyDirectory(
-                self._parent.path + (self.fName,), self.data_cursor, {}, self._file, self,
+                self._parent.path + (self.fName,),
+                self.data_cursor,
+                {},
+                self._file,
+                self,
             )
 
         else:
             chunk, cursor = self.get_uncompressed_chunk_cursor()
             cls = self._file.class_named(self._fClassName)
             out = cls.read(
-                chunk,
-                cursor,
-                {"breadcrumbs": [], "TKey": self},
-                self._file,
-                self)
+                chunk, cursor, {"breadcrumbs": [], "TKey": self}, self._file, self
+            )
 
         if self._file.object_cache is not None:
             self._file.object_cache[self.cache_key] = out

--- a/uproot4/source/chunk.py
+++ b/uproot4/source/chunk.py
@@ -339,13 +339,14 @@ for file path {2}""".format(
         self.wait()
         return self._raw_data
 
-    def get(self, start, stop):
+    def get(self, start, stop, context):
         """
         Args:
             start (int): Starting byte position to extract (inclusive, global
                 in Source).
             stop (int): Stopping byte position to extract (exclusive, global
                 in Source).
+            context (dict): Information about the current state of deserialization.
 
         Returns a subinterval of the `raw_data` using global coordinates as a
         NumPy array with dtype uint8.
@@ -373,11 +374,12 @@ of file path {4}""".format(
         else:
             raise RefineChunk(start, stop, self._start, self._stop)
 
-    def remainder(self, start):
+    def remainder(self, start, context):
         """
         Args:
             start (int): Starting byte position to extract (inclusive, global
                 in Source).
+            context (dict): Information about the current state of deserialization.
 
         Returns a subinterval of the `raw_data` from `start` to the end of the
         Chunk as a NumPy array with dtype uint8.

--- a/uproot4/source/chunk.py
+++ b/uproot4/source/chunk.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 
 import numpy
 
+import uproot4.deserialization
 import uproot4.source.futures
 import uproot4.source.cursor
 
@@ -363,12 +364,13 @@ for file path {2}""".format(
             return self._raw_data[local_start:local_stop]
 
         elif self._exact:
-            raise OSError(
+            raise uproot4.deserialization.DeserializationError(
                 """attempting to get bytes {0}:{1}
- outside expected range {2}:{3} for this Chunk
-of file path {4}""".format(
-                    start, stop, self._start, self._stop, self._source.file_path,
-                )
+outside expected range {2}:{3} for this Chunk""".format(
+                    start, stop, self._start, self._stop
+                ),
+                context,
+                self._source.file_path,
             )
 
         else:
@@ -395,10 +397,11 @@ of file path {4}""".format(
             return self._raw_data[local_start:]
 
         else:
-            raise OSError(
-                """attempting to get byte {0}
- outside expected range {1}:{2} for this Chunk
-of file path {3}""".format(
-                    start, self._start, self._stop, self._source.file_path,
-                )
+            raise uproot4.deserialization.DeserializationError(
+                """attempting to get bytes after {0}
+outside expected range {1}:{2} for this Chunk""".format(
+                    start, self._start, self._stop
+                ),
+                context,
+                self._source.file_path,
             )

--- a/uproot4/source/cursor.py
+++ b/uproot4/source/cursor.py
@@ -130,13 +130,13 @@ class Cursor(object):
             )
         self._index = start_cursor.index + num_bytes
 
-    def skip_over(self, chunk):
+    def skip_over(self, chunk, context):
         """
         Move the index after serialized data for an object with
         numbytes_version.
         """
         num_bytes, version = uproot4.deserialization.numbytes_version(
-            chunk, self, move=False
+            chunk, self, context, move=False
         )
         if num_bytes is None:
             raise TypeError(
@@ -145,7 +145,7 @@ class Cursor(object):
             )
         self._index += num_bytes
 
-    def fields(self, chunk, format, move=True):
+    def fields(self, chunk, format, context, move=True):
         """
         Interpret data at this index of the Chunk with a `struct.Struct`
         format. Returns a tuple (length determined by `format`).
@@ -158,7 +158,7 @@ class Cursor(object):
             self._index = stop
         return format.unpack(chunk.get(start, stop))
 
-    def field(self, chunk, format, move=True):
+    def field(self, chunk, format, context, move=True):
         """
         Interpret data at this index of the Chunk with a `struct.Struct`
         format, returning a single item instead of a tuple (the first).
@@ -171,7 +171,7 @@ class Cursor(object):
             self._index = stop
         return format.unpack(chunk.get(start, stop))[0]
 
-    def bytes(self, chunk, length, move=True, copy_if_memmap=False):
+    def bytes(self, chunk, length, context, move=True, copy_if_memmap=False):
         """
         Interpret data at this index of the Chunk as raw bytes with a
         given `length`.
@@ -193,7 +193,7 @@ class Cursor(object):
                 step = step.base
         return out
 
-    def array(self, chunk, length, dtype, move=True):
+    def array(self, chunk, length, dtype, context, move=True):
         """
         Interpret data at this index of the Chunk as an array with a
         given `length` and `dtype`.
@@ -209,7 +209,7 @@ class Cursor(object):
     _u1 = numpy.dtype("u1")
     _i4 = numpy.dtype(">i4")
 
-    def bytestring(self, chunk, move=True):
+    def bytestring(self, chunk, context, move=True):
         """
         Interpret data at this index of the Chunk as a ROOT bytestring
         (first 1 or 5 bytes indicate size).
@@ -231,7 +231,7 @@ class Cursor(object):
             self._index = stop
         return chunk.get(start, stop).tostring()
 
-    def string(self, chunk, move=True):
+    def string(self, chunk, context, move=True):
         """
         Interpret data at this index of the Chunk as a Python str
         (first 1 or 5 bytes indicate size).
@@ -240,13 +240,13 @@ class Cursor(object):
 
         If `move` is False, only peek: don't update the index.
         """
-        out = self.bytestring(chunk, move=move)
+        out = self.bytestring(chunk, context, move=move)
         if uproot4._util.py2:
             return out
         else:
             return out.decode(errors="surrogateescape")
 
-    def classname(self, chunk, move=True):
+    def classname(self, chunk, context, move=True):
         """
         Interpret data at this index of the Chunk as a ROOT class
         name, which is the only usage of null-terminated strings (rather than

--- a/uproot4/source/cursor.py
+++ b/uproot4/source/cursor.py
@@ -156,7 +156,7 @@ class Cursor(object):
         stop = start + format.size
         if move:
             self._index = stop
-        return format.unpack(chunk.get(start, stop))
+        return format.unpack(chunk.get(start, stop, context))
 
     def field(self, chunk, format, context, move=True):
         """
@@ -169,7 +169,7 @@ class Cursor(object):
         stop = start + format.size
         if move:
             self._index = stop
-        return format.unpack(chunk.get(start, stop))[0]
+        return format.unpack(chunk.get(start, stop, context))[0]
 
     def bytes(self, chunk, length, context, move=True, copy_if_memmap=False):
         """
@@ -184,7 +184,7 @@ class Cursor(object):
         stop = start + length
         if move:
             self._index = stop
-        out = chunk.get(start, stop)
+        out = chunk.get(start, stop, context)
         if copy_if_memmap:
             step = out
             while getattr(step, "base", None) is not None:
@@ -204,7 +204,7 @@ class Cursor(object):
         stop = start + length * dtype.itemsize
         if move:
             self._index = stop
-        return numpy.frombuffer(chunk.get(start, stop), dtype=dtype)
+        return numpy.frombuffer(chunk.get(start, stop, context), dtype=dtype)
 
     _u1 = numpy.dtype("u1")
     _i4 = numpy.dtype(">i4")
@@ -218,18 +218,17 @@ class Cursor(object):
         """
         start = self._index
         stop = start + 1
-        length = chunk.get(start, stop)[0]
+        length = chunk.get(start, stop, context)[0]
         if length == 255:
             start = stop
             stop = start + 4
-            length = numpy.frombuffer(chunk.get(start, stop), dtype=self._u1).view(
-                self._i4
-            )[0]
+            length_data = chunk.get(start, stop, context)
+            length = numpy.frombuffer(length_data, dtype=self._u1).view(self._i4)[0]
         start = stop
         stop = start + length
         if move:
             self._index = stop
-        return chunk.get(start, stop).tostring()
+        return chunk.get(start, stop, context).tostring()
 
     def string(self, chunk, context, move=True):
         """
@@ -256,7 +255,7 @@ class Cursor(object):
 
         If `move` is False, only peek: don't update the index.
         """
-        remainder = chunk.remainder(self._index)
+        remainder = chunk.remainder(self._index, context)
         local_stop = 0
         char = None
         while char != 0:
@@ -285,7 +284,13 @@ of file path {2}""".format(
     )
 
     def debug(
-        self, chunk, limit_bytes=None, dtype=None, offset=0, stream=sys.stdout,
+        self,
+        chunk,
+        context={},
+        limit_bytes=None,
+        dtype=None,
+        offset=0,
+        stream=sys.stdout,
     ):
         """
         Args:
@@ -316,7 +321,7 @@ of file path {2}""".format(
                 --- --- ---   C   J --- ---   C --- --- ---   {   {
                       101.0           202.0           303.0
         """
-        data = chunk.remainder(self._index)
+        data = chunk.remainder(self._index, context)
         if limit_bytes is not None:
             data = data[:limit_bytes]
 

--- a/uproot4/streamers.py
+++ b/uproot4/streamers.py
@@ -190,8 +190,9 @@ class Model_TStreamerInfo(uproot4.model.Model):
     def new_class(self, file):
         class_code = self.class_code()
         class_name = uproot4.model.classname_encode(self.name, self.class_version)
+        classes = uproot4.model.maybe_custom_classes(file.custom_classes)
         return uproot4.deserialization.compile_class(
-            file, file.classes, class_code, class_name
+            file, classes, class_code, class_name
         )
 
     def class_code(self):

--- a/uproot4/streamers.py
+++ b/uproot4/streamers.py
@@ -135,7 +135,7 @@ class Model_TStreamerInfo(uproot4.model.Model):
         )
 
         self._members["fCheckSum"], self._members["fClassVersion"] = cursor.fields(
-            chunk, _tstreamerinfo_format1
+            chunk, _tstreamerinfo_format1, context
         )
 
         self._members["fElements"] = uproot4.deserialization.read_object_any(
@@ -289,19 +289,19 @@ class Model_TStreamerElement(uproot4.model.Model):
             self._members["fSize"],
             self._members["fArrayLength"],
             self._members["fArrayDim"],
-        ) = cursor.fields(chunk, _tstreamerelement_format1)
+        ) = cursor.fields(chunk, _tstreamerelement_format1, context)
 
         if self._instance_version == 1:
-            n = cursor.field(chunk, _tstreamerelement_format2)
+            n = cursor.field(chunk, _tstreamerelement_format2, context)
             self._members["fMaxIndex"] = cursor.array(
-                chunk, n, _tstreamerelement_dtype1
+                chunk, n, _tstreamerelement_dtype1, context
             )
         else:
             self._members["fMaxIndex"] = cursor.array(
-                chunk, 5, _tstreamerelement_dtype1
+                chunk, 5, _tstreamerelement_dtype1, context
             )
 
-        self._members["fTypeName"] = _canonical_typename(cursor.string(chunk))
+        self._members["fTypeName"] = _canonical_typename(cursor.string(chunk, context))
 
         if self._members["fType"] == 11 and self._members["fTypeName"] in (
             "Bool_t" or "bool"
@@ -394,7 +394,7 @@ class Model_TStreamerBase(Model_TStreamerElement):
             )
         )
         if self._instance_version >= 2:
-            self._members["fBaseVersion"] = cursor.field(chunk, _tstreamerbase_format1)
+            self._members["fBaseVersion"] = cursor.field(chunk, _tstreamerbase_format1, context)
 
     @property
     def base_version(self):
@@ -449,10 +449,10 @@ class Model_TStreamerBasicPointer(Model_TStreamerElement):
             )
         )
         self._members["fCountVersion"] = cursor.field(
-            chunk, _tstreamerbasicpointer_format1
+            chunk, _tstreamerbasicpointer_format1, context
         )
-        self._members["fCountName"] = cursor.string(chunk)
-        self._members["fCountClass"] = cursor.string(chunk)
+        self._members["fCountName"] = cursor.string(chunk, context)
+        self._members["fCountClass"] = cursor.string(chunk, context)
 
     @property
     def count_name(self):
@@ -474,13 +474,13 @@ class Model_TStreamerBasicPointer(Model_TStreamerElement):
         read_members.append("        tmp = self._dtype{0}".format(len(dtypes)))
         if streamerinfo.name == "TBranch" and self.name == "fBasketSeek":
             read_members.append("        if context.get('speedbump', True):")
-            read_members.append("            if cursor.bytes(chunk, 1)[0] == 2:")
+            read_members.append("            if cursor.bytes(chunk, 1, context)[0] == 2:")
             read_members.append("                tmp = numpy.dtype('>i8')")
         else:
             read_members.append("        if context.get('speedbump', True):")
             read_members.append("            cursor.skip(1)")
         read_members.append(
-            "        self._members[{0}] = cursor.array(chunk, self.member({1}), tmp)".format(
+            "        self._members[{0}] = cursor.array(chunk, self.member({1}), tmp, context)".format(
                 repr(self.name), repr(self.count_name)
             )
         )
@@ -592,11 +592,11 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
                 if len(fields[-1]) == 1:
                     read_members.append(
                         "        self._members['{0}'] = cursor.field(chunk, "
-                        "self._format{1})".format(fields[-1][0], len(formats) - 1)
+                        "self._format{1}, context)".format(fields[-1][0], len(formats) - 1)
                     )
                 else:
                     read_members.append(
-                        "        {0} = cursor.fields(chunk, self._format{1})".format(
+                        "        {0} = cursor.fields(chunk, self._format{1}, context)".format(
                             ", ".join(
                                 "self._members[{0}]".format(repr(x)) for x in fields[-1]
                             ),
@@ -607,7 +607,7 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
         else:
             read_members.append(
                 "        self._members[{0}] = cursor.array(chunk, {1}, "
-                "self._dtype{2})".format(
+                "self._dtype{2}, context)".format(
                     repr(self.name), self.array_length, len(dtypes)
                 )
             )
@@ -626,9 +626,9 @@ class Model_TStreamerLoop(Model_TStreamerElement):
                 chunk, cursor, context, self._file, self._parent
             )
         )
-        self._members["fCountVersion"] = cursor.field(chunk, _tstreamerloop_format1)
-        self._members["fCountName"] = cursor.string(chunk)
-        self._members["fCountClass"] = cursor.string(chunk)
+        self._members["fCountVersion"] = cursor.field(chunk, _tstreamerloop_format1, context)
+        self._members["fCountName"] = cursor.string(chunk, context)
+        self._members["fCountClass"] = cursor.string(chunk, context)
 
     @property
     def count_name(self):
@@ -678,7 +678,7 @@ class Model_TStreamerSTL(Model_TStreamerElement):
             )
         )
         self._members["fSTLtype"], self._members["fCtype"] = cursor.fields(
-            chunk, _tstreamerstl_format1
+            chunk, _tstreamerstl_format1, context
         )
 
         if self._members["fSTLtype"] in (
@@ -801,7 +801,7 @@ class Model_TStreamerSTL(Model_TStreamerElement):
         if self.is_string:
             read_members.append("        cursor.skip(6)")
             read_members.append(
-                "        self._members[{0}] = cursor.string(chunk)".format(
+                "        self._members[{0}] = cursor.string(chunk, context)".format(
                     repr(self.name)
                 )
             )
@@ -809,13 +809,13 @@ class Model_TStreamerSTL(Model_TStreamerElement):
         elif self.is_vector_dtype:
             read_members.append("        cursor.skip(6)")
             read_members.append(
-                "        tmp = cursor.field(chunk, self._format{0})".format(
+                "        tmp = cursor.field(chunk, self._format{0}, context)".format(
                     len(formats)
                 )
             )
             read_members.append(
                 "        self._members[{0}] = cursor.array(chunk, tmp, "
-                "self._dtype{1})".format(repr(self.name), len(dtypes))
+                "self._dtype{1}, context)".format(repr(self.name), len(dtypes))
             )
             formats.append(["i"])
             dtypes.append(self.vector_dtype)

--- a/uproot4/streamers.py
+++ b/uproot4/streamers.py
@@ -394,7 +394,9 @@ class Model_TStreamerBase(Model_TStreamerElement):
             )
         )
         if self._instance_version >= 2:
-            self._members["fBaseVersion"] = cursor.field(chunk, _tstreamerbase_format1, context)
+            self._members["fBaseVersion"] = cursor.field(
+                chunk, _tstreamerbase_format1, context
+            )
 
     @property
     def base_version(self):
@@ -474,7 +476,9 @@ class Model_TStreamerBasicPointer(Model_TStreamerElement):
         read_members.append("        tmp = self._dtype{0}".format(len(dtypes)))
         if streamerinfo.name == "TBranch" and self.name == "fBasketSeek":
             read_members.append("        if context.get('speedbump', True):")
-            read_members.append("            if cursor.bytes(chunk, 1, context)[0] == 2:")
+            read_members.append(
+                "            if cursor.bytes(chunk, 1, context)[0] == 2:"
+            )
             read_members.append("                tmp = numpy.dtype('>i8')")
         else:
             read_members.append("        if context.get('speedbump', True):")
@@ -592,7 +596,9 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
                 if len(fields[-1]) == 1:
                     read_members.append(
                         "        self._members['{0}'] = cursor.field(chunk, "
-                        "self._format{1}, context)".format(fields[-1][0], len(formats) - 1)
+                        "self._format{1}, context)".format(
+                            fields[-1][0], len(formats) - 1
+                        )
                     )
                 else:
                     read_members.append(
@@ -626,7 +632,9 @@ class Model_TStreamerLoop(Model_TStreamerElement):
                 chunk, cursor, context, self._file, self._parent
             )
         )
-        self._members["fCountVersion"] = cursor.field(chunk, _tstreamerloop_format1, context)
+        self._members["fCountVersion"] = cursor.field(
+            chunk, _tstreamerloop_format1, context
+        )
         self._members["fCountName"] = cursor.string(chunk, context)
         self._members["fCountClass"] = cursor.string(chunk, context)
 
@@ -822,7 +830,7 @@ class Model_TStreamerSTL(Model_TStreamerElement):
 
         elif self.is_map_string_string:
             read_members.append(
-                "        self._members[{0}] = map_string_string(chunk, cursor)"
+                "        self._members[{0}] = map_string_string(chunk, cursor, context)"
             )
 
         else:


### PR DESCRIPTION
   * [x] Reproduce the failure in demo-double32.root without trying to read Double32. (Just load TTree metadata.)
   * [x] Add breadcrumbs to know where we are in the deserialization process. (Perhaps in `context`.)
   * [x] Create a new exception for deserialization failures and include the breadcrumbs in the message.
   * [x] Ensure that it's possible to locally override the `classes` dict.
   * [x] Catch that new exception in `TKey.get` and fallback to reading the streamer before actually giving up.
   * [x] The demo-double32.root example should then work. That's the end: close PR and move on!