### PR TITLE
Fix error from calling `reshape` on TArrayD that lives inside of a TH1D

### DIFF
--- a/uproot4/behaviors/TH1.py
+++ b/uproot4/behaviors/TH1.py
@@ -75,7 +75,7 @@ class TH1(object):
 
         sumw2 = self.member("fSumw2", none_if_missing=True)
         if sumw2 is not None and len(sumw2) == self.member("fNcells"):
-            sumw2 = sumw2.reshape(values.shape)
+            sumw2 = numpy.reshape(sumw2, values.shape)
             positive = sumw2 > 0
             errors[positive] = numpy.sqrt(sumw2[positive])
         else:

--- a/uproot4/behaviors/TH2.py
+++ b/uproot4/behaviors/TH2.py
@@ -33,7 +33,7 @@ class TH2(object):
 
         sumw2 = self.member("fSumw2", none_if_missing=True)
         if sumw2 is not None and len(sumw2) == self.member("fNcells"):
-            sumw2 = sumw2.reshape(values.shape)
+            sumw2 = numpy.reshape(sumw2, values.shape)
             positive = sumw2 > 0
             errors[positive] = numpy.sqrt(sumw2[positive])
         else:
@@ -76,7 +76,7 @@ class TH2(object):
 
         if sumw2 is not None and len(sumw2) == self.member("fNcells"):
             sumw2 = numpy.array(sumw2, dtype=sumw2.dtype.newbyteorder("="))
-            sumw2.reshape(values.shape)
+            sumw2 = sumw2.reshape(values.shape)
             storage = boost_histogram.storage.Weight()
         else:
             if issubclass(values.dtype.type, numpy.integer):

--- a/uproot4/behaviors/TH3.py
+++ b/uproot4/behaviors/TH3.py
@@ -36,7 +36,7 @@ class TH3(object):
 
         sumw2 = self.member("fSumw2", none_if_missing=True)
         if sumw2 is not None and len(sumw2) == self.member("fNcells"):
-            sumw2 = sumw2.reshape(values.shape)
+            sumw2 = numpy.reshape(sumw2, values.shape)
             positive = sumw2 > 0
             errors[positive] = numpy.sqrt(sumw2[positive])
         else:
@@ -81,7 +81,7 @@ class TH3(object):
 
         if sumw2 is not None and len(sumw2) == self.member("fNcells"):
             sumw2 = numpy.array(sumw2, dtype=sumw2.dtype.newbyteorder("="))
-            sumw2.reshape(values.shape)
+            sumw2 = sumw2.reshape(values.shape)
             storage = boost_histogram.storage.Weight()
         else:
             if issubclass(values.dtype.type, numpy.integer):


### PR DESCRIPTION
While moving some code from uproot3 to uproot4 I stumbled upon this error (trying to pull the values and errors from a `TH1D`:

```
In [19]: h.values_errors()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-19-431438897d77> in <module>
----> 1 h.values_errors()

~/.pyenv/versions/3.8.2/envs/tdub/lib/python3.8/site-packages/uproot4/behaviors/TH1.py in values_errors(self)
     76         sumw2 = self.member("fSumw2", none_if_missing=True)
     77         if sumw2 is not None and len(sumw2) == self.member("fNcells"):
---> 78             sumw2 = sumw2.reshape(values.shape)
     79             positive = sumw2 > 0
     80             errors[positive] = numpy.sqrt(sumw2[positive])

AttributeError: 'Model_TArrayD' object has no attribute 'reshape'
```

Since `Model_TArray` has an `__array__` method, we can just use `numpy.reshape` directly on the TArrayD object to fix the error.
