### PR TITLE
Add function to retrieve common entry offsets among branches

### DIFF
--- a/tests/test_pr0067-common-entry-offsets.py
+++ b/tests/test_pr0067-common-entry-offsets.py
@@ -17,4 +17,7 @@ def test_common_offsets():
     with uproot4.open(skhep_testdata.data_path("uproot-foriter.root")) as f:
         assert f["foriter;1"].common_entry_offsets() == [0, 6, 12, 18, 24, 30, 36, 42, 46]
 
-    # I could not find a testdata file with many well-aligned branches
+    with uproot4.open(skhep_testdata.data_path("uproot-small-dy-nooffsets.root")) as f:
+        assert f["tree;1"].common_entry_offsets() == [0, 200, 400, 501]
+        assert f["tree;1"].common_entry_offsets(["Jet_pt"]) == [0, 200, 397, 400, 501]
+        assert f["tree;1"].common_entry_offsets(["Jet_pt", "nJet"]) == [0, 200, 400, 501]

--- a/tests/test_pr0067.py
+++ b/tests/test_pr0067.py
@@ -1,0 +1,20 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import pytest
+import skhep_testdata
+
+import uproot4
+
+
+def test_common_offsets():
+    # this file has terrible branch alignment
+    with uproot4.open(skhep_testdata.data_path("uproot-hepdata-example.root")) as f:
+        assert f["ntuple;1"].common_entry_offsets() == [0, 75000]
+
+    # this file has just one branch
+    with uproot4.open(skhep_testdata.data_path("uproot-foriter.root")) as f:
+        assert f["foriter;1"].common_entry_offsets() == [0, 6, 12, 18, 24, 30, 36, 42, 46]
+
+    # I could not find a testdata file with many well-aligned branches

--- a/uproot4/behaviors/TBranch.py
+++ b/uproot4/behaviors/TBranch.py
@@ -1175,6 +1175,31 @@ class HasBranches(Mapping):
                 for branch, basket_num, basket in ranges_or_baskets:
                     previous_baskets[branch.cache_key, basket_num] = basket
 
+    def common_entry_offsets(self, branches=None):
+        """Find common breakpoints in baskets
+
+        Arguments:
+            branches (list of str): If None, compute common
+            offsets for all branches, otherwise only compute
+            common offsets for listed branches
+
+        Returns a list of integers
+        """
+        if not len(self):
+            # assume it is a "leaf" branch
+            return self.entry_offsets
+        elif branches is None:
+            branches = self
+        else:
+            branches = (self[b] for b in branches)
+        common_offsets = None
+        for branch in branches:
+            if common_offsets is None:
+                common_offsets = set(branch.common_entry_offsets())
+            else:
+                common_offsets &= set(branch.common_entry_offsets())
+        return sorted(list(common_offsets))
+
 
 _branch_clean_name = re.compile(r"(.*\.)*([^\.\[\]]*)(\[.*\])*")
 _branch_clean_parent_name = re.compile(r"(.*\.)*([^\.\[\]]*)\.([^\.\[\]]*)(\[.*\])*")

--- a/uproot4/behaviors/TBranch.py
+++ b/uproot4/behaviors/TBranch.py
@@ -1178,10 +1178,10 @@ class HasBranches(Mapping):
     def common_entry_offsets(self, branches=None):
         """Find common breakpoints in baskets
 
-        Arguments:
-            branches (list of str): If None, compute common
+        Args:
+            branches (list): If None, compute common
             offsets for all branches, otherwise only compute
-            common offsets for listed branches
+            common offsets for listed branch names
 
         Returns a list of integers
         """
@@ -1198,7 +1198,7 @@ class HasBranches(Mapping):
                 common_offsets = set(branch.common_entry_offsets())
             else:
                 common_offsets &= set(branch.common_entry_offsets())
-        return sorted(list(common_offsets))
+        return sorted(common_offsets)
 
 
 _branch_clean_name = re.compile(r"(.*\.)*([^\.\[\]]*)(\[.*\])*")


### PR DESCRIPTION
This used to be called "clusters" in uproot0 but is not strictly the
ROOT definition of clusters. Users may wish to partition reading
a TTree according to these offsets to prevent having to read and
decompress the same basket in multiple partitions.