### PR TITLE
Hide ReferenceError in XRootD atexit.

### DIFF
--- a/uproot/extras.py
+++ b/uproot/extras.py
@@ -110,8 +110,13 @@ def XRootD_client():
         import gc
 
         for obj in gc.get_objects():
-            if isinstance(obj, XRootD.client.file.File) and obj.is_open():
-                obj.close()
+            try:
+                isopen = isinstance(obj, XRootD.client.file.File) and obj.is_open()
+            except ReferenceError:
+                pass
+            else:
+                if isopen:
+                    obj.close()
 
     return XRootD.client
 


### PR DESCRIPTION
From @ryuwd on https://gitter.im/Scikit-HEP/uproot:

> I am using `uproot4.iterate` to read files over xrootd - I am currently seeing this error at exit after the script has completed all its tasks:
> 
> ```
>     ERROR    | Error in atexit._run_exitfuncs:
>     ERROR    | Traceback (most recent call last):
>     ERROR    |   File "/XicpStToXicpPiPi/.snakemake/conda/3c5bbdd0/lib/python3.8/site-packages/uproot4/extras.py", line 112, in cleanup_open_files
>     ERROR    | if isinstance(obj, XRootD.client.file.File) and obj.is_open():
>     ERROR    | ReferenceError
>     ERROR    | :
>     ERROR    | weakly-referenced object no longer exists
>     ERROR    | Error in atexit._run_exitfuncs:
> ```

My response:

> Uproot has one `atexit` handler, which runs when the script is done, and apparently XRootD has weak references that are no longer valid at that time. You're not forgetting to do something (requiring users to check off formalities is not "Pythonic"). However, there isn't much to do about this error except ignore it. This PR does that: scikit-hep/uproot4#237 Could you check to see if it fixes your error message? (I don't have anything that reproduces it.)

I should point out that this PR does a little more than just ignore the ReferenceError: it ignores it on a per-file basis, so that the exception in one file doesn't cause another file to not get closed. (The `try/except/else` is inside the `for` loop, not outside.)