### PR TITLE
When searching for a streamer by member name, be sure to include a class's base classes.

### DIFF
--- a/uproot4/behaviors/TBranch.py
+++ b/uproot4/behaviors/TBranch.py
@@ -1367,19 +1367,21 @@ in file {3}""".format(
                 if matches is not None:
                     streamerinfo = matches[max(matches)]
 
-                    for element in streamerinfo.elements:
+                    for element in streamerinfo.walk_members(self._file.streamers):
                         if element.name == clean_name:
                             self._streamer = element
                             break
 
                     if self._streamer is None and clean_parentname is not None:
                         clean_parentname = clean_parentname.group(2)
-                        for element in streamerinfo.elements:
+                        for element in streamerinfo.walk_members(self._file.streamers):
                             if element.name == clean_parentname:
                                 substreamerinfo = self._file.streamer_named(
                                     element.typename
                                 )
-                                for subelement in substreamerinfo.elements:
+                                for subelement in substreamerinfo.walk_members(
+                                    self._file.streamers
+                                ):
                                     if subelement.name == clean_name:
                                         self._streamer = subelement
                                         break

--- a/uproot4/streamers.py
+++ b/uproot4/streamers.py
@@ -174,6 +174,15 @@ class Model_TStreamerInfo(uproot4.model.Model):
     def elements(self):
         return self._members["fElements"]
 
+    def walk_members(self, streamers):
+        for element in self._members["fElements"]:
+            if isinstance(element, Model_TStreamerBase):
+                base = streamers[element.name][element.base_version]
+                for x in base.walk_members(streamers):
+                    yield x
+            else:
+                yield element
+
     @property
     def file_uuid(self):
         return self._file.uuid


### PR DESCRIPTION
Fixes #85.