### PR TITLE
Fix multipart HTTP reading

### DIFF
--- a/tests/test_0088-read-with-http.py
+++ b/tests/test_0088-read-with-http.py
@@ -1,0 +1,18 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+import pytest
+
+import uproot4
+
+
+@pytest.mark.network
+def test_issue176():
+    with uproot4.open('https://starterkit.web.cern.ch/starterkit/data/advanced-python-2019/dalitzdata.root') as f:
+        data = f['tree'].arrays()
+        assert len(data.M2AB) == 100000
+        assert len(data.M2AC) == 100000
+        assert len(data.Y1) == 100000
+        assert len(data.Y2) == 100000
+        assert len(data.Y3) == 100000

--- a/tests/test_0088-read-with-http.py
+++ b/tests/test_0088-read-with-http.py
@@ -16,3 +16,11 @@ def test_issue176():
         assert len(data.Y1) == 100000
         assert len(data.Y2) == 100000
         assert len(data.Y3) == 100000
+
+
+@pytest.mark.network
+@pytest.mark.xfail
+def test_issue121():
+    with uproot4.open("https://github.com/CoffeaTeam/coffea/raw/master/tests/samples/nano_dy.root") as f:
+        data = f['Runs'].arrays()
+        assert len(data) == 1

--- a/tests/test_0088-read-with-http.py
+++ b/tests/test_0088-read-with-http.py
@@ -9,8 +9,10 @@ import uproot4
 
 @pytest.mark.network
 def test_issue176():
-    with uproot4.open('https://starterkit.web.cern.ch/starterkit/data/advanced-python-2019/dalitzdata.root') as f:
-        data = f['tree'].arrays()
+    with uproot4.open(
+        "https://starterkit.web.cern.ch/starterkit/data/advanced-python-2019/dalitzdata.root"
+    ) as f:
+        data = f["tree"].arrays()
         assert len(data.M2AB) == 100000
         assert len(data.M2AC) == 100000
         assert len(data.Y1) == 100000
@@ -21,6 +23,8 @@ def test_issue176():
 @pytest.mark.network
 @pytest.mark.xfail
 def test_issue121():
-    with uproot4.open("https://github.com/CoffeaTeam/coffea/raw/master/tests/samples/nano_dy.root") as f:
-        data = f['Runs'].arrays()
+    with uproot4.open(
+        "https://github.com/CoffeaTeam/coffea/raw/master/tests/samples/nano_dy.root"
+    ) as f:
+        data = f["Runs"].arrays()
         assert len(data) == 1

--- a/uproot4/source/http.py
+++ b/uproot4/source/http.py
@@ -284,8 +284,12 @@ for URL {0}""".format(
 
         return uproot4.source.futures.ResourceFuture(task)
 
-    _content_type = re.compile(r"^multipart/byteranges; boundary=([^;=]+)$", re.IGNORECASE)
-    _content_range_size = re.compile(b"Content-Range: bytes ([0-9]+-[0-9]+)/([0-9]+)", re.IGNORECASE)
+    _content_type = re.compile(
+        r"^multipart/byteranges; boundary=([^;=]+)$", re.IGNORECASE
+    )
+    _content_range_size = re.compile(
+        b"Content-Range: bytes ([0-9]+-[0-9]+)/([0-9]+)", re.IGNORECASE
+    )
     _content_range = re.compile(b"Content-Range: bytes ([0-9]+-[0-9]+)", re.IGNORECASE)
 
     def is_multipart_supported(self, ranges, response):
@@ -333,7 +337,9 @@ for URL {0}""".format(
             multipart_boundary = None
 
         for i in uproot4._util.range(len(futures)):
-            range_string, size, multipart_boundary = self.next_header(response, multipart_boundary)
+            range_string, size, multipart_boundary = self.next_header(
+                response, multipart_boundary
+            )
             if range_string is None:
                 raise OSError(
                     """found {0} of {1} expected headers in HTTP multipart
@@ -388,12 +394,13 @@ for URL {3}""".format(
                 elif len(line.strip()) == 0:
                     continue
                 elif line.startswith(b"--"):
-                    multipart_boundary = line[len(b"--"):].strip().decode()
+                    multipart_boundary = line[len(b"--") :].strip().decode()
                     break
 
                 raise NotImplementedError(
-                    "Failed to parse Content-Type header {}"
-                    .format(response.getheader("Content-Type"))
+                    "Failed to parse Content-Type header {}".format(
+                        response.getheader("Content-Type")
+                    )
                 )
         else:
             line = response.fp.readline()


### PR DESCRIPTION
Fixes #176 with dd75037.

I started looking at #121 but it becomes messy with the current architecture. I think the fundamental problem is that `uproot4/source/http.py` uses too low level an interface (`http.client`). The [Python docs also suggest this](https://docs.python.org/3/library/http.client.html):

> It is normally not used directly — the module `urllib.request` uses it to handle URLs that use HTTP and HTTPS.
> **See also:** The Requests package is recommended for a higher-level HTTP client interface. 

For now I've left an expected-to-fail test for #121 (2fce1d1) and slightly improved HTTP error code handling to make failures easier to understand (be91e45) but I can rebase these out if you'd rather not have these changes.