### PR TITLE
Fixes #36 by replacing range with xrange in Python 2.

### DIFF
--- a/tests/test_0053-parents-should-not-be-bases.py
+++ b/tests/test_0053-parents-should-not-be-bases.py
@@ -9,7 +9,6 @@ import skhep_testdata
 import uproot4
 
 
-@pytest.mark.skipif(uproot4._util.py2, reason="Bug in Python 2")
 def test_TRefArray():
     with uproot4.open(skhep_testdata.data_path("uproot-issue513.root"))["Delphes"] as t:
         array = t["GenJet.Particles"].array(entry_stop=1, library="np")[0]
@@ -85,7 +84,6 @@ def test_TRefArray():
         ]
 
 
-@pytest.mark.skipif(uproot4._util.py2, reason="Bug in Python 2")
 def test_awkward_TRefArray():
     awkward1 = pytest.importorskip("awkward1")
     with uproot4.open(skhep_testdata.data_path("uproot-issue513.root"))["Delphes"] as t:
@@ -336,7 +334,6 @@ def test_awkward_TRefArray():
         ]
 
 
-@pytest.mark.skipif(uproot4._util.py2, reason="Bug in Python 2")
 def test_same_names():
     with uproot4.open(skhep_testdata.data_path("uproot-issue513.root"))["Delphes"] as t:
         one, two = t.values(filter_name="Particle_size")

--- a/uproot4/_util.py
+++ b/uproot4/_util.py
@@ -31,11 +31,13 @@ py35 = not py2 and sys.version_info[1] <= 5
 win = os.name == "nt"
 
 
-# to silence flake8 F821 errors
 if py2:
+    # to silence flake8 F821 errors
     unicode = eval("unicode")
+    range = eval("xrange")
 else:
     unicode = None
+    range = eval("range")
 
 
 def isint(x):

--- a/uproot4/behaviors/TBranch.py
+++ b/uproot4/behaviors/TBranch.py
@@ -1098,7 +1098,7 @@ class HasBranches(Mapping):
                 tree = self.tree
 
             previous_baskets = {}
-            for sub_entry_start in range(entry_start, entry_stop, entry_step):
+            for sub_entry_start in uproot4._util.range(entry_start, entry_stop, entry_step):
                 sub_entry_stop = min(sub_entry_start + entry_step, entry_stop)
                 if sub_entry_stop - sub_entry_start == 0:
                     continue
@@ -1728,7 +1728,7 @@ def _regularize_object_path(
             object_cache=None,
             array_cache=None,
             custom_classes=custom_classes,
-            **options,
+            **options
         ).root_directory
         if object_path is None:
             trees = [k for k, v in file.classnames().items() if v == "TTree"]
@@ -2022,7 +2022,7 @@ def lazy(
             obj, step_size, entry_start, entry_stop, branchid_interpretation
         )
 
-        for start in range(entry_start, entry_stop, entry_step):
+        for start in uproot4._util.range(entry_start, entry_stop, entry_step):
             stop = min(start + entry_step, entry_stop)
             length = stop - start
 

--- a/uproot4/behaviors/TBranch.py
+++ b/uproot4/behaviors/TBranch.py
@@ -1098,7 +1098,9 @@ class HasBranches(Mapping):
                 tree = self.tree
 
             previous_baskets = {}
-            for sub_entry_start in uproot4._util.range(entry_start, entry_stop, entry_step):
+            for sub_entry_start in uproot4._util.range(
+                entry_start, entry_stop, entry_step
+            ):
                 sub_entry_stop = min(sub_entry_start + entry_step, entry_stop)
                 if sub_entry_stop - sub_entry_start == 0:
                     continue
@@ -1728,7 +1730,7 @@ def _regularize_object_path(
             object_cache=None,
             array_cache=None,
             custom_classes=custom_classes,
-            **options
+            **options    # NOTE: a comma after **options breaks Python 2
         ).root_directory
         if object_path is None:
             trees = [k for k, v in file.classnames().items() if v == "TTree"]
@@ -1791,7 +1793,7 @@ def iterate(
     report=False,
     custom_classes=None,
     allow_missing=False,
-    **options
+    **options    # NOTE: a comma after **options breaks Python 2
 ):
     files = _regularize_files(files)
     decompression_executor, interpretation_executor = _regularize_executors(
@@ -1861,7 +1863,7 @@ def concatenate(
     report=False,
     custom_classes=None,
     allow_missing=False,
-    **options
+    **options    # NOTE: a comma after **options breaks Python 2
 ):
     files = _regularize_files(files)
     decompression_executor, interpretation_executor = _regularize_executors(
@@ -1915,7 +1917,7 @@ def lazy(
     report=False,
     custom_classes=None,
     allow_missing=False,
-    **options
+    **options    # NOTE: a comma after **options breaks Python 2
 ):
     files = _regularize_files(files)
     decompression_executor, interpretation_executor = _regularize_executors(

--- a/uproot4/containers.py
+++ b/uproot4/containers.py
@@ -63,12 +63,12 @@ def _read_nested(
     else:
         values = numpy.empty(length, dtype=_stl_object_type)
         if isinstance(model, AsContainer):
-            for i in range(length):
+            for i in uproot4._util.range(length):
                 values[i] = model.read(
                     chunk, cursor, context, file, selffile, parent, header=header
                 )
         else:
-            for i in range(length):
+            for i in uproot4._util.range(length):
                 values[i] = model.read(chunk, cursor, context, file, selffile, parent)
         return values
 
@@ -1121,7 +1121,7 @@ class STLMap(Container, Mapping):
 
     def tolist(self):
         out = {}
-        for i in range(len(self)):
+        for i in uproot4._util.range(len(self)):
             x = self._values[i]
             if isinstance(x, (Container, numpy.ndarray)):
                 out[self._keys[i]] = x.tolist()

--- a/uproot4/interpretation/identify.py
+++ b/uproot4/interpretation/identify.py
@@ -726,15 +726,15 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
 
         if quote:
             cls = "c({0})".format(repr(classname))
-            for x in range(pointers):
+            for x in uproot4._util.range(pointers):
                 cls = "uproot4.containers.AsPointer({0})".format(cls)
         elif file is None:
             cls = uproot4.classes[classname]
-            for x in range(pointers):
+            for x in uproot4._util.range(pointers):
                 cls = uproot4.containers.AsPointer(cls)
         else:
             cls = file.class_named(classname)
-            for x in range(pointers):
+            for x in uproot4._util.range(pointers):
                 cls = uproot4.containers.AsPointer(cls)
 
         return i + 1, cls

--- a/uproot4/interpretation/library.py
+++ b/uproot4/interpretation/library.py
@@ -578,7 +578,9 @@ class Pandas(Library):
             names = []
             arrays = {}
             for n in array.dtype.names:
-                for tup in itertools.product(*[uproot4._util.range(d) for d in array.shape[1:]]):
+                for tup in itertools.product(
+                    *[uproot4._util.range(d) for d in array.shape[1:]]
+                ):
                     name = (n + "".join("[" + str(x) + "]" for x in tup),)
                     names.append(name)
                     arrays[name] = array[n][(slice(None),) + tup]
@@ -598,7 +600,9 @@ class Pandas(Library):
         elif len(array.shape) != 1:
             names = []
             arrays = {}
-            for tup in itertools.product(*[uproot4._util.range(d) for d in array.shape[1:]]):
+            for tup in itertools.product(
+                *[uproot4._util.range(d) for d in array.shape[1:]]
+            ):
                 name = "".join("[" + str(x) + "]" for x in tup)
                 names.append(name)
                 arrays[name] = array[(slice(None),) + tup]

--- a/uproot4/interpretation/library.py
+++ b/uproot4/interpretation/library.py
@@ -112,7 +112,7 @@ class NumPy(Library):
             return all_arrays
 
         if isinstance(all_arrays[0], (tuple, list)):
-            keys = range(len(all_arrays[0]))
+            keys = uproot4._util.range(len(all_arrays[0]))
         elif isinstance(all_arrays[0], dict):
             keys = list(all_arrays[0])
         else:
@@ -450,7 +450,7 @@ in object {3}""".format(
             return all_arrays
 
         if isinstance(all_arrays[0], (tuple, list)):
-            keys = range(len(all_arrays[0]))
+            keys = uproot4._util.range(len(all_arrays[0]))
         elif isinstance(all_arrays[0], dict):
             keys = list(all_arrays[0])
         else:
@@ -496,7 +496,7 @@ def _pandas_basic_index(pandas, entry_start, entry_stop):
     if hasattr(pandas, "RangeIndex"):
         return pandas.RangeIndex(entry_start, entry_stop)
     else:
-        return pandas.Int64Index(range(entry_start, entry_stop))
+        return pandas.Int64Index(uproot4._util.range(entry_start, entry_stop))
 
 
 class Pandas(Library):
@@ -578,7 +578,7 @@ class Pandas(Library):
             names = []
             arrays = {}
             for n in array.dtype.names:
-                for tup in itertools.product(*[range(d) for d in array.shape[1:]]):
+                for tup in itertools.product(*[uproot4._util.range(d) for d in array.shape[1:]]):
                     name = (n + "".join("[" + str(x) + "]" for x in tup),)
                     names.append(name)
                     arrays[name] = array[n][(slice(None),) + tup]
@@ -598,7 +598,7 @@ class Pandas(Library):
         elif len(array.shape) != 1:
             names = []
             arrays = {}
-            for tup in itertools.product(*[range(d) for d in array.shape[1:]]):
+            for tup in itertools.product(*[uproot4._util.range(d) for d in array.shape[1:]]):
                 name = "".join("[" + str(x) + "]" for x in tup)
                 names.append(name)
                 arrays[name] = array[(slice(None),) + tup]
@@ -789,7 +789,7 @@ class Pandas(Library):
             return all_arrays
 
         if isinstance(all_arrays[0], (tuple, list)):
-            keys = range(len(all_arrays[0]))
+            keys = uproot4._util.range(len(all_arrays[0]))
         elif isinstance(all_arrays[0], dict):
             keys = list(all_arrays[0])
         else:
@@ -845,7 +845,7 @@ class CuPy(Library):
             return all_arrays
 
         if isinstance(all_arrays[0], (tuple, list)):
-            keys = range(len(all_arrays[0]))
+            keys = uproot4._util.range(len(all_arrays[0]))
         elif isinstance(all_arrays[0], dict):
             keys = list(all_arrays[0])
         else:

--- a/uproot4/interpretation/objects.py
+++ b/uproot4/interpretation/objects.py
@@ -205,25 +205,25 @@ class AsObjects(uproot4.interpretation.Interpretation):
         for basket_num, stop in enumerate(entry_offsets[1:]):
             if start <= entry_start and entry_stop <= stop:
                 basket_array = basket_arrays[basket_num]
-                for global_i in range(entry_start, entry_stop):
+                for global_i in uproot4._util.range(entry_start, entry_stop):
                     local_i = global_i - start
                     output[global_i - entry_start] = basket_array[local_i]
 
             elif start <= entry_start < stop:
                 basket_array = basket_arrays[basket_num]
-                for global_i in range(entry_start, stop):
+                for global_i in uproot4._util.range(entry_start, stop):
                     local_i = global_i - start
                     output[global_i - entry_start] = basket_array[local_i]
 
             elif start <= entry_stop <= stop:
                 basket_array = basket_arrays[basket_num]
-                for global_i in range(start, entry_stop):
+                for global_i in uproot4._util.range(start, entry_stop):
                     local_i = global_i - start
                     output[global_i - entry_start] = basket_array[local_i]
 
             elif entry_start < stop and start <= entry_stop:
                 basket_array = basket_arrays[basket_num]
-                for global_i in range(start, stop):
+                for global_i in uproot4._util.range(start, stop):
                     local_i = global_i - start
                     output[global_i - entry_start] = basket_array[local_i]
 

--- a/uproot4/model.py
+++ b/uproot4/model.py
@@ -593,7 +593,9 @@ if uproot4._util.py2:
 
     def _classname_decode_convert(hex_characters):
         g = hex_characters.group(1)
-        return b"".join(chr(int(g[i : i + 2], 16)) for i in uproot4._util.range(0, len(g), 2))
+        return b"".join(
+            chr(int(g[i : i + 2], 16)) for i in uproot4._util.range(0, len(g), 2)
+        )
 
 
 else:

--- a/uproot4/model.py
+++ b/uproot4/model.py
@@ -593,7 +593,7 @@ if uproot4._util.py2:
 
     def _classname_decode_convert(hex_characters):
         g = hex_characters.group(1)
-        return b"".join(chr(int(g[i : i + 2], 16)) for i in range(0, len(g), 2))
+        return b"".join(chr(int(g[i : i + 2], 16)) for i in uproot4._util.range(0, len(g), 2))
 
 
 else:
@@ -604,7 +604,7 @@ else:
 
     def _classname_decode_convert(hex_characters):
         g = hex_characters.group(1)
-        return bytes(int(g[i : i + 2], 16) for i in range(0, len(g), 2))
+        return bytes(int(g[i : i + 2], 16) for i in uproot4._util.range(0, len(g), 2))
 
 
 def classname_encode(classname, version=None, unknown=False):

--- a/uproot4/models/TList.py
+++ b/uproot4/models/TList.py
@@ -43,7 +43,7 @@ in file {1}""".format(
         self._members["fSize"] = cursor.field(chunk, _tlist_format1, context)
 
         self._data = []
-        for i in range(self._members["fSize"]):
+        for i in uproot4._util.range(self._members["fSize"]):
             item = uproot4.deserialization.read_object_any(
                 chunk, cursor, context, file, self._file, self._parent
             )

--- a/uproot4/models/TObjArray.py
+++ b/uproot4/models/TObjArray.py
@@ -43,9 +43,8 @@ in file {1}""".format(
         self._members["fSize"], self._members["fLowerBound"] = cursor.fields(
             chunk, _tobjarray_format1, context
         )
-
         self._data = []
-        for i in range(self._members["fSize"]):
+        for i in uproot4._util.range(self._members["fSize"]):
             item = uproot4.deserialization.read_object_any(
                 chunk, cursor, context, file, self._file, self._parent
             )
@@ -102,7 +101,7 @@ in file {1}""".format(
         )
 
         self._data = []
-        for i in range(self._members["fSize"]):
+        for i in uproot4._util.range(self._members["fSize"]):
             item = uproot4.deserialization.read_object_any(
                 chunk,
                 cursor,

--- a/uproot4/reading.py
+++ b/uproot4/reading.py
@@ -1059,7 +1059,7 @@ class ReadOnlyDirectory(Mapping):
             )
 
             self._keys = []
-            for i in range(num_keys):
+            for i in uproot4._util.range(num_keys):
                 key = ReadOnlyKey(
                     keys_chunk, keys_cursor, {}, file, self, read_strings=True
                 )

--- a/uproot4/reading.py
+++ b/uproot4/reading.py
@@ -37,7 +37,7 @@ def open(
     object_cache=100,
     array_cache="100 MB",
     custom_classes=None,
-    **options
+    **options    # NOTE: a comma after **options breaks Python 2
 ):
     """
     Args:
@@ -100,7 +100,7 @@ def open(
         object_cache=object_cache,
         array_cache=array_cache,
         custom_classes=custom_classes,
-        **options
+        **options    # NOTE: a comma after **options breaks Python 2
     )
 
     if object_path is None:
@@ -262,7 +262,7 @@ class ReadOnlyFile(CommonFileMethods):
         object_cache=100,
         array_cache="100 MB",
         custom_classes=None,
-        **options
+        **options    # NOTE: a comma after **options breaks Python 2
     ):
         self._file_path = file_path
         self.object_cache = object_cache
@@ -282,7 +282,10 @@ class ReadOnlyFile(CommonFileMethods):
         Source, file_path = uproot4._util.file_path_to_source_class(
             file_path, self._options
         )
-        self._source = Source(file_path, **self._options)
+        self._source = Source(
+            file_path,
+            **self._options    # NOTE: a comma after **options breaks Python 2
+        )
 
         self.hook_before_get_chunks()
 

--- a/uproot4/source/cursor.py
+++ b/uproot4/source/cursor.py
@@ -402,7 +402,9 @@ of file path {2}""".format(
 
             formatter = u"{{0:>{0}.{0}s}}".format(dtype.itemsize * 4 - 1)
 
-        for line_start in uproot4._util.range(0, int(numpy.ceil(len(data) / 20.0)) * 20, 20):
+        for line_start in uproot4._util.range(
+            0, int(numpy.ceil(len(data) / 20.0)) * 20, 20
+        ):
             line_data = data[line_start : line_start + 20]
 
             prefix = u""

--- a/uproot4/source/cursor.py
+++ b/uproot4/source/cursor.py
@@ -402,7 +402,7 @@ of file path {2}""".format(
 
             formatter = u"{{0:>{0}.{0}s}}".format(dtype.itemsize * 4 - 1)
 
-        for line_start in range(0, int(numpy.ceil(len(data) / 20.0)) * 20, 20):
+        for line_start in uproot4._util.range(0, int(numpy.ceil(len(data) / 20.0)) * 20, 20):
             line_data = data[line_start : line_start + 20]
 
             prefix = u""

--- a/uproot4/source/file.py
+++ b/uproot4/source/file.py
@@ -80,7 +80,8 @@ class MemmapSource(uproot4.source.chunk.Source):
             opts = dict(options)
             opts["num_workers"] = num_fallback_workers
             self._fallback = uproot4.source.file.MultithreadedFileSource(
-                file_path, **opts
+                file_path,
+                **opts    # NOTE: a comma after **opts breaks Python 2
             )
 
     def __repr__(self):

--- a/uproot4/source/file.py
+++ b/uproot4/source/file.py
@@ -56,7 +56,7 @@ class MultithreadedFileSource(uproot4.source.chunk.MultithreadedSource):
 
         self._file_path = file_path
         self._executor = uproot4.source.futures.ResourceThreadPoolExecutor(
-            [FileResource(file_path) for x in range(num_workers)]
+            [FileResource(file_path) for x in uproot4._util.range(num_workers)]
         )
         self._num_bytes = os.path.getsize(self._file_path)
 

--- a/uproot4/source/futures.py
+++ b/uproot4/source/futures.py
@@ -116,7 +116,7 @@ class ThreadPoolExecutor(object):
 
         self._work_queue = queue.Queue()
         self._workers = []
-        for x in range(num_workers):
+        for x in uproot4._util.range(num_workers):
             self._workers.append(Worker(self._work_queue))
         for worker in self._workers:
             worker.start()

--- a/uproot4/source/http.py
+++ b/uproot4/source/http.py
@@ -194,13 +194,13 @@ for URL {0}""".format(
         notifications = queue.Queue()
         source.fallback.chunks(ranges, notifications)
 
-        for x in range(len(ranges)):
+        for x in uproot4._util.range(len(ranges)):
             chunk = notifications.get()
             results[chunk.start, chunk.stop] = chunk.raw_data
             futures[chunk.start, chunk.stop]._run(self)
 
     def handle_multipart(self, source, futures, results, response):
-        for i in range(len(futures)):
+        for i in uproot4._util.range(len(futures)):
             range_string, size = self.next_header(response)
             if range_string is None:
                 raise OSError(
@@ -282,7 +282,7 @@ class MultithreadedHTTPSource(uproot4.source.chunk.MultithreadedSource):
         self._timeout = timeout
 
         self._executor = uproot4.source.futures.ResourceThreadPoolExecutor(
-            [HTTPResource(file_path, timeout) for x in range(num_workers)]
+            [HTTPResource(file_path, timeout) for x in uproot4._util.range(num_workers)]
         )
 
     @property

--- a/uproot4/source/http.py
+++ b/uproot4/source/http.py
@@ -360,7 +360,8 @@ class HTTPSource(uproot4.source.chunk.Source):
 
     def _set_fallback(self):
         self._fallback = MultithreadedHTTPSource(
-            self._file_path, **self._fallback_options
+            self._file_path,
+            **self._fallback_options    # NOTE: a comma after **fallback_options breaks Python 2
         )
 
     def __enter__(self):

--- a/uproot4/source/xrootd.py
+++ b/uproot4/source/xrootd.py
@@ -161,7 +161,7 @@ class MultithreadedXRootDSource(uproot4.source.chunk.MultithreadedSource):
         self._timeout = timeout
 
         self._executor = uproot4.source.futures.ResourceThreadPoolExecutor(
-            [XRootDResource(file_path, timeout) for x in range(num_workers)]
+            [XRootDResource(file_path, timeout) for x in uproot4._util.range(num_workers)]
         )
 
     @property

--- a/uproot4/source/xrootd.py
+++ b/uproot4/source/xrootd.py
@@ -161,7 +161,10 @@ class MultithreadedXRootDSource(uproot4.source.chunk.MultithreadedSource):
         self._timeout = timeout
 
         self._executor = uproot4.source.futures.ResourceThreadPoolExecutor(
-            [XRootDResource(file_path, timeout) for x in uproot4._util.range(num_workers)]
+            [
+                XRootDResource(file_path, timeout)
+                for x in uproot4._util.range(num_workers)
+            ]
         )
 
     @property

--- a/uproot4/streamers.py
+++ b/uproot4/streamers.py
@@ -258,7 +258,7 @@ class Model_TStreamerInfo(uproot4.model.Model):
         member_names = []
         class_flags = {}
 
-        for i in range(len(self._members["fElements"])):
+        for i in uproot4._util.range(len(self._members["fElements"])):
             self._members["fElements"][i].class_code(
                 self,
                 i,
@@ -900,7 +900,9 @@ class Model_TStreamerLoop(Model_TStreamerElement):
         read_members.extend(
             [
                 "        cursor.skip(6)",
-                "        for tmp in range(self.member({0})):".format(self.count_name),
+                "        for tmp in uproot4._util.range(self.member({0})):".format(
+                    self.count_name
+                ),
                 "            self._members[{0}] = c({1}).read(chunk, cursor, "
                 "context, file, self._file, self._concrete)".format(
                     repr(self.name), repr(self.typename.rstrip("*"))


### PR DESCRIPTION
Uproot's deserialization is based on nominal versions of classes first, then falls back to streamers if they're wrong. Streamers being wrong can have you thinking you need to iterate over 1329201155 elements in a TObjArray before the error gets fixed. In Python 2, `range(1329201155)` constructs a list, which uses an enormous amount of memory. `uproot4._util.range` is `range` in Python 3 and `xrange` in Python 2; we just need to use `uproot4._util.range` wherever we'd use `range`.

Issue #36 warned that it might be a deep bug, affecting Python 3 in unknown and apparently invisible ways. It's not.