### PR TITLE
Check for memberwise serialization and raise NotImplementedError as needed.

### DIFF
--- a/tests/test_0087-memberwise-splitting-not-implemented-messages.py
+++ b/tests/test_0087-memberwise-splitting-not-implemented-messages.py
@@ -1,0 +1,32 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import pytest
+import skhep_testdata
+
+import uproot4
+
+
+def test_issue510b():
+    with pytest.raises(NotImplementedError):
+        with uproot4.open(skhep_testdata.data_path("uproot-issue510b.root"))[
+            "EDepSimEvents"
+        ] as t:
+            t["Event"]["Trajectories.Points"].array()
+
+
+def test_issue403():
+    with pytest.raises(NotImplementedError):
+        with uproot4.open(skhep_testdata.data_path("uproot-issue403.root"))[
+            "Model"
+        ] as t:
+            t["Model.collimatorInfo"].array()
+
+
+def test_issue475():
+    with pytest.raises(NotImplementedError):
+        with uproot4.open(skhep_testdata.data_path("uproot-issue475.root"))[
+            "Event/Elec/ElecEvent"
+        ] as t:
+            t["fElecChannels"].array()

--- a/uproot4/const.py
+++ b/uproot4/const.py
@@ -103,3 +103,7 @@ kSTLany = 300
 ############# IOFeatures
 
 kGenerateOffsetMap = numpy.uint8(1)
+
+############# other
+
+kStreamedMemberWise = numpy.uint16(1 << 14)

--- a/uproot4/deserialization.py
+++ b/uproot4/deserialization.py
@@ -202,7 +202,11 @@ def numbytes_version(chunk, cursor, context, move=True):
         num_bytes = None
         version = cursor.field(chunk, _numbytes_version_2, context, move=move)
 
-    return num_bytes, version
+    is_memberwise = version & uproot4.const.kStreamedMemberWise
+    if is_memberwise:
+        version = version & ~uproot4.const.kStreamedMemberWise
+
+    return num_bytes, version, is_memberwise
 
 
 def numbytes_check(

--- a/uproot4/model.py
+++ b/uproot4/model.py
@@ -86,6 +86,7 @@ class Model(object):
         self._bases = []
         self._num_bytes = None
         self._instance_version = None
+        self._is_memberwise = False
         return self
 
     @classmethod
@@ -103,6 +104,7 @@ class Model(object):
         self._bases = []
         self._num_bytes = None
         self._instance_version = None
+        self._is_memberwise = False
 
         old_breadcrumbs = context.get("breadcrumbs", ())
         context["breadcrumbs"] = old_breadcrumbs + (self,)
@@ -152,6 +154,7 @@ class Model(object):
         (
             self._num_bytes,
             self._instance_version,
+            self._is_memberwise,
         ) = uproot4.deserialization.numbytes_version(chunk, cursor, context)
 
     def read_members(self, chunk, cursor, context, file):
@@ -234,6 +237,10 @@ class Model(object):
     @property
     def instance_version(self):
         return self._instance_version
+
+    @property
+    def is_memberwise(self):
+        return self._is_memberwise
 
     @property
     def members(self):
@@ -487,7 +494,7 @@ class DispatchByVersion(object):
         import uproot4.deserialization
 
         start_cursor = cursor.copy()
-        num_bytes, version = uproot4.deserialization.numbytes_version(
+        (num_bytes, version, is_memberwise,) = uproot4.deserialization.numbytes_version(
             chunk, cursor, context, move=False
         )
 

--- a/uproot4/models/RNTuple.py
+++ b/uproot4/models/RNTuple.py
@@ -13,6 +13,14 @@ _rntuple_format1 = struct.Struct(">IIQIIQIIQ")
 
 class Model_ROOT_3a3a_Experimental_3a3a_RNTuple(uproot4.model.Model):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
+
         cursor.skip(4)
         (
             self._members["fVersion"],

--- a/uproot4/models/TArray.py
+++ b/uproot4/models/TArray.py
@@ -23,6 +23,13 @@ class Model_TArray(uproot4.model.Model, Sequence):
         pass
 
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._members["fN"] = cursor.field(chunk, _tarray_format1, context)
         self._data = cursor.array(chunk, self._members["fN"], self.dtype, context)
 

--- a/uproot4/models/TAtt.py
+++ b/uproot4/models/TAtt.py
@@ -15,6 +15,13 @@ _tattline1_format1 = struct.Struct(">hhh")
 
 class Model_TAttLine_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         (
             self._members["fLineColor"],
             self._members["fLineStyle"],
@@ -69,6 +76,13 @@ class Model_TAttLine_v1(uproot4.model.VersionedModel):
 
 class Model_TAttLine_v2(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         (
             self._members["fLineColor"],
             self._members["fLineStyle"],
@@ -127,6 +141,13 @@ _tattfill2_format1 = struct.Struct(">hh")
 
 class Model_TAttFill_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._members["fFillColor"], self._members["fFillStyle"] = cursor.fields(
             chunk, _tattfill1_format1, context
         )
@@ -175,6 +196,13 @@ class Model_TAttFill_v1(uproot4.model.VersionedModel):
 
 class Model_TAttFill_v2(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._members["fFillColor"], self._members["fFillStyle"] = cursor.fields(
             chunk, _tattfill2_format1, context
         )
@@ -226,6 +254,13 @@ _tattmarker2_format1 = struct.Struct(">hhf")
 
 class Model_TAttMarker_v2(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         (
             self._members["fMarkerColor"],
             self._members["fMarkerStyle"],

--- a/uproot4/models/TBranch.py
+++ b/uproot4/models/TBranch.py
@@ -21,6 +21,13 @@ class Model_TBranch_v10(
     uproot4.behaviors.TBranch.TBranch, uproot4.model.VersionedModel
 ):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TNamed", 1).read(
                 chunk,
@@ -140,6 +147,13 @@ class Model_TBranch_v11(
     uproot4.behaviors.TBranch.TBranch, uproot4.model.VersionedModel
 ):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TNamed", 1).read(
                 chunk,
@@ -261,6 +275,13 @@ class Model_TBranch_v12(
     uproot4.behaviors.TBranch.TBranch, uproot4.model.VersionedModel
 ):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TNamed", 1).read(
                 chunk,
@@ -383,6 +404,13 @@ class Model_TBranch_v13(
     uproot4.behaviors.TBranch.TBranch, uproot4.model.VersionedModel
 ):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TNamed", 1).read(
                 chunk,
@@ -516,6 +544,13 @@ class Model_TBranchElement_v8(
     uproot4.behaviors.TBranch.TBranch, uproot4.model.VersionedModel
 ):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TBranch", 10).read(
                 chunk,
@@ -577,6 +612,13 @@ class Model_TBranchElement_v9(
     uproot4.behaviors.TBranch.TBranch, uproot4.model.VersionedModel
 ):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TBranch", 12).read(
                 chunk,
@@ -638,6 +680,13 @@ class Model_TBranchElement_v10(
     uproot4.behaviors.TBranch.TBranch, uproot4.model.VersionedModel
 ):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TBranch", 12).read(
                 chunk,
@@ -704,6 +753,13 @@ class Model_TBranchObject_v1(
     uproot4.behaviors.TBranch.TBranch, uproot4.model.VersionedModel
 ):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TBranch", 13).read(
                 chunk,

--- a/uproot4/models/THashList.py
+++ b/uproot4/models/THashList.py
@@ -10,6 +10,13 @@ class Model_THashList(uproot4.model.Model):
         pass
 
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             uproot4.models.TList.Model_TList.read(
                 chunk,

--- a/uproot4/models/TLeaf.py
+++ b/uproot4/models/TLeaf.py
@@ -13,6 +13,13 @@ _tleaf2_format0 = struct.Struct(">iii??")
 
 class Model_TLeaf_v2(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TNamed", 1).read(
                 chunk,
@@ -57,6 +64,13 @@ _tleafb1_format1 = struct.Struct(">bb")
 
 class Model_TLeafB_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TLeaf", 2).read(
                 chunk,
@@ -87,6 +101,13 @@ _tleafc1_format1 = struct.Struct(">ii")
 
 class Model_TLeafC_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TLeaf", 2).read(
                 chunk,
@@ -117,6 +138,13 @@ _tleafd1_format1 = struct.Struct(">dd")
 
 class Model_TLeafD_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TLeaf", 2).read(
                 chunk,
@@ -147,6 +175,13 @@ _tleaff1_format1 = struct.Struct(">ff")
 
 class Model_TLeafF_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TLeaf", 2).read(
                 chunk,
@@ -177,6 +212,13 @@ _tleafi1_format1 = struct.Struct(">ii")
 
 class Model_TLeafI_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TLeaf", 2).read(
                 chunk,
@@ -207,6 +249,13 @@ _tleafl1_format0 = struct.Struct(">qq")
 
 class Model_TLeafL_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TLeaf", 2).read(
                 chunk,
@@ -237,6 +286,13 @@ _tleafO1_format1 = struct.Struct(">??")
 
 class Model_TLeafO_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TLeaf", 2).read(
                 chunk,
@@ -267,6 +323,13 @@ _tleafs1_format1 = struct.Struct(">hh")
 
 class Model_TLeafS_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TLeaf", 2).read(
                 chunk,
@@ -297,6 +360,13 @@ _tleafelement1_format1 = struct.Struct(">ii")
 
 class Model_TLeafElement_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TLeaf", 2).read(
                 chunk,
@@ -324,6 +394,13 @@ class Model_TLeafElement(uproot4.model.DispatchByVersion):
 
 class Model_TLeafD32_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TLeaf", 2).read(
                 chunk,
@@ -349,6 +426,13 @@ class Model_TLeafD32(uproot4.model.DispatchByVersion):
 
 class Model_TLeafF16_v1(uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TLeaf", 2).read(
                 chunk,

--- a/uproot4/models/TList.py
+++ b/uproot4/models/TList.py
@@ -20,6 +20,13 @@ _tlist_format2 = struct.Struct(">B")
 
 class Model_TList(uproot4.model.Model, Sequence):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             uproot4.models.TObject.Model_TObject.read(
                 chunk,

--- a/uproot4/models/TNamed.py
+++ b/uproot4/models/TNamed.py
@@ -11,6 +11,13 @@ import uproot4.containers
 
 class Model_TNamed(uproot4.model.Model):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             uproot4.models.TObject.Model_TObject.read(
                 chunk,

--- a/uproot4/models/TObjArray.py
+++ b/uproot4/models/TObjArray.py
@@ -20,6 +20,13 @@ _tobjarray_format1 = struct.Struct(">ii")
 
 class Model_TObjArray(uproot4.model.Model, Sequence):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             uproot4.models.TObject.Model_TObject.read(
                 chunk,
@@ -70,6 +77,13 @@ uproot4.classes["TObjArray"] = Model_TObjArray
 
 class Model_TObjArrayOfTBaskets(Model_TObjArray):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             uproot4.models.TObject.Model_TObject.read(
                 chunk,

--- a/uproot4/models/TObjString.py
+++ b/uproot4/models/TObjString.py
@@ -8,6 +8,13 @@ import uproot4.models.TObject
 
 class Model_TObjString(uproot4.model.Model, str):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             uproot4.models.TObject.Model_TObject.read(
                 chunk,

--- a/uproot4/models/TObject.py
+++ b/uproot4/models/TObject.py
@@ -19,6 +19,13 @@ class Model_TObject(uproot4.model.Model):
         pass
 
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._instance_version = cursor.field(chunk, _tobject_format1, context)
         if numpy.int64(self._instance_version) & uproot4.const.kByteCountVMask:
             cursor.skip(4)

--- a/uproot4/models/TRef.py
+++ b/uproot4/models/TRef.py
@@ -22,6 +22,13 @@ class Model_TRef(uproot4.model.Model):
         pass
 
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._ref = cursor.field(chunk, _tref_format1, context)
 
     @property
@@ -72,6 +79,13 @@ _trefarray_dtype = numpy.dtype(">i4")
 
 class Model_TRefArray(uproot4.model.Model, Sequence):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         cursor.skip(10)
         self._members["fName"] = cursor.string(chunk, context)
         self._members["fSize"] = cursor.field(chunk, _trefarray_format1, context)

--- a/uproot4/models/TString.py
+++ b/uproot4/models/TString.py
@@ -10,6 +10,13 @@ class Model_TString(uproot4.model.Model, str):
         pass
 
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._data = cursor.string(chunk, context)
 
     def postprocess(self, chunk, cursor, context, file):

--- a/uproot4/models/TTree.py
+++ b/uproot4/models/TTree.py
@@ -16,6 +16,13 @@ _ttree16_format1 = struct.Struct(">qqqqdiiiqqqqq")
 
 class Model_TTree_v16(uproot4.behaviors.TTree.TTree, uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TNamed", 1).read(
                 chunk,
@@ -155,6 +162,13 @@ _ttree17_format1 = struct.Struct(">qqqqdiiiiqqqqq")
 
 class Model_TTree_v17(uproot4.behaviors.TTree.TTree, uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TNamed", 1).read(
                 chunk,
@@ -295,6 +309,13 @@ _ttree18_format1 = struct.Struct(">qqqqqdiiiiqqqqqq")
 
 class Model_TTree_v18(uproot4.behaviors.TTree.TTree, uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TNamed", 1).read(
                 chunk,
@@ -441,6 +462,13 @@ _ttree19_dtype2 = numpy.dtype(">i8")
 
 class Model_TTree_v19(uproot4.behaviors.TTree.TTree, uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TNamed", 1).read(
                 chunk,
@@ -603,6 +631,13 @@ _ttree20_dtype2 = numpy.dtype(">i8")
 
 class Model_TTree_v20(uproot4.behaviors.TTree.TTree, uproot4.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         self._bases.append(
             self.class_named("TNamed", 1).read(
                 chunk,
@@ -777,6 +812,13 @@ _tiofeatures_format1 = struct.Struct(">B")
 
 class Model_ROOT_3a3a_TIOFeatures(uproot4.model.Model):
     def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {0}
+in file {1}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
         cursor.skip(4)
         self._members["fIOBits"] = cursor.field(chunk, _tiofeatures_format1, context)
 

--- a/uproot4/source/cursor.py
+++ b/uproot4/source/cursor.py
@@ -145,7 +145,7 @@ class Cursor(object):
         Returns True if successful (cursor has moved), False otherwise (cursor
         has NOT moved).
         """
-        num_bytes, version = uproot4.deserialization.numbytes_version(
+        num_bytes, version, is_memberwise = uproot4.deserialization.numbytes_version(
             chunk, self, context, move=False
         )
         if num_bytes is None:

--- a/uproot4/streamers.py
+++ b/uproot4/streamers.py
@@ -218,7 +218,14 @@ class Model_TStreamerInfo(uproot4.model.Model):
         )
 
     def class_code(self):
-        read_members = ["    def read_members(self, chunk, cursor, context, file):"]
+        read_members = [
+            "    def read_members(self, chunk, cursor, context, file):",
+            "        if self.is_memberwise:",
+            "            raise NotImplementedError(",
+            '                "memberwise serialization of {0}\\nin file {1}".format('
+            "type(self).__name__, self.file.file_path)",
+            "            )",
+        ]
         strided_interpretation = [
             "    @classmethod",
             "    def strided_interpretation(cls, file, header=False, "
@@ -230,15 +237,18 @@ class Model_TStreamerInfo(uproot4.model.Model):
         ]
         awkward_form = [
             "    @classmethod",
-            "    def awkward_form(cls, file, index_format='i64', header=False, tobject_header=True):",
+            "    def awkward_form(cls, file, index_format='i64', header=False, "
+            "tobject_header=True):",
             "        from awkward1.forms import NumpyForm, ListOffsetForm, "
             "RegularForm, RecordForm",
             "        contents = {}",
             "        if header:",
             "            contents['@num_bytes'] = "
-            "uproot4._util.awkward_form(numpy.dtype('u4'), file, index_format, header, tobject_header)",
+            "uproot4._util.awkward_form(numpy.dtype('u4'), file, index_format, "
+            "header, tobject_header)",
             "            contents['@instance_version'] = "
-            "uproot4._util.awkward_form(numpy.dtype('u2'), file, index_format, header, tobject_header)",
+            "uproot4._util.awkward_form(numpy.dtype('u2'), file, index_format, "
+            "header, tobject_header)",
         ]
         fields = []
         formats = []


### PR DESCRIPTION
This will remove the "bug" label from #38, but won't close it.

Now

```python
>>> import uproot4, skhep_testdata
>>> t = uproot4.open(skhep_testdata.data_path("uproot-issue510b.root"))["EDepSimEvents"]
>>> b = t["Event"]["Trajectories.Points"]
>>> b.array()
```

raises

```
NotImplementedError: memberwise serialization of AsArray
in file /python3.8/site-packages/skhep_testdata/data/uproot-issue510b.root
```

so it should be more clear that this is a missing feature, not a bug.