### PR TITLE
Cast start and length to int before passing to pyxrootd.client.File.read

### DIFF
--- a/tests/test_0001-source-class.py
+++ b/tests/test_0001-source-class.py
@@ -392,6 +392,20 @@ def test_xrootd_size():
     assert size1 == 3469136394
 
 
+@pytest.mark.network
+@pytest.mark.xrootd
+def test_xrootd_numpy_int():
+    pytest.importorskip("XRootD")
+    with uproot.source.xrootd.XRootDSource(
+        "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
+        timeout=10,
+        max_num_elements=None,
+        num_workers=1,
+    ) as source:
+        chunk = source.chunk(numpy.int64(0), numpy.int64(100))
+        assert len(chunk.raw_data) == 100
+
+
 def test_cursor_debug():
     data = numpy.concatenate(
         [

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -149,7 +149,11 @@ in file {1}""".format(
 
         Returns a Python buffer of data between ``start`` and ``stop``.
         """
-        status, data = self._file.read(start, stop - start, timeout=self._xrd_timeout())
+        status, data = self._file.read(
+            int(start),
+            int(stop - start),
+            timeout=self._xrd_timeout()
+        )
         if status.error:
             self._xrd_error(status)
         return data


### PR DESCRIPTION
When requesting a single chunk with `uproot.source.xrootd.XRootDSource` the arguments have to be eventually casted to (python) int before giving them to `pyxrootd.client.File.read`, otherwise it will throw an exception. This happenend when requesting data via `uproot.TBranch.basket` because that passes the parameters through as `np.int64` (coming from `branch.member("fBasketSeek")`:

```pycon
>>> import uproot
>>> branch = uproot.open("root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root:Events/Muon_pt")
>>> branch.basket(0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/nikolai/python/uproot4/uproot/behaviors/TBranch.py", line 2484, in basket
    chunk, cursor = self.basket_chunk_cursor(basket_num)
  File "/home/nikolai/python/uproot4/uproot/behaviors/TBranch.py", line 2508, in basket_chunk_cursor
    chunk = self._file.source.chunk(start, stop)
  File "/home/nikolai/python/uproot4/uproot/source/xrootd.py", line 277, in chunk
    data = self._resource.get(start, stop)
  File "/home/nikolai/python/uproot4/uproot/source/xrootd.py", line 152, in get
    status, data = self._file.read(start, stop - start, timeout=self._xrd_timeout())
  File "/home/nikolai/.conda/envs/physlite-experiments/lib/python3.8/site-packages/XRootD/client/file.py", line 126, in read
    status, response = self.__file.read(offset, size, timeout)
TypeError: integer argument expected for offset
```

This should be fixed by this MR. I added a test that directly tries to pass `np.int64` to `uproot.source.xrootd.XRootDSource.chunk`.