### PR TITLE
ci: cleanup a bit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,8 +21,6 @@ jobs:
             python-version: "3.6"
           - platform: "windows-latest"
             python-version: "3.7"
-        # platform: ["windows-latest"]
-        # python-version: ["3.5", "3.6", "3.7", "3.8"]
 
     runs-on: "${{ matrix.platform }}"
     
@@ -39,12 +37,11 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          channels: "conda-forge"
 
       - name: "Install most dependencies"
         run: |
           conda env list
-          conda config --add channels conda-forge
-          conda update -n base -c defaults conda
           conda info
           conda install numpy pandas pytest flake8 lz4 python-xxhash
           pip install scikit-hep-testdata

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,18 +25,22 @@ jobs:
         # python-version: ["3.5", "3.6", "3.7", "3.8"]
 
     runs-on: "${{ matrix.platform }}"
+    
+    # Required for miniconda to activate conda
+    defaults:
+      run:
+        shell: "bash -l {0}"
 
     steps:
       - uses: "actions/checkout@v2"
 
       - name: "Get conda"
-        uses: "goanpeca/setup-miniconda@v1"
+        uses: "conda-incubator/setup-miniconda@v1"
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
 
       - name: "Install most dependencies"
-        shell: "bash -l {0}"
         run: |
           conda env list
           conda config --add channels conda-forge
@@ -47,24 +51,20 @@ jobs:
           conda list
 
       - name: "Install Awkward"
-        shell: "bash -l {0}"
         run: |
           conda env list
           pip install awkward1
           conda list
 
       - name: "Install XRootD"
-        if: "${{ matrix.python-version != 3.5  &&  !contains(matrix.platform, 'macos')  &&  !contains(matrix.platform, 'windows') }}"
-        shell: "bash -l {0}"
+        if: "matrix.python-version != 3.5 && runner.os != 'macOS'  &&  runner.os != 'Windows'"
         run: |
           conda env list
           conda install xrootd
           conda list
 
       - name: "Run flake8"
-        shell: "bash -l {0}"
         run: python -m flake8
 
       - name: "Run pytest"
-        shell: "bash -l {0}"
         run: python -m pytest -vv tests


### PR DESCRIPTION
Cleaning up a little. setup-minconda has moved. GHA has added a new feature that allows the default shell to be set.

You still have way too many quotes on things that don't need them. :P

(But you are okay to put the contents of `run:` in without quotes?...)