### PR TITLE
XRootD improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The full list is
    * `pandas`: only if `library="pd"`.
    * `cupy`: only if `library="cp"` (reads arrays onto GPUs).
    * `dask[array]` and `dask[dataframe]`: experimental, for lazy arrays with `library="da"`.
-   * `pyxrootd`: only if reading files with `root://` URLs.
+   * `xrootd`: only if reading files with `root://` URLs.
    * `lz4` and `xxhash`: only if reading ROOT files that have been LZ4-compressed.
    * `zstandard`: only if reading ROOT files that have been ZSTD-compressed.
    * `backports.lzma`: only if reading ROOT files that have been LZMA-compressed (in Python 2).

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,17 @@ def get_version():
     exec(open(os.path.join("uproot4", "version.py")).read(), g)
     return g["__version__"]
 
+tests_require = [
+    "pytest",
+    "flake8",
+    "scikit-hep-testdata",
+    "pandas",
+    "awkward1",
+    "boost_histogram",
+    "hist>=2.0.0a1",
+    "dask[array,dataframe]",
+]
+
 setup(name = "uproot4",
       packages = find_packages(exclude = ["tests"]),
       scripts = [],
@@ -26,7 +37,10 @@ setup(name = "uproot4",
       test_suite = "tests",
       python_requires = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
       install_requires = ["numpy"],
-      tests_require = ["pytest", "flake8", "scikit-hep-testdata", "pandas", "awkward1"],
+      tests_require = tests_require,
+      extras_require = {
+          "testing": tests_require,
+      },
 
       classifiers = [
 #         "Development Status :: 1 - Planning",

--- a/tests/test_0001-source-class.py
+++ b/tests/test_0001-source-class.py
@@ -235,7 +235,7 @@ def test_fallback():
 
 @pytest.mark.network
 def test_xrootd():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     with uproot4.source.xrootd.MultithreadedXRootDSource(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         num_workers=0,
@@ -251,7 +251,7 @@ def test_xrootd():
 
 @pytest.mark.network
 def test_xrootd_fail():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     with pytest.raises(Exception) as err:
         source = uproot4.source.xrootd.MultithreadedXRootDSource(
             "root://wonky.cern/does-not-exist", num_workers=0, timeout=1
@@ -260,7 +260,7 @@ def test_xrootd_fail():
 
 @pytest.mark.network
 def test_xrootd_vectorread():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     with uproot4.source.xrootd.XRootDSource(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         timeout=10,
@@ -276,7 +276,7 @@ def test_xrootd_vectorread():
 
 @pytest.mark.network
 def test_xrootd_vectorread_fail():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     with pytest.raises(Exception) as err:
         source = uproot4.source.xrootd.XRootDSource(
             "root://wonky.cern/does-not-exist", timeout=1, max_num_elements=None
@@ -285,7 +285,7 @@ def test_xrootd_vectorread_fail():
 
 @pytest.mark.network
 def test_xrootd_size():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     with uproot4.source.xrootd.XRootDSource(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         timeout=10,
@@ -293,7 +293,7 @@ def test_xrootd_size():
     ) as source:
         size1 = source.num_bytes
 
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     with uproot4.source.xrootd.MultithreadedXRootDSource(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         timeout=10,

--- a/tests/test_0001-source-class.py
+++ b/tests/test_0001-source-class.py
@@ -250,6 +250,16 @@ def test_xrootd():
 
 
 @pytest.mark.network
+def test_xrootd_deadlock():
+    pytest.importorskip("XRootD")
+    # Attach this file to the "test_xrootd_deadlock" function so it leaks
+    pytest.uproot_test_xrootd_deadlock_f = uproot4.source.xrootd.XRootDResource(
+        "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
+        timeout=20,
+    )
+
+
+@pytest.mark.network
 def test_xrootd_fail():
     pytest.importorskip("XRootD")
     with pytest.raises(Exception) as err:

--- a/tests/test_0006-notify-when-downloaded.py
+++ b/tests/test_0006-notify-when-downloaded.py
@@ -159,7 +159,7 @@ def test_http_fallback_workers():
 
 @pytest.mark.network
 def test_xrootd():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     notifications = queue.Queue()
     with uproot4.source.xrootd.MultithreadedXRootDSource(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
@@ -177,7 +177,7 @@ def test_xrootd():
 
 @pytest.mark.network
 def test_xrootd_workers():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     notifications = queue.Queue()
     with uproot4.source.xrootd.MultithreadedXRootDSource(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
@@ -195,7 +195,7 @@ def test_xrootd_workers():
 
 @pytest.mark.network
 def test_xrootd_vectorread():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     notifications = queue.Queue()
     with uproot4.source.xrootd.XRootDSource(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",

--- a/tests/test_0007-single-chunk-interface.py
+++ b/tests/test_0007-single-chunk-interface.py
@@ -112,7 +112,7 @@ def test_http_multipart():
 
 @pytest.mark.network
 def test_xrootd():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     with uproot4.source.xrootd.MultithreadedXRootDSource(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         num_workers=0,
@@ -129,7 +129,7 @@ def test_xrootd():
 
 @pytest.mark.network
 def test_xrootd_worker():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     with uproot4.source.xrootd.MultithreadedXRootDSource(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         num_workers=5,
@@ -146,7 +146,7 @@ def test_xrootd_worker():
 
 @pytest.mark.network
 def test_xrootd_vectorread():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     with uproot4.source.xrootd.XRootDSource(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         timeout=10,

--- a/tests/test_0008-start-interpretation.py
+++ b/tests/test_0008-start-interpretation.py
@@ -70,7 +70,7 @@ def test_http_begin_end_fallback():
 
 @pytest.mark.network
 def test_xrootd_begin_end():
-    pytest.importorskip("pyxrootd")
+    pytest.importorskip("XRootD")
     with uproot4.source.xrootd.XRootDSource(
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         timeout=10,

--- a/tests/test_0046-histograms-bh-hist.py
+++ b/tests/test_0046-histograms-bh-hist.py
@@ -2836,12 +2836,12 @@ def test_boost_2d():
 
 
 def test_hist_1d():
-    boost_histogram = pytest.importorskip("boost_histogram")
+    hist = pytest.importorskip("hist")
     with uproot4.open(skhep_testdata.data_path("uproot-hepdata-example.root")) as f:
         f["hpx"].to_hist()
 
 
 def test_hist_2d():
-    boost_histogram = pytest.importorskip("boost_histogram")
+    hist = pytest.importorskip("hist")
     with uproot4.open(skhep_testdata.data_path("uproot-hepdata-example.root")) as f:
         f["hpxpy"].to_hist()

--- a/uproot4/extras.py
+++ b/uproot4/extras.py
@@ -94,7 +94,7 @@ def XRootD_client():
 
     except ImportError:
         raise ImportError(
-            """Install pyxrootd package with:
+            """Install XRootD python bindings with:
 
     conda install -c conda-forge xrootd
 

--- a/uproot4/extras.py
+++ b/uproot4/extras.py
@@ -86,11 +86,9 @@ or
         return dask.dataframe
 
 
-def pyxrootd_XRootD_client():
+def XRootD_client():
     os.environ["XRD_RUNFORKHANDLER"] = "1"  # set multiprocessing flag
     try:
-        import pyxrootd
-        import pyxrootd.client
         import XRootD
         import XRootD.client
 
@@ -105,7 +103,7 @@ def pyxrootd_XRootD_client():
         )
 
     else:
-        return pyxrootd.client, XRootD.client
+        return XRootD.client
 
 
 def lzma():

--- a/uproot4/source/xrootd.py
+++ b/uproot4/source/xrootd.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/master/LICENSE
 
 """
-Source and Resource for XRootD (pyxrootd).
+Source and Resource for XRootD.
 """
 
 from __future__ import absolute_import
@@ -48,7 +48,7 @@ def get_server_config(file_path):
 
 class XRootDResource(uproot4.source.chunk.Resource):
     """
-    Resource wrapping a pyxrootd.File.
+    Resource wrapping a XRootD.client.File.
     """
 
     def __init__(self, file_path, timeout):
@@ -94,7 +94,7 @@ in file {1}""".format(
     @property
     def file(self):
         """
-        The pyxrootd.File handle.
+        The XRootD.client.File handle.
         """
         return self._file
 
@@ -106,7 +106,7 @@ in file {1}""".format(
 
     def __exit__(self, exception_type, exception_value, traceback):
         """
-        Closes the pyxrootd.File.
+        Closes the XRootD.client.File.
         """
         self._file.close(timeout=(0 if self._timeout is None else self._timeout))
 


### PR DESCRIPTION
Apologies this PR grew a little as I wrote it, the commits should be self contained and easy to review individually. If you'd rather not have any of them (especially 52aa7f4 and a68a6bd) I'll rebase that commit out of the history.

In summary:
* Adds an extra to `setup.py` so `pip install -e .[testing]` allows the tests to be ran fully
* Makes some minor corrections to the test dependencies and what is used in `importorskip`
* Replaces `pyxrootd` with `XRootD` as `pyxrootd` is more of a private implementation detail that should be prefixed with an underscore
* Avoids a deadlock on exit (https://github.com/scikit-hep/uproot/issues/504) by using an `atexit` handler to cleanup open files (this should be made XRootD version dependent once fixed upstream (https://github.com/xrootd/xrootd/pull/1260)
* Adds a test which leaks an open file to make sure pytest deadlocks if https://github.com/scikit-hep/uproot/issues/504 is an issue
* Improves the XRootD server configuration detection to handle redirectors and locally stored files (https://github.com/scikit-hep/uproot4/issues/57)

Closes https://github.com/scikit-hep/uproot4/issues/57
Closes https://github.com/scikit-hep/uproot/issues/504