### PR TITLE
Distinguish between 1-byte and 6-byte header in AsArray.

### DIFF
--- a/uproot4/__init__.py
+++ b/uproot4/__init__.py
@@ -62,7 +62,7 @@ from uproot4.containers import STLMap
 import uproot4.interpretation
 import uproot4.interpretation.library
 from uproot4.interpretation.numerical import AsDtype
-from uproot4.interpretation.numerical import AsArray
+from uproot4.interpretation.numerical import AsDtypeInPlace
 from uproot4.interpretation.numerical import AsDouble32
 from uproot4.interpretation.numerical import AsFloat16
 from uproot4.interpretation.numerical import AsSTLBits

--- a/uproot4/behaviors/TBranch.py
+++ b/uproot4/behaviors/TBranch.py
@@ -1385,7 +1385,11 @@ in file {3}""".format(
                                         break
                                 break
 
-                    if self.parent.member("fClassName") == "TClonesArray":
+                    if (
+                        self.parent.member("fClassName") == "TClonesArray"
+                        or self.parent.member("fClonesName", none_if_missing=True)
+                        == fParentName
+                    ):
                         self._streamer_isTClonesArray = True
 
             elif fClassName is not None and fClassName != "":

--- a/uproot4/interpretation/identify.py
+++ b/uproot4/interpretation/identify.py
@@ -245,7 +245,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype("?"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype("?"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -253,7 +255,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype("?"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype("?"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -271,7 +275,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype("u1"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype("u1"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -283,7 +289,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 2,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype("u1"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype("u1"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -303,7 +311,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">i2"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">i2"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -311,7 +321,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">i2"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">i2"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -319,7 +331,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">u2"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">u2"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -331,7 +345,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 2,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">u2"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">u2"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -349,7 +365,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">i4"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">i4"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -357,7 +375,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">i4"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">i4"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -365,7 +385,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">u4"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">u4"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -377,7 +399,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 2,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">u4"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">u4"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -399,7 +423,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">i8"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">i8"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -407,7 +433,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">i8"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">i8"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -415,7 +443,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">i8"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">i8"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -423,7 +453,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">u8"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">u8"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -431,7 +463,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">u8"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">u8"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -443,7 +477,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 2,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">u8"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">u8"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -457,7 +493,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">f4"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">f4"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -465,7 +503,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">f4"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">f4"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -479,7 +519,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">f8"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">f8"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -487,7 +529,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot4.containers.AsArray({0}, numpy.dtype(">f8"))'.format(header),
+                'uproot4.containers.AsArray(False, {0}, numpy.dtype(">f8"))'.format(
+                    header
+                ),
                 quote,
             ),
         )
@@ -504,7 +548,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                "uproot4.containers.AsArray({0}, "
+                "uproot4.containers.AsArray(False, {0}, "
                 'uproot4.containers.AsFIXME("Float16_t in array"))'.format(header),
                 quote,
             ),
@@ -522,7 +566,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                "uproot4.containers.AsArray({0}, "
+                "uproot4.containers.AsArray(False, {0}, "
                 'uproot4.containers.AsFIXME("Double32_t in array '
                 '(note: Event.root fClosestDistance has an example)"))'.format(header),
                 quote,
@@ -1098,7 +1142,12 @@ def interpretation_of(branch, context, simplify=True):
                     model_cls = model_cls.pointee
 
             if branch._streamer_isTClonesArray:
-                model_cls = uproot4.containers.AsArray(False, model_cls)
+                if isinstance(branch.streamer, uproot4.streamers.Model_TStreamerObject):
+                    model_cls = uproot4.containers.AsArray(False, False, model_cls)
+                else:
+                    if hasattr(model_cls, "header"):
+                        model_cls._header = False
+                    model_cls = uproot4.containers.AsArray(True, False, model_cls)
 
             out = uproot4.interpretation.objects.AsObjects(model_cls, branch)
             if simplify:

--- a/uproot4/interpretation/numerical.py
+++ b/uproot4/interpretation/numerical.py
@@ -270,7 +270,7 @@ in file {4}""".format(
         return output
 
 
-class AsArray(AsDtype):
+class AsDtypeInPlace(AsDtype):
     def __init__(self):
         raise NotImplementedError
 

--- a/uproot4/interpretation/objects.py
+++ b/uproot4/interpretation/objects.py
@@ -279,12 +279,17 @@ class AsObjects(uproot4.interpretation.Interpretation):
         if isinstance(
             self._model, (uproot4.containers.AsArray, uproot4.containers.AsVector),
         ):
-            if not self._model.header:
-                header_bytes = 0
-            elif isinstance(self._model, uproot4.containers.AsArray):
-                header_bytes = 1
-            else:
-                header_bytes = 10
+            header_bytes = 0
+            if (
+                isinstance(self._model, uproot4.containers.AsArray)
+                and self._model.speedbump
+            ):
+                header_bytes += 1
+            if (
+                isinstance(self._model, uproot4.containers.AsVector)
+                and self._model.header
+            ):
+                header_bytes += 10
 
             if isinstance(self._model.values, numpy.dtype):
                 content = uproot4.interpretation.numerical.AsDtype(self._model.values)

--- a/uproot4/source/file.py
+++ b/uproot4/source/file.py
@@ -77,7 +77,9 @@ class MemmapSource(uproot4.source.chunk.Source):
             self._file = None
             opts = dict(options)
             opts["num_workers"] = num_fallback_workers
-            self._fallback = uproot4.source.file.MultithreadedFileSource(file_path, **opts)
+            self._fallback = uproot4.source.file.MultithreadedFileSource(
+                file_path, **opts
+            )
 
     def __repr__(self):
         path = repr(self._file_path)


### PR DESCRIPTION
This only fixes the strings case in scikit-hep/uproot#510, commented upon in https://github.com/scikit-hep/uproot4/issues/38#issuecomment-681161557. It doesn't touch the strangely split class.