### PR TITLE
Add specialized behaviors for TParameter, including generic dispatch for '<number>' templates.

### DIFF
--- a/tests/test_0278-specializations-for-TParameter.py
+++ b/tests/test_0278-specializations-for-TParameter.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+import numpy as np
+from numpy.testing import assert_array_equal
+import skhep_testdata
+import uproot
+
+
+def test():
+    with uproot.open(skhep_testdata.data_path("uproot-issue64.root")) as file:
+        p = file["events/nbevents"]
+        assert p.value == 500
+        assert p
+        assert int(p) == 500
+        assert float(p) == 500.0

--- a/uproot/__init__.py
+++ b/uproot/__init__.py
@@ -191,6 +191,13 @@ def behavior_of(classname):
     assert name.startswith("Model_")
     name = name[6:]
 
+    specialization = None
+    for param in behavior_of._specializations:
+        if name.endswith(param):
+            specialization = param
+            name = name[: -len(param)]
+            break
+
     if name not in globals():
         if name in behavior_of._module_names:
             exec(
@@ -204,12 +211,49 @@ def behavior_of(classname):
             if behavior_cls is not None:
                 globals()[name] = behavior_cls
 
-    return globals().get(name)
+    if specialization is None:
+        return globals().get(name)
+    else:
+        return globals().get(name)(specialization)
 
 
 behavior_of._module_names = [
     module_name
     for loader, module_name, is_pkg in pkgutil.walk_packages(uproot.behaviors.__path__)
+]
+
+behavior_of._specializations = [
+    "_3c_bool_3e_",
+    "_3c_char_3e_",
+    "_3c_unsigned_20_char_3e_",
+    "_3c_short_3e_",
+    "_3c_unsigned_20_short_3e_",
+    "_3c_int_3e_",
+    "_3c_unsigned_20_int_3e_",
+    "_3c_long_3e_",
+    "_3c_unsigned_20_long_3e_",
+    "_3c_long_20_long_3e_",
+    "_3c_unsigned_20_long_20_long_3e_",
+    "_3c_size_5f_t_3e_",
+    "_3c_ssize_5f_t_3e_",
+    "_3c_float_3e_",
+    "_3c_double_3e_",
+    "_3c_long_20_double_3e_",
+    "_3c_Bool_5f_t_3e_",
+    "_3c_Char_5f_t_3e_",
+    "_3c_UChar_5f_t_3e_",
+    "_3c_Short_5f_t_3e_",
+    "_3c_UShort_5f_t_3e_",
+    "_3c_Int_5f_t_3e_",
+    "_3c_UInt_5f_t_3e_",
+    "_3c_Long_5f_t_3e_",
+    "_3c_ULong_5f_t_3e_",
+    "_3c_Long64_5f_t_3e_",
+    "_3c_ULong64_5f_t_3e_",
+    "_3c_Size_5f_t_3e_",
+    "_3c_Float_5f_t_3e_",
+    "_3c_Double_5f_t_3e_",
+    "_3c_LongDouble_5f_t_3e_",
 ]
 
 del pkgutil

--- a/uproot/behaviors/TParameter.py
+++ b/uproot/behaviors/TParameter.py
@@ -1,0 +1,83 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+"""
+This module defines the behavior of ``TParameter<T>``.
+"""
+
+from __future__ import absolute_import
+
+
+class TParameter_3c_boolean_3e_(object):
+    """
+    Behaviors for ``TParameter<boolean>``.
+    """
+
+    @property
+    def value(self):
+        return bool(self.member("fVal"))
+
+    def __bool__(self):
+        return bool(self.member("fVal"))
+
+    def __int__(self):
+        return int(self.member("fVal"))
+
+    def __float__(self):
+        return float(self.member("fVal"))
+
+
+class TParameter_3c_integer_3e_(object):
+    """
+    Behaviors for ``TParameter<integer>``.
+    """
+
+    @property
+    def value(self):
+        return int(self.member("fVal"))
+
+    def __bool__(self):
+        return bool(self.member("fVal"))
+
+    def __int__(self):
+        return int(self.member("fVal"))
+
+    def __index__(self):
+        return int(self.member("fVal"))
+
+    def __float__(self):
+        return float(self.member("fVal"))
+
+
+class TParameter_3c_floating_3e_(object):
+    """
+    Behaviors for ``TParameter<floating>``.
+    """
+
+    @property
+    def value(self):
+        return float(self.member("fVal"))
+
+    def __bool__(self):
+        return bool(self.member("fVal"))
+
+    def __int__(self):
+        return int(self.member("fVal"))
+
+    def __float__(self):
+        return float(self.member("fVal"))
+
+
+def TParameter(specialization):
+    if specialization in ("_3c_bool_3e_", "_3c_Bool_5f_t_3e_"):
+        return TParameter_3c_boolean_3e_
+    elif specialization in (
+        "_3c_float_3e_",
+        "_3c_double_3e_",
+        "_3c_long_20_double_3e_",
+        "_3c_Float_5f_t_3e_",
+        "_3c_Double_5f_t_3e_",
+        "_3c_LongDouble_5f_t_3e_",
+    ):
+        return TParameter_3c_floating_3e_
+    else:
+        return TParameter_3c_integer_3e_


### PR DESCRIPTION
This was requested by @WenzDaniel on Gitter. It's good to have an example of a class with `<int>` in its name to introduce a way to generate behaviors for any numeric specialization (though I still need to move `behavior_of` out of `__init__.py`).