### PR TITLE
Prevent the xrootd server readv_iov_max limit from being exceeded

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,10 +11,8 @@ jobs:
     strategy:
       matrix:
         platform: ["windows-latest", "macos-latest", "ubuntu-latest"]
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
         exclude:
-          - platform: "macos-latest"
-            python-version: "3.5"
           - platform: "macos-latest"
             python-version: "3.6"
           - platform: "windows-latest"
@@ -54,7 +52,7 @@ jobs:
           conda list
 
       - name: "Install XRootD"
-        if: "matrix.python-version != 3.5 && runner.os != 'macOS'  &&  runner.os != 'Windows'"
+        if: "runner.os != 'macOS'  &&  runner.os != 'Windows'"
         run: |
           conda env list
           conda install xrootd

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/uproot.svg)](https://pypi.org/project/uproot)
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/uproot)](https://github.com/conda-forge/uproot-feedstock)
-[![Python 3.5‒3.9](https://img.shields.io/badge/python-3.5%E2%80%923.9-blue)](https://www.python.org)
+[![Python 3.6‒3.9](https://img.shields.io/badge/python-3.6%E2%80%923.9-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Continuous integration tests](https://img.shields.io/github/workflow/status/scikit-hep/uproot4/Test%20build/main?label=tests)](https://github.com/scikit-hep/uproot4/actions)
 

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -292,7 +292,7 @@ class XRootDSource(uproot.source.chunk.Source):
         sub_ranges = {}
 
         def add_request_range(start, length, sub_ranges_list):
-            if len(all_request_ranges[-1]) > self._max_num_elements:
+            if len(all_request_ranges[-1]) >= self._max_num_elements:
                 all_request_ranges.append([])
             all_request_ranges[-1].append((start, length))
             sub_ranges_list.append((start, start + length))


### PR DESCRIPTION
Fixes #253 

This change just prevents the length of any sublist in `all_request_ranges` from exceeding the `readv_iov_max` limit.