### PR TITLE
Don't assume branch names are expressions

### DIFF
--- a/tests/test_0044-concatenate-function.py
+++ b/tests/test_0044-concatenate-function.py
@@ -25,7 +25,7 @@ def test_concatenate_awkward():
     )
     arrays = uproot4.concatenate({files: "sample"}, ["i8", "f8"], library="ak")
     assert isinstance(arrays, awkward1.Array)
-    assert set(awkward1.keys(arrays)) == set(["i8", "f8"])
+    assert set(awkward1.fields(arrays)) == set(["i8", "f8"])
     assert len(arrays) == 420
 
 

--- a/uproot4/behaviors/TBranch.py
+++ b/uproot4/behaviors/TBranch.py
@@ -1112,9 +1112,10 @@ class HasBranches(Mapping):
             for branch in context["branches"]:
                 if branch.cache_key not in checked:
                     checked.add(branch.cache_key)
-                    for basket_num, range_or_basket in branch.entries_to_ranges_or_baskets(
-                        entry_start, entry_stop
-                    ):
+                    for (
+                        basket_num,
+                        range_or_basket,
+                    ) in branch.entries_to_ranges_or_baskets(entry_start, entry_stop):
                         ranges_or_baskets.append((branch, basket_num, range_or_basket))
 
         _ranges_or_baskets_to_arrays(
@@ -2996,12 +2997,12 @@ in file {2} at {3}""".format(
             expression_branches.extend(expression_context[-1][1]["branches"])
 
         c = {
-                "is_primary": is_primary,
-                "is_cut": is_cut,
-                "is_jagged": is_jagged,
-                "is_branch": False,
-                "branches": expression_branches,
-            }
+            "is_primary": is_primary,
+            "is_cut": is_cut,
+            "is_jagged": is_jagged,
+            "is_branch": False,
+            "branches": expression_branches,
+        }
         if rename is not None:
             c["rename"] = rename
         expression_context.append((expression, c))

--- a/uproot4/interpretation/library.py
+++ b/uproot4/interpretation/library.py
@@ -122,7 +122,9 @@ class Library(object):
         elif how is list:
             return [arrays[name] for name, _ in expression_context]
         elif how is dict or how is None:
-            return dict((_rename(name, c), arrays[name]) for name, c in expression_context)
+            return dict(
+                (_rename(name, c), arrays[name]) for name, c in expression_context
+            )
         else:
             raise TypeError(
                 "for library {0}, how must be tuple, list, dict, or None (for "
@@ -519,10 +521,14 @@ in object {3}""".format(
         elif how is list:
             return [arrays[name] for name, _ in expression_context]
         elif how is dict:
-            return dict((_rename(name, c), arrays[name]) for name, c in expression_context)
+            return dict(
+                (_rename(name, c), arrays[name]) for name, c in expression_context
+            )
         elif how is None:
             return awkward1.zip(
-                dict((_rename(name, c), arrays[name]) for name, c in expression_context),
+                dict(
+                    (_rename(name, c), arrays[name]) for name, c in expression_context
+                ),
                 depth_limit=1,
             )
         elif how == "zip":
@@ -807,7 +813,9 @@ class Pandas(Library):
             return [arrays[name] for name, _ in expression_context]
 
         elif how is dict:
-            return dict((_rename(name, c), arrays[name]) for name, c in expression_context)
+            return dict(
+                (_rename(name, c), arrays[name]) for name, c in expression_context
+            )
 
         elif uproot4._util.isstr(how) or how is None:
             arrays, names = _pandas_only_series(pandas, arrays, expression_context)

--- a/uproot4/interpretation/library.py
+++ b/uproot4/interpretation/library.py
@@ -40,6 +40,13 @@ import uproot4.containers
 import uproot4.extras
 
 
+def _rename(name, context):
+    if context is None or "rename" not in context:
+        return name
+    else:
+        return context["rename"]
+
+
 class Library(object):
     """
     Abstract superclass of array-library handlers, for libraries such as NumPy,
@@ -115,7 +122,7 @@ class Library(object):
         elif how is list:
             return [arrays[name] for name, _ in expression_context]
         elif how is dict or how is None:
-            return dict((name, arrays[name]) for name, _ in expression_context)
+            return dict((_rename(name, c), arrays[name]) for name, c in expression_context)
         else:
             raise TypeError(
                 "for library {0}, how must be tuple, list, dict, or None (for "
@@ -512,10 +519,10 @@ in object {3}""".format(
         elif how is list:
             return [arrays[name] for name, _ in expression_context]
         elif how is dict:
-            return dict((name, arrays[name]) for name, _ in expression_context)
+            return dict((_rename(name, c), arrays[name]) for name, c in expression_context)
         elif how is None:
             return awkward1.zip(
-                dict((name, arrays[name]) for name, _ in expression_context),
+                dict((_rename(name, c), arrays[name]) for name, c in expression_context),
                 depth_limit=1,
             )
         elif how == "zip":
@@ -527,17 +534,17 @@ in object {3}""".format(
                 if context["is_jagged"]:
                     if len(offsets) == 0:
                         offsets.append(array.layout.offsets)
-                        jaggeds.append([name])
+                        jaggeds.append([_rename(name, context)])
                     else:
                         for o, j in zip(offsets, jaggeds):
                             if numpy.array_equal(array.layout.offsets, o):
-                                j.append(name)
+                                j.append(_rename(name, context))
                                 break
                         else:
                             offsets.append(array.layout.offsets)
-                            jaggeds.append([name])
+                            jaggeds.append([_rename(name, context)])
                 else:
-                    nonjagged.append(name)
+                    nonjagged.append(_rename(name, context))
             out = None
             if len(nonjagged) != 0:
                 out = awkward1.zip(
@@ -627,6 +634,28 @@ def _pandas_basic_index(pandas, entry_start, entry_stop):
         return pandas.RangeIndex(entry_start, entry_stop)
     else:
         return pandas.Int64Index(uproot4._util.range(entry_start, entry_stop))
+
+
+def _pandas_only_series(pandas, original_arrays, expression_context):
+    arrays = {}
+    names = []
+    for name, context in expression_context:
+        if isinstance(original_arrays[name], pandas.Series):
+            arrays[_rename(name, context)] = original_arrays[name]
+            names.append(_rename(name, context))
+        else:
+            df = original_arrays[name]
+            for subname in df.columns:
+                if df.leaflist:
+                    if isinstance(subname, tuple):
+                        path = (_rename(name, context),) + subname
+                    else:
+                        path = (_rename(name, context), subname)
+                else:
+                    path = _rename(name, context) + subname
+                arrays[path] = df[subname]
+                names.append(path)
+    return arrays, names
 
 
 class Pandas(Library):
@@ -768,43 +797,20 @@ class Pandas(Library):
             index = _pandas_basic_index(pandas, entry_start, entry_stop)
             return pandas.Series(array, index=index)
 
-    def _only_series(self, original_arrays, original_names):
-        pandas = self.imported
-        arrays = {}
-        names = []
-        for name in original_names:
-            if isinstance(original_arrays[name], pandas.Series):
-                arrays[name] = original_arrays[name]
-                names.append(name)
-            else:
-                df = original_arrays[name]
-                for subname in df.columns:
-                    if df.leaflist:
-                        if isinstance(subname, tuple):
-                            path = (name,) + subname
-                        else:
-                            path = (name, subname)
-                    else:
-                        path = name + subname
-                    arrays[path] = df[subname]
-                    names.append(path)
-        return arrays, names
-
     def group(self, arrays, expression_context, how):
         pandas = self.imported
-        names = [name for name, _ in expression_context]
 
         if how is tuple:
-            return tuple(arrays[name] for name in names)
+            return tuple(arrays[name] for name, _ in expression_context)
 
         elif how is list:
-            return [arrays[name] for name in names]
+            return [arrays[name] for name, _ in expression_context]
 
         elif how is dict:
-            return dict((name, arrays[name]) for name in names)
+            return dict((_rename(name, c), arrays[name]) for name, c in expression_context)
 
         elif uproot4._util.isstr(how) or how is None:
-            arrays, names = self._only_series(arrays, names)
+            arrays, names = _pandas_only_series(pandas, arrays, expression_context)
 
             if any(isinstance(x, tuple) for x in names):
                 longest = max(len(x) for x in names if isinstance(x, tuple))

--- a/uproot4/language/python.py
+++ b/uproot4/language/python.py
@@ -339,6 +339,15 @@ class PythonLanguage(uproot4.language.Language):
         """
         return self._getter
 
+    def getter_of(self, name):
+        """
+        Returns a string, an expression in which the ``getter`` is getting
+        ``name`` as a quoted string.
+
+        For example, ``"get('something')"``.
+        """
+        return "{0}({1})".format(self._getter, repr(name))
+
     def free_symbols(self, expression, keys, aliases, file_path, object_path):
         """
         Args:
@@ -400,9 +409,12 @@ class PythonLanguage(uproot4.language.Language):
 
         scope = {self._getter: getter, "function": self._functions}
         for expression, context in expression_context:
-            branch = context.get("branch")
-            if branch is not None:
-                values[expression] = arrays[branch.cache_key]
+            single_branch = context.get("branch", None)
+            if single_branch is not None:
+                values[single_branch.name] = arrays[single_branch.cache_key]
+            else:
+                for branch in context["branches"]:
+                    values[branch.name] = arrays[branch.cache_key]
 
         output = {}
         for expression, context in expression_context:

--- a/uproot4/language/python.py
+++ b/uproot4/language/python.py
@@ -409,12 +409,8 @@ class PythonLanguage(uproot4.language.Language):
 
         scope = {self._getter: getter, "function": self._functions}
         for expression, context in expression_context:
-            single_branch = context.get("branch", None)
-            if single_branch is not None:
-                values[single_branch.name] = arrays[single_branch.cache_key]
-            else:
-                for branch in context["branches"]:
-                    values[branch.name] = arrays[branch.cache_key]
+            for branch in context["branches"]:
+                values[branch.name] = arrays[branch.cache_key]
 
         output = {}
         for expression, context in expression_context:

--- a/uproot4/language/python.py
+++ b/uproot4/language/python.py
@@ -410,7 +410,12 @@ class PythonLanguage(uproot4.language.Language):
         scope = {self._getter: getter, "function": self._functions}
         for expression, context in expression_context:
             for branch in context["branches"]:
-                values[branch.name] = arrays[branch.cache_key]
+                array = arrays[branch.cache_key]
+                name = branch.name
+                while isinstance(branch, uproot4.behaviors.TBranch.TBranch):
+                    values[name] = array
+                    branch = branch.parent
+                    name = branch.name + "/" + name
 
         output = {}
         for expression, context in expression_context:


### PR DESCRIPTION
So, for instance, if a user types

```python
tree.arrays()
```

and any branch names are things like `"what # ever"`, don't make that an expression; make `"get('what # ever')"` an expression instead.

Also noticed a blocking error (could not find previous iteration's basket data) in HasBranches.iterate if the expression is not the branch name. Fixing the above revealed that brittleness, and now it has been fixed.

Also simplified the metadata in `expression_context`.