### PR TITLE
feat: Add TGraphAsymmErrors

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,7 +23,7 @@ jobs:
             python-version: "3.7"
 
     runs-on: "${{ matrix.platform }}"
-    
+
     # Required for miniconda to activate conda
     defaults:
       run:
@@ -43,7 +43,7 @@ jobs:
         run: |
           conda env list
           conda info
-          conda install numpy pandas pytest flake8 lz4 python-xxhash
+          conda install numpy pandas pytest flake8 lz4 python-xxhash requests
           pip install scikit-hep-testdata
           conda list
 
@@ -59,7 +59,7 @@ jobs:
           conda env list
           conda install xrootd
           conda list
-          
+
       - name: "Pip install the package"
         run: pip install .
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,3 @@ pandas
 awkward>=1.0.0
 boost_histogram
 hist
-requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pandas
 awkward>=1.0.0
 boost_histogram
 hist
+requests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ flake8-print
 scikit-hep-testdata
 lz4
 xxhash
+requests

--- a/tests/test_0240-read_TGraphAsymmErrors.py
+++ b/tests/test_0240-read_TGraphAsymmErrors.py
@@ -14,7 +14,7 @@ def datafile(tmpdir_factory):
     tmp_file = tmpdir_factory.mktemp("data").join(
         "HEPData-ins1755298-v3-Expected_limit_1lbb.root"
     )
-    with open(str(tmp_file), "w+") as f:
+    with open(str(tmp_file), "wb") as f:
         f.write(response.content)
     yield str(tmp_file)
 

--- a/tests/test_0240-read_TGraphAsymmErrors.py
+++ b/tests/test_0240-read_TGraphAsymmErrors.py
@@ -1,0 +1,67 @@
+import pytest
+import requests
+import uproot
+import numpy as np
+
+
+@pytest.mark.network
+@pytest.fixture(scope="module")
+def data(tmp_path_factory):
+    response = requests.get(
+        "https://www.hepdata.net/download/table/ins1755298/Expected%20limit%201lbb/3/root"
+    )
+    response.raise_for_status()
+    tmp_file = (
+        tmp_path_factory.mktemp("data")
+        / "HEPData-ins1755298-v3-Expected_limit_1lbb.root"
+    )
+    tmp_file.write_bytes(response.content)
+    yield tmp_file
+
+
+@pytest.fixture
+def graph(data):
+    with uproot.open(data) as f:
+        yield f["Expected limit 1lbb/Graph1D_y1"]
+
+
+def test_interpretation(data, graph):
+    assert graph.classname == "TGraphAsymmErrors"
+    assert graph.behaviors[0] == uproot.behaviors.TGraphAsymmErrors.TGraphAsymmErrors
+
+    assert "fX" in graph.all_members.keys()
+    assert "fY" in graph.all_members.keys()
+    assert "fEXlow" in graph.all_members.keys()
+    assert "fEYlow" in graph.all_members.keys()
+    assert "fEXhigh" in graph.all_members.keys()
+    assert "fEYhigh" in graph.all_members.keys()
+
+
+@pytest.mark.parametrize("axis", [-2, -1, 0, 1, "x", "y"])
+def test_values_single(graph, axis):
+    values = graph.values(axis=axis)
+    assert isinstance(values, np.ndarray)
+    assert values.shape == (162,)
+
+
+@pytest.mark.parametrize("axis", [-2, -1, 0, 1, "x", "y"])
+@pytest.mark.parametrize("which", ["low", "high", "mean", "diff"])
+def test_errors_single(graph, axis, which):
+    errors = graph.errors(axis=axis, which=which)
+    assert isinstance(errors, np.ndarray)
+    assert errors.shape == (162,)
+
+
+@pytest.mark.parametrize("axis", ["both"])
+def test_values_double(graph, axis):
+    values = graph.values(axis=axis)
+    assert all(isinstance(arr, np.ndarray) for arr in values)
+    assert all(arr.shape == (162,) for arr in values)
+
+
+@pytest.mark.parametrize("axis", ["both"])
+@pytest.mark.parametrize("which", ["low", "high", "mean", "diff"])
+def test_errors_double(graph, axis, which):
+    errors = graph.errors(axis=axis, which=which)
+    assert all(isinstance(arr, np.ndarray) for arr in errors)
+    assert all(arr.shape == (162,) for arr in errors)

--- a/tests/test_0240-read_TGraphAsymmErrors.py
+++ b/tests/test_0240-read_TGraphAsymmErrors.py
@@ -6,26 +6,26 @@ import numpy as np
 
 @pytest.mark.network
 @pytest.fixture(scope="module")
-def data(tmp_path_factory):
+def datafile(tmpdir_factory):
     response = requests.get(
         "https://www.hepdata.net/download/table/ins1755298/Expected%20limit%201lbb/3/root"
     )
     response.raise_for_status()
-    tmp_file = (
-        tmp_path_factory.mktemp("data")
-        / "HEPData-ins1755298-v3-Expected_limit_1lbb.root"
+    tmp_file = tmpdir_factory.mktemp("data").join(
+        "HEPData-ins1755298-v3-Expected_limit_1lbb.root"
     )
-    tmp_file.write_bytes(response.content)
-    yield tmp_file
+    with open(str(tmp_file), "w+") as f:
+        f.write(response.content)
+    yield str(tmp_file)
 
 
 @pytest.fixture
-def graph(data):
-    with uproot.open(data) as f:
+def graph(datafile):
+    with uproot.open(datafile) as f:
         yield f["Expected limit 1lbb/Graph1D_y1"]
 
 
-def test_interpretation(data, graph):
+def test_interpretation(graph):
     assert graph.classname == "TGraphAsymmErrors"
     assert graph.behaviors[0] == uproot.behaviors.TGraphAsymmErrors.TGraphAsymmErrors
 

--- a/tests/test_0240-read_TGraphAsymmErrors.py
+++ b/tests/test_0240-read_TGraphAsymmErrors.py
@@ -1,7 +1,13 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import numpy
 import pytest
-import requests
+
 import uproot
-import numpy as np
+
+requests = pytest.importorskip("requests")
 
 
 @pytest.mark.network
@@ -40,7 +46,7 @@ def test_interpretation(graph):
 @pytest.mark.parametrize("axis", [-2, -1, 0, 1, "x", "y"])
 def test_values_single(graph, axis):
     values = graph.values(axis=axis)
-    assert isinstance(values, np.ndarray)
+    assert isinstance(values, numpy.ndarray)
     assert values.shape == (162,)
 
 
@@ -48,7 +54,7 @@ def test_values_single(graph, axis):
 @pytest.mark.parametrize("which", ["low", "high", "mean", "diff"])
 def test_errors_single(graph, axis, which):
     errors = graph.errors(axis=axis, which=which)
-    assert isinstance(errors, np.ndarray)
+    assert isinstance(errors, numpy.ndarray)
     assert errors.shape == (162,)
 
 
@@ -56,7 +62,7 @@ def test_errors_single(graph, axis, which):
 def test_values_double(graph, axis):
     values = graph.values(axis=axis)
     assert len(values) == 2
-    assert all(isinstance(arr, np.ndarray) for arr in values)
+    assert all(isinstance(arr, numpy.ndarray) for arr in values)
     assert all(arr.shape == (162,) for arr in values)
 
 
@@ -65,5 +71,5 @@ def test_values_double(graph, axis):
 def test_errors_double(graph, axis, which):
     errors = graph.errors(axis=axis, which=which)
     assert len(errors) == 2
-    assert all(isinstance(arr, np.ndarray) for arr in errors)
+    assert all(isinstance(arr, numpy.ndarray) for arr in errors)
     assert all(arr.shape == (162,) for arr in errors)

--- a/tests/test_0240-read_TGraphAsymmErrors.py
+++ b/tests/test_0240-read_TGraphAsymmErrors.py
@@ -55,6 +55,7 @@ def test_errors_single(graph, axis, which):
 @pytest.mark.parametrize("axis", ["both"])
 def test_values_double(graph, axis):
     values = graph.values(axis=axis)
+    assert len(values) == 2
     assert all(isinstance(arr, np.ndarray) for arr in values)
     assert all(arr.shape == (162,) for arr in values)
 
@@ -63,5 +64,6 @@ def test_values_double(graph, axis):
 @pytest.mark.parametrize("which", ["low", "high", "mean", "diff"])
 def test_errors_double(graph, axis, which):
     errors = graph.errors(axis=axis, which=which)
+    assert len(errors) == 2
     assert all(isinstance(arr, np.ndarray) for arr in errors)
     assert all(arr.shape == (162,) for arr in errors)

--- a/uproot/behaviors/TGraphAsymmErrors.py
+++ b/uproot/behaviors/TGraphAsymmErrors.py
@@ -8,9 +8,8 @@ from __future__ import absolute_import
 
 import numpy
 
-import uproot
-
 # dict_keys(['@fUniqueID', '@fBits', 'fName', 'fTitle', 'fLineColor', 'fLineStyle', 'fLineWidth', 'fFillColor', 'fFillStyle', 'fMarkerColor', 'fMarkerStyle', 'fMarkerSize', 'fNpoints', 'fX', 'fY', 'fFunctions', 'fHistogram', 'fMinimum', 'fMaximum', 'fEXlow', 'fEXhigh', 'fEYlow', 'fEYhigh'])
+
 
 class TGraphAsymmErrors(object):
     """
@@ -41,7 +40,9 @@ class TGraphAsymmErrors(object):
             _exhigh, _eyhigh = self.member("fEXhigh"), self.member("fEYhigh")
 
             _low = numpy.asarray([_exlow, _eylow], dtype=_exlow.dtype.newbyteorder("="))
-            _high = numpy.asarray([_exhigh, _eyhigh], dtype=_exhigh.dtype.newbyteorder("="))
+            _high = numpy.asarray(
+                [_exhigh, _eyhigh], dtype=_exhigh.dtype.newbyteorder("=")
+            )
             errors = (_low, _high)
             self._errors = errors
 

--- a/uproot/behaviors/TGraphAsymmErrors.py
+++ b/uproot/behaviors/TGraphAsymmErrors.py
@@ -8,12 +8,15 @@ from __future__ import absolute_import
 
 import numpy
 
-# dict_keys(['@fUniqueID', '@fBits', 'fName', 'fTitle', 'fLineColor', 'fLineStyle', 'fLineWidth', 'fFillColor', 'fFillStyle', 'fMarkerColor', 'fMarkerStyle', 'fMarkerSize', 'fNpoints', 'fX', 'fY', 'fFunctions', 'fHistogram', 'fMinimum', 'fMaximum', 'fEXlow', 'fEXhigh', 'fEYlow', 'fEYhigh'])
+# ['@fUniqueID', '@fBits', 'fName', 'fTitle', 'fLineColor', 'fLineStyle',
+#  'fLineWidth', 'fFillColor', 'fFillStyle', 'fMarkerColor', 'fMarkerStyle',
+#  'fMarkerSize', 'fNpoints', 'fX', 'fY', 'fFunctions', 'fHistogram',
+#  'fMinimum', 'fMaximum', 'fEXlow', 'fEXhigh', 'fEYlow', 'fEYhigh']
 
 
 class TGraphAsymmErrors(object):
     """
-    Behaviors for TGraphAsymmErrors, not including ``TGraph``
+    Behaviors for TGraphAsymmErrors: get values and errors as NumPy arrays.
     """
 
     def _normalize_array(self, key):

--- a/uproot/behaviors/TGraphAsymmErrors.py
+++ b/uproot/behaviors/TGraphAsymmErrors.py
@@ -1,0 +1,48 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+"""
+This module defines the behaviors of ``TGraphAsymmErrors``, not including ``TGraph``.
+"""
+
+from __future__ import absolute_import
+
+import numpy
+
+import uproot
+
+# dict_keys(['@fUniqueID', '@fBits', 'fName', 'fTitle', 'fLineColor', 'fLineStyle', 'fLineWidth', 'fFillColor', 'fFillStyle', 'fMarkerColor', 'fMarkerStyle', 'fMarkerSize', 'fNpoints', 'fX', 'fY', 'fFunctions', 'fHistogram', 'fMinimum', 'fMaximum', 'fEXlow', 'fEXhigh', 'fEYlow', 'fEYhigh'])
+
+class TGraphAsymmErrors(object):
+    """
+    Behaviors for TGraphAsymmErrors, not including ``TGraph``
+    """
+
+    def values(self):
+        """
+        array[X, Y]
+        """
+        if hasattr(self, "_values"):
+            values = self._values
+        else:
+            _x, _y = self.member("fX"), self.member("fY")
+            values = numpy.asarray([_x, _y], dtype=_x.dtype.newbyteorder("="))
+            self._values = values
+
+        return values
+
+    def errors(self):
+        """
+        ( array[XLow, YLow], array[XHigh, YHigh] )
+        """
+        if hasattr(self, "_errors"):
+            errors = self._errors
+        else:
+            _exlow, _eylow = self.member("fEXlow"), self.member("fEYlow")
+            _exhigh, _eyhigh = self.member("fEXhigh"), self.member("fEYhigh")
+
+            _low = numpy.asarray([_exlow, _eylow], dtype=_exlow.dtype.newbyteorder("="))
+            _high = numpy.asarray([_exhigh, _eyhigh], dtype=_exhigh.dtype.newbyteorder("="))
+            errors = (_low, _high)
+            self._errors = errors
+
+        return errors

--- a/uproot/behaviors/TGraphAsymmErrors.py
+++ b/uproot/behaviors/TGraphAsymmErrors.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
 """
-This module defines the behaviors of ``TGraphAsymmErrors``, not including ``TGraph``.
+This module defines the behaviors of ``TGraphAsymmErrors``.
 """
 
 from __future__ import absolute_import
@@ -36,6 +36,16 @@ class TGraphAsymmErrors(object):
             return self._normalize_array(highkey) - self._normalize_array(lowkey)
 
     def values(self, axis="both"):
+        """
+        Args:
+            axis (int or str): If ``0``, ``-2``, or ``"x"``, get the *x* axis.
+                If ``1``, ``-1``, or ``"y"``, get the *y* axis. If ``"both"``,
+                get ``"x"`` and ``"y"`` axes as a 2-tuple.
+
+        Returns the values of all points in the scatter plot, either as a
+        1-dimensional NumPy array (if ``axis`` selects only one) or as a 2-tuple
+        (if ``axis="both"``).
+        """
         if axis in [0, -2, "x"]:
             return self._normalize_array("fX")
         elif axis in [1, -1, "y"]:
@@ -44,10 +54,24 @@ class TGraphAsymmErrors(object):
             return (self.values("x"), self.values("y"))
         else:
             raise ValueError(
-                "axis must be 0 (-2), 1 (-1) or 'x', 'y' or 'both' for a TGraphAsymmErrors"
+                "axis must be 0 (-2, 'x'), 1 (-1, 'y'), or 'both' for a TGraphAsymmErrors"
             )
 
     def errors(self, which, axis="both"):
+        """
+        Args:
+            which (str): If ``"low"`` or ``"high"``, get the low-side or
+                high-side error. If ``"mean"``, get the average. If ``"diff"``,
+                get their difference.
+            axis (int or str): If ``0``, ``-2``, or ``"x"``, get the *x* axis.
+                If ``1``, ``-1``, or ``"y"``, get the *y* axis. If ``"both"``,
+                get ``"x"`` and ``"y"`` axes as a 2-tuple.
+
+        Returns the errors in all points in the scatter plot, either as a
+        1-dimensional NumPy array (if ``axis`` selects only one) or as a 2-tuple
+        (if ``axis="both"``). The value of ``which`` does not affect the return
+        type.
+        """
         if which not in ["low", "high", "mean", "diff"]:
             raise ValueError(
                 "which must be 'low', 'high', 'mean', or 'diff' for a TGraphAsymmErrors"
@@ -61,5 +85,5 @@ class TGraphAsymmErrors(object):
             return (self.errors(which, "x"), self.errors(which, "y"))
         else:
             raise ValueError(
-                "axis must be 0 (-2), 1 (-1) or 'x', 'y' or 'both' for a TGraphAsymmErrors"
+                "axis must be 0 (-2, 'x'), 1 (-1, 'y'), or 'both' for a TGraphAsymmErrors"
             )


### PR DESCRIPTION
here's a test script to work with

```python
import uproot
import os.path

fname = "HEPData-ins1755298-v3-Expected_limit_1lbb.root"

if not os.path.isfile(fname):
    with open(fname, 'wb') as f:
        import requests
        response = requests.get("https://www.hepdata.net/download/table/ins1755298/Expected%20limit%201lbb/3/root")
        response.raise_for_status()
        f.write(response.content)

f = uproot.open(fname)
graph = f['Expected limit 1lbb/Graph1D_y1']
graph.values()
graph.errors()
```