### PR TITLE
docs: add example for custom interpretations

### DIFF
--- a/docs-sphinx/uproot3-to-4.rst
+++ b/docs-sphinx/uproot3-to-4.rst
@@ -4,3 +4,79 @@ Uproot 3 → 4 cheat-sheet
 I'm collecting ideas for this cheat-sheet on the `Uproot 4 wiki <https://github.com/scikit-hep/uproot4/wiki>`__.
 
 If you think of something that would be good for me to write here, dump it there (doesn't need to be polished).
+
+Custom interpretations
+----------------------
+
+Whenever the automatic serialisation of uproot fails for whatever reason, a
+custom interpretation comes to the rescue. The concept remained the same but a
+few details have been changed. Below are two examples, the first showing how to
+pass a custom interpretation in ``uproot3`` and the second the same approach in
+``uproot4``.
+
+uproot3
+~~~~~~~
+
+.. code-block:: python
+
+    import uproot  # version 3
+    from skhep_testdata import data_path
+
+    f = uproot.open(data_path("uproot-issue124.root"))
+
+    tree = f["KM3NET_EVENT"]
+
+    snapshot_hits = tree["snapshotHits"].array(
+        uproot.asjagged(
+            uproot.astable(
+                uproot.asdtype(
+                    [
+                        ("dom_id", ">i4"),
+                        ("channel_id", "u1"),
+                        ("time", "<u4"),
+                        ("tot", "u1"),
+                    ]
+                )
+            ),
+            skipbytes=10,
+        )
+    )
+
+This will return an ``awkward0.JaggedArray``:
+
+.. code-block:: python
+    >>> snapshot_hits
+    <JaggedArray [[<Row 0> <Row 1> <Row 2> ... <Row 50> <Row 51> <Row 52>]  ...  [<Row 849> <Row 850> <Row 851> ... <Row 887> <Row 888> <Row 889>] [<Row 890> <Row 891> <Row 892> ... <Row 920> <Row 921> <Row 922>]] at 0x7f9b8e6c89d0>
+
+    >>> snapshot_hits.dom_id
+    <JaggedArray [[808432835 808432835 808432835 ... 809526097 809526097 809526097]   ...  [808432835 808488997 808488997 ... 809526097 809526097 809544061] [808432835 808432835 808432835 ... 809526097 809526097 809544061]] at 0x7f9bc99b05e0>
+
+uproot4
+~~~~~~~
+
+.. code-block:: python
+    import uproot4 as uproot  # version 4
+    from skhep_testdata import data_path
+
+    f = uproot.open(data_path("uproot-issue124.root"))
+
+    tree = f["KM3NET_EVENT"]
+
+    snapshot_hits = tree["snapshotHits"].array(
+        uproot4.interpretation.jagged.AsJagged(
+            uproot4.interpretation.numerical.AsDtype(
+                [
+                    ("dom_id", ">i4"),
+                    ("channel_id", "u1"),
+                    ("time", "<u4"),
+                    ("tot", "u1"),
+                ]
+            ), header_bytes=10,
+        )
+    )
+
+Which will return an ``awkward1.Array``:
+
+.. code-block:: python
+    >>> snapshot_hits
+    <Array [[{dom_id: 808432835, ... tot: 30}]] type='23 * var * {"dom_id": int32, "...'>

--- a/docs-sphinx/uproot3-to-4.rst
+++ b/docs-sphinx/uproot3-to-4.rst
@@ -45,6 +45,7 @@ uproot3
 This will return an ``awkward0.JaggedArray``:
 
 .. code-block:: python
+
     >>> snapshot_hits
     <JaggedArray [[<Row 0> <Row 1> <Row 2> ... <Row 50> <Row 51> <Row 52>]  ...  [<Row 849> <Row 850> <Row 851> ... <Row 887> <Row 888> <Row 889>] [<Row 890> <Row 891> <Row 892> ... <Row 920> <Row 921> <Row 922>]] at 0x7f9b8e6c89d0>
 
@@ -55,6 +56,7 @@ uproot4
 ~~~~~~~
 
 .. code-block:: python
+
     import uproot4 as uproot  # version 4
     from skhep_testdata import data_path
 
@@ -78,5 +80,6 @@ uproot4
 Which will return an ``awkward1.Array``:
 
 .. code-block:: python
+
     >>> snapshot_hits
     <Array [[{dom_id: 808432835, ... tot: 30}]] type='23 * var * {"dom_id": int32, "...'>


### PR DESCRIPTION
These are just two tiny examples which show how to pass a custom interpretation of a jagged structure in uproot3 vs uproot4.

Not sure if the cheat sheet is intended to look like this, so please feel free to take whatever you think is useful.

Edit: crossref to #169