### PR TITLE
Skip some tests because HEPData isn't producing the source file anymore.

### DIFF
--- a/tests/test_0240-read_TGraphAsymmErrors.py
+++ b/tests/test_0240-read_TGraphAsymmErrors.py
@@ -31,6 +31,7 @@ def graph(datafile):
         yield f["Expected limit 1lbb/Graph1D_y1"]
 
 
+@pytest.mark.skip(reason="HEPData can't supply this file: https://www.hepdata.net/download/table/ins1755298/Expected%20limit%201lbb/3/root")
 def test_interpretation(graph):
     assert graph.classname == "TGraphAsymmErrors"
     assert graph.behaviors[0] == uproot.behaviors.TGraphAsymmErrors.TGraphAsymmErrors
@@ -43,6 +44,7 @@ def test_interpretation(graph):
     assert "fEYhigh" in graph.all_members.keys()
 
 
+@pytest.mark.skip(reason="HEPData can't supply this file: https://www.hepdata.net/download/table/ins1755298/Expected%20limit%201lbb/3/root")
 @pytest.mark.parametrize("axis", [-2, -1, 0, 1, "x", "y"])
 def test_values_single(graph, axis):
     values = graph.values(axis=axis)
@@ -50,6 +52,7 @@ def test_values_single(graph, axis):
     assert values.shape == (162,)
 
 
+@pytest.mark.skip(reason="HEPData can't supply this file: https://www.hepdata.net/download/table/ins1755298/Expected%20limit%201lbb/3/root")
 @pytest.mark.parametrize("axis", [-2, -1, 0, 1, "x", "y"])
 @pytest.mark.parametrize("which", ["low", "high", "mean", "diff"])
 def test_errors_single(graph, axis, which):
@@ -58,6 +61,7 @@ def test_errors_single(graph, axis, which):
     assert errors.shape == (162,)
 
 
+@pytest.mark.skip(reason="HEPData can't supply this file: https://www.hepdata.net/download/table/ins1755298/Expected%20limit%201lbb/3/root")
 @pytest.mark.parametrize("axis", ["both"])
 def test_values_double(graph, axis):
     values = graph.values(axis=axis)
@@ -66,6 +70,7 @@ def test_values_double(graph, axis):
     assert all(arr.shape == (162,) for arr in values)
 
 
+@pytest.mark.skip(reason="HEPData can't supply this file: https://www.hepdata.net/download/table/ins1755298/Expected%20limit%201lbb/3/root")
 @pytest.mark.parametrize("axis", ["both"])
 @pytest.mark.parametrize("which", ["low", "high", "mean", "diff"])
 def test_errors_double(graph, axis, which):


### PR DESCRIPTION
The TGraphAsymmErrors tests all assume that a ROOT file can be supplied by

https://www.hepdata.net/download/table/ins1755298/Expected%20limit%201lbb/3/root

However, this URL now returns a page saying, "Converter error encountered." Perhaps the file has been deleted or moved? Could we instead put it in [scikit-hep/scikit-hep-testdata](https://github.com/scikit-hep/scikit-hep-testdata) like the others, @kratsg?

At the end of scikit-hep/uproot4#240, we were talking about the possibility of setting up something that delivers test files. This would be an instance in which relying on a third-party server is a problem, though putting everything into a GitHub repo (scikit-hep-testdata) is not a great solution, either, because of the PyPI file limits and the fact that these data are not really versioned.