### PR TITLE
Quickfix .lazy() when called on missing files. Fixes #120

### DIFF
--- a/tests/test_0045-lazy-arrays-1.py
+++ b/tests/test_0045-lazy-arrays-1.py
@@ -148,3 +148,10 @@ def test_awkward_pluralization():
     )
     array = uproot4.lazy({files: "sample"})
     assert awkward1.to_list(array[:5, "i4"]) == [-15, -14, -13, -12, -11]
+
+
+def test_lazy_called_on_nonexistent_file():
+    filename = "nonexistent_file.root"
+    with pytest.raises(FileNotFoundError) as excinfo:
+        uproot4.lazy(filename)
+    assert filename in str(excinfo.value)

--- a/uproot4/behaviors/TBranch.py
+++ b/uproot4/behaviors/TBranch.py
@@ -2830,7 +2830,7 @@ def _regularize_files(files):
             out.append((file_path, object_path))
 
     if len(out) == 0:
-        uproot4._util._file_not_found(files)
+        raise uproot4._util._file_not_found(files)
 
     return out
 


### PR DESCRIPTION
The exception from `uproot4._util._file_not_found` was simply not raised.