### PR TITLE
Split vector reads into smaller chunk when single requests are larger than `max_element_size`

### DIFF
--- a/tests/test_0001-source-class.py
+++ b/tests/test_0001-source-class.py
@@ -313,6 +313,21 @@ def test_xrootd_vectorread():
 
 @pytest.mark.network
 @pytest.mark.xrootd
+def test_xrootd_vectorread_max_element_split():
+    pytest.importorskip("XRootD")
+    with uproot.source.xrootd.XRootDSource(
+        "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
+        timeout=10,
+        max_num_elements=None,
+    ) as source:
+        notifications = queue.Queue()
+        max_element_size = 2097136
+        chunks = source.chunks([(0, max_element_size + 1)], notifications)
+        assert len(tobytes(chunks[0].raw_data)) == max_element_size + 1
+
+
+@pytest.mark.network
+@pytest.mark.xrootd
 def test_xrootd_vectorread_fail():
     pytest.importorskip("XRootD")
     with pytest.raises(Exception) as err:

--- a/tests/test_0001-source-class.py
+++ b/tests/test_0001-source-class.py
@@ -323,7 +323,8 @@ def test_xrootd_vectorread_max_element_split():
         notifications = queue.Queue()
         max_element_size = 2097136
         chunks = source.chunks([(0, max_element_size + 1)], notifications)
-        assert len(tobytes(chunks[0].raw_data)) == max_element_size + 1
+        one, = [tobytes(chunk.raw_data) for chunk in chunks]
+        assert len(one) == max_element_size + 1
 
 
 @pytest.mark.network

--- a/tests/test_0001-source-class.py
+++ b/tests/test_0001-source-class.py
@@ -301,6 +301,7 @@ def test_xrootd_vectorread():
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         timeout=10,
         max_num_elements=None,
+        num_workers=1
     ) as source:
         notifications = queue.Queue()
         chunks = source.chunks([(0, 100), (50, 55), (200, 400)], notifications)
@@ -319,6 +320,7 @@ def test_xrootd_vectorread_max_element_split():
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         timeout=10,
         max_num_elements=None,
+        num_workers=1
     ) as source:
         notifications = queue.Queue()
         max_element_size = 2097136
@@ -344,7 +346,8 @@ def test_xrootd_vectorread_max_element_split_consistency():
     chunk1 = get_chunk(
         uproot.source.xrootd.XRootDSource,
         timeout=10,
-        max_num_elements=None
+        max_num_elements=None,
+        num_workers=1
     )
     chunk2 = get_chunk(
         uproot.source.xrootd.MultithreadedXRootDSource,
@@ -361,7 +364,7 @@ def test_xrootd_vectorread_fail():
     pytest.importorskip("XRootD")
     with pytest.raises(Exception) as err:
         source = uproot.source.xrootd.XRootDSource(
-            "root://wonky.cern/does-not-exist", timeout=1, max_num_elements=None
+            "root://wonky.cern/does-not-exist", timeout=1, max_num_elements=None, num_workers=1
         )
 
 
@@ -373,6 +376,7 @@ def test_xrootd_size():
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         timeout=10,
         max_num_elements=None,
+        num_workers=1
     ) as source:
         size1 = source.num_bytes
 

--- a/tests/test_0006-notify-when-downloaded.py
+++ b/tests/test_0006-notify-when-downloaded.py
@@ -197,6 +197,7 @@ def test_xrootd_vectorread():
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         timeout=10,
         max_num_elements=None,
+        num_workers=1,
     ) as source:
         chunks = source.chunks(
             [(0, 100), (50, 55), (200, 400)], notifications=notifications

--- a/tests/test_0007-single-chunk-interface.py
+++ b/tests/test_0007-single-chunk-interface.py
@@ -154,6 +154,7 @@ def test_xrootd_vectorread():
         "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
         timeout=10,
         max_num_elements=None,
+        num_workers=1,
     ) as source:
         one = tobytes(source.chunk(0, 100).raw_data)
         assert len(one) == 100

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -304,7 +304,6 @@ class XRootDSource(uproot.source.chunk.Source):
                         sub_ranges[start, stop]
                     )
                 if rem > 0:
-                    nsplit += 1
                     add_request_range(
                         start + nsplit * self._max_element_size,
                         rem,

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -193,7 +193,9 @@ in file {1}""".format(
     @staticmethod
     def mergefuture(partfutures):
         """
-        Wait for partfutures and merge them.
+        Returns a :doc:`uproot.source.futures.ResourceFuture` that merges the
+        chunks previously submitted via
+        :ref:`uproot.source.xrootd.XRootDResource.partfuture` which had to be split
         """
 
         def task(resource):

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -204,7 +204,6 @@ in file {1}""".format(
 
         return uproot.source.futures.ResourceFuture(task)
 
-
     @staticmethod
     def callbacker(futures, results):
         """


### PR DESCRIPTION
Since i also ran into #122 i would like to help fixing it. I believe better than falling back to non-vector reads in case a single request is larger than the maximum the server allows would be chunking the request into smaller parts as i think [ROOT does it](https://root.cern/doc/master/TNetXNGFile_8cxx_source.html#l00469). The relevant code is probably that part:

```cpp
       // If the length is bigger than max readv size, split into smaller chunks
       if (length[i] > fReadvIorMax) {
          Int_t nsplit = length[i] / fReadvIorMax;
          Int_t rem    = length[i] % fReadvIorMax;
          Int_t j;
  
          // Add as many max-size chunks as are divisible
          for (j = 0; j < nsplit; ++j) {
             offset = position[i] + (j * fReadvIorMax);
             chunks.push_back(ChunkInfo(offset, fReadvIorMax, cursor));
             cursor += fReadvIorMax;
          }
  
          // Add the remainder
          offset = position[i] + (j * fReadvIorMax);
          chunks.push_back(ChunkInfo(offset, rem, cursor));
          cursor += rem;
```

I tried to implement that into `XRootDResource`, but the problem is now that the returned chunks are expected to be the same ranges that were requested. So this would need an additional kind of "merging" step before returning the chunks.
But i don't really know how to do that best - at that stage the chunks are not necessarily "materialized" yet and might just contain futures - so either one would need to wait for the result and then merge them, creating a new chunk object with merged `raw_data` or modify the task that is submitted to not only fetch the chunks, but also merge them if nescessary ...

Any ideas what could be good ways to deal with this?