### PR TITLE
Minor tweak to regex to fix #74.

### DIFF
--- a/uproot4/interpretation/identify.py
+++ b/uproot4/interpretation/identify.py
@@ -755,7 +755,7 @@ def parse_typename_for_streamer(typename, file):
     return out
 
 
-_title_has_dims = re.compile(r"^([^\[\]]+)(\[[^\[\]]+\])+")
+_title_has_dims = re.compile(r"^([^\[\]]*)(\[[^\[\]]+\])+")
 _item_dim_pattern = re.compile(r"\[([1-9][0-9]*)\]")
 _item_any_pattern = re.compile(r"\[(.*)\]")
 _vector_pointer = re.compile(r"vector\<([^<>]*)\*\>")


### PR DESCRIPTION
@tamasgal and @bernd1995, this fixes #74 and therefore provides a good model for tamasgal/UnROOT.jl#9. The information about a branch's dimensions are stored in the TLeaf's fTitle, and that needs to be parsed by a regex. The example @bernd1995 created had no leaf names:

```c++
tree_arr -> Branch("6dVec",&vec,"[6]/D");
tree_arr -> Branch("2x3Mat",&mat,"[2][3]/D");
```

as opposed to

```c++
tree_str -> Branch("2x3mat",&mat,"el[6]/D");
```

(where the leaf name is `"el"`), which I guess is legal, so the regex has to allow for that.

This CI is going to fail until I fix scikit-hep/awkward-1.0#416, which @tamasgal pointed out in another issue.