### PR TITLE
Homogenize uses of KeyInFileError

### DIFF
--- a/uproot4/__init__.py
+++ b/uproot4/__init__.py
@@ -239,9 +239,9 @@ class KeyInFileError(KeyError):
         self.key = key
         self.because = because
         self.cycle = cycle
+        self.keys = keys
         self.file_path = file_path
         self.object_path = object_path
-        self.keys = keys
 
     def __str__(self):
         if self.because == "":

--- a/uproot4/behaviors/TBranch.py
+++ b/uproot4/behaviors/TBranch.py
@@ -1730,8 +1730,8 @@ class HasBranches(Mapping):
             else:
                 raise uproot4.KeyInFileError(
                     original_where,
-                    file_path=self._file.file_path,
                     keys=self.keys(recursive=recursive),
+                    file_path=self._file.file_path,
                     object_path=self.object_path,
                 )
 

--- a/uproot4/language/python.py
+++ b/uproot4/language/python.py
@@ -363,7 +363,7 @@ class PythonLanguage(uproot4.language.Language):
             )
         except KeyError as err:
             raise uproot4.KeyInFileError(
-                err.args[0], file_path, object_path=object_path
+                err.args[0], file_path=file_path, object_path=object_path
             )
 
     def compute_expressions(

--- a/uproot4/model.py
+++ b/uproot4/model.py
@@ -501,7 +501,7 @@ class Model(object):
         else:
             raise uproot4.KeyInFileError(
                 name,
-                """{0}.{1} has only the following members:
+                because="""{0}.{1} has only the following members:
 
     {2}
 """.format(

--- a/uproot4/reading.py
+++ b/uproot4/reading.py
@@ -1809,7 +1809,7 @@ class ReadOnlyDirectory(Mapping):
                     else:
                         raise uproot4.KeyInFileError(
                             where,
-                            repr(item) + " is not a TDirectory",
+                            because=repr(item) + " is not a TDirectory",
                             keys=[key.fName for key in last._keys],
                             file_path=self._file.file_path,
                         )
@@ -1864,8 +1864,7 @@ class ReadOnlyDirectory(Mapping):
                             else:
                                 raise uproot4.KeyInFileError(
                                     where,
-                                    repr(head)
-                                    + " is not a TDirectory, TTree, or TBranch",
+                                    because=repr(head) + " is not a TDirectory, TTree, or TBranch",
                                     keys=[key.fName for key in last._keys],
                                     file_path=self._file.file_path,
                                 )
@@ -1879,7 +1878,7 @@ class ReadOnlyDirectory(Mapping):
                     else:
                         raise uproot4.KeyInFileError(
                             where,
-                            repr(item) + " is not a TDirectory, TTree, or TBranch",
+                            because=repr(item) + " is not a TDirectory, TTree, or TBranch",
                             keys=[key.fName for key in last._keys],
                             file_path=self._file.file_path,
                         )

--- a/uproot4/reading.py
+++ b/uproot4/reading.py
@@ -1864,7 +1864,8 @@ class ReadOnlyDirectory(Mapping):
                             else:
                                 raise uproot4.KeyInFileError(
                                     where,
-                                    because=repr(head) + " is not a TDirectory, TTree, or TBranch",
+                                    because=repr(head)
+                                    + " is not a TDirectory, TTree, or TBranch",
                                     keys=[key.fName for key in last._keys],
                                     file_path=self._file.file_path,
                                 )
@@ -1878,7 +1879,8 @@ class ReadOnlyDirectory(Mapping):
                     else:
                         raise uproot4.KeyInFileError(
                             where,
-                            because=repr(item) + " is not a TDirectory, TTree, or TBranch",
+                            because=repr(item)
+                            + " is not a TDirectory, TTree, or TBranch",
                             keys=[key.fName for key in last._keys],
                             file_path=self._file.file_path,
                         )


### PR DESCRIPTION
Raised by @kratsg on Slack:

```python
Traceback (most recent call last):
...
  File "/home/kratsg/pyhf/lib/python3.8/site-packages/uproot4/behaviors/TBranch.py", line 945, in arrays
    arrays, expression_context, branchid_interpretation = _regularize_expressions(
  File "/home/kratsg/pyhf/lib/python3.8/site-packages/uproot4/behaviors/TBranch.py", line 2881, in _regularize_expressions
    _regularize_expression(
  File "/home/kratsg/pyhf/lib/python3.8/site-packages/uproot4/behaviors/TBranch.py", line 2789, in _regularize_expression
    for symbol in language.free_symbols(
  File "/home/kratsg/pyhf/lib/python3.8/site-packages/uproot4/language/python.py", line 365, in free_symbols
    raise uproot4.KeyInFileError(
uproot4.KeyInFileError: not found: 'mjj' because /home/mhance/mario-mapyde/output/VjjQCD_13_mmjj_8000_9000/analysis/histograms.root
in object /presel/hftree;1
```

should be

```python
...
  File "/home/kratsg/pyhf/lib/python3.8/site-packages/uproot4/language/python.py", line 365, in free_symbols
    raise uproot4.KeyInFileError(
uproot4.KeyInFileError: not found: 'mjj'
in file /home/mhance/mario-mapyde/output/VjjQCD_13_mmjj_8000_9000/analysis/histograms.root
in object /presel/hftree;1
```