### PR TITLE
Fix warnings associated with NumPy deprecations.

### DIFF
--- a/uproot/_util.py
+++ b/uproot/_util.py
@@ -47,7 +47,7 @@ def isint(x):
     including bool).
     """
     return isinstance(x, (int, numbers.Integral, numpy.integer)) and not isinstance(
-        x, (numpy.bool, numpy.bool_)
+        x, (bool, numpy.bool_)
     )
 
 
@@ -57,7 +57,7 @@ def isnum(x):
     including bool).
     """
     return isinstance(x, (int, float, numbers.Real, numpy.number)) and not isinstance(
-        x, (numpy.bool, numpy.bool_)
+        x, (bool, numpy.bool_)
     )
 
 
@@ -390,7 +390,7 @@ def awkward_form(
         model = model.newbyteorder("=")
 
         if model not in _primitive_awkward_form:
-            if model == numpy.dtype(numpy.bool_) or model == numpy.dtype(numpy.bool):
+            if model == numpy.dtype(numpy.bool_) or model == numpy.dtype(bool):
                 _primitive_awkward_form[model] = awkward.forms.Form.fromjson('"bool"')
             elif model == numpy.dtype(numpy.int8):
                 _primitive_awkward_form[model] = awkward.forms.Form.fromjson('"int8"')

--- a/uproot/containers.py
+++ b/uproot/containers.py
@@ -32,7 +32,7 @@ import uproot
 
 
 _stl_container_size = struct.Struct(">I")
-_stl_object_type = numpy.dtype(numpy.object)
+_stl_object_type = numpy.dtype(object)
 
 
 def _content_typename(content):
@@ -695,7 +695,7 @@ in file {1}""".format(
                         context,
                         file.file_path,
                     )
-                return numpy.array(out, dtype=numpy.dtype(numpy.object))
+                return numpy.array(out, dtype=numpy.dtype(object))
 
         else:
             if self._speedbump:
@@ -713,7 +713,7 @@ in file {1}""".format(
                             chunk, cursor, context, file, selffile, parent
                         )
                     )
-                return numpy.array(out, dtype=numpy.dtype(numpy.object))
+                return numpy.array(out, dtype=numpy.dtype(object))
 
 
 class AsVector(AsContainer):

--- a/uproot/interpretation/jagged.py
+++ b/uproot/interpretation/jagged.py
@@ -103,7 +103,7 @@ class AsJagged(uproot.interpretation.Interpretation):
 
     @property
     def numpy_dtype(self):
-        return numpy.dtype(numpy.object)
+        return numpy.dtype(object)
 
     def awkward_form(
         self,

--- a/uproot/interpretation/library.py
+++ b/uproot/interpretation/library.py
@@ -205,9 +205,9 @@ class NumPy(Library):
         if isinstance(array, uproot.interpretation.jagged.JaggedArray) and isinstance(
             array.content, uproot.interpretation.objects.StridedObjectArray,
         ):
-            out = numpy.zeros(len(array), dtype=numpy.object)
+            out = numpy.zeros(len(array), dtype=object)
             for i, x in enumerate(array):
-                out[i] = numpy.zeros(len(x), dtype=numpy.object)
+                out[i] = numpy.zeros(len(x), dtype=object)
                 for j, y in enumerate(x):
                     out[i][j] = y
             return out
@@ -221,7 +221,7 @@ class NumPy(Library):
                 uproot.interpretation.objects.StridedObjectArray,
             ),
         ):
-            out = numpy.zeros(len(array), dtype=numpy.object)
+            out = numpy.zeros(len(array), dtype=object)
             for i, x in enumerate(array):
                 out[i] = x
             return out
@@ -849,7 +849,7 @@ class Pandas(Library):
                 uproot.interpretation.objects.ObjectArray,
             ),
         ):
-            out = numpy.zeros(len(array), dtype=numpy.object)
+            out = numpy.zeros(len(array), dtype=object)
             for i, x in enumerate(array):
                 out[i] = x
             index = _pandas_basic_index(pandas, entry_start, entry_stop)

--- a/uproot/interpretation/objects.py
+++ b/uproot/interpretation/objects.py
@@ -91,7 +91,7 @@ class AsObjects(uproot.interpretation.Interpretation):
 
     @property
     def numpy_dtype(self):
-        return numpy.dtype(numpy.object)
+        return numpy.dtype(object)
 
     @property
     def cache_key(self):
@@ -419,7 +419,7 @@ class AsStridedObjects(uproot.interpretation.numerical.AsDtype):
 
     @property
     def numpy_dtype(self):
-        return numpy.dtype(numpy.object)
+        return numpy.dtype(object)
 
     def awkward_form(
         self,
@@ -572,7 +572,7 @@ class ObjectArray(object):
         """
         Convert this ObjectArray into a NumPy ``dtype="O"`` (object) array.
         """
-        output = numpy.empty(len(self), dtype=numpy.dtype(numpy.object))
+        output = numpy.empty(len(self), dtype=numpy.dtype(object))
         for i in range(len(self)):
             output[i] = self[i]
         return output

--- a/uproot/interpretation/strings.py
+++ b/uproot/interpretation/strings.py
@@ -119,7 +119,7 @@ class AsStrings(uproot.interpretation.Interpretation):
 
     @property
     def numpy_dtype(self):
-        return numpy.dtype(numpy.object)
+        return numpy.dtype(object)
 
     def awkward_form(
         self,

--- a/uproot/streamers.py
+++ b/uproot/streamers.py
@@ -974,7 +974,7 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
             uproot.const.kULong,
             uproot.const.kLong,
         ):
-            self._bases[0]._members["fSize"] = numpy.dtype(numpy.long).itemsize
+            self._bases[0]._members["fSize"] = numpy.dtype(numpy.compat.long).itemsize
 
         elif self._bases[0]._members["fType"] in (
             uproot.const.kULong64,


### PR DESCRIPTION
I'm playing with cutting edge NumPy and I got some warnings in unit tests from deprecations triggered in uproot. [NumPy v1.20 deprecates](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) using `numpy.builtin` over `builtin` (e.g. `numpy.object` instead of `object`). The one change in this PR that I'm not sure about is `numpy.long --> numpy.compat.long`. This is necessary if uproot4 is supporting Python 2, but if Python 3 is required the change can be `numpy.long --> int`.