### PR TITLE
fix: warning about GHA security

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: "actions/checkout@v2"
 
       - name: "Get conda"
-        uses: "conda-incubator/setup-miniconda@v1"
+        uses: "conda-incubator/setup-miniconda@v2"
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
We can instead use dependabot.yml to keep actions up via PRs every day or week when new changes are detected. In that case, we'd use v2.0.0 here.

This was released about 30 minutes ago, see https://github.com/conda-incubator/setup-miniconda/issues/84