### PR TITLE
Update basic.rst with conditional cut example

### DIFF
--- a/docs-sphinx/basic.rst
+++ b/docs-sphinx/basic.rst
@@ -480,6 +480,14 @@ The second argument is a ``cut``, or filter on entries. Whereas the uncut array 
     >>> events.arrays(["M"], "pt1 > 50", aliases={"pt1": "sqrt(px1**2 + py1**2)"})
     <Array [{M: 91.8}, {M: 91.9, ... {M: 96.1}] type='290 * {"M": float64}'>
 
+or with additional cut conditions expressed using parentheses, the cut array (below) has 269 entries.
+
+.. code-block:: python
+
+    >>> events.arrays(["M"], "(pt1 > 50) & ((E1>100) | (E1<90))", aliases={"pt1": "sqrt(px1**2 + py1**2)"})
+    <Array [{M: 91.8}, {M: 91.9, ... {M: 96.1}] type='269 * {"M": float64}'>
+
+
 Note that expressions are *not*, in general, computed more quickly if expressed in these strings. The above is equivalent to the following:
 
 .. code-block:: python


### PR DESCRIPTION
Update the basic.rst documentation, in the section "Computing expressions and cuts",
with an example of the conditional cut using the python syntax and explicitly with the
parentheses. Without the parentheses a TypeError will occur, and it is not necessarily
obvious when coming from ROOT and C++ syntax.