### PR TITLE
XRootD: raise an exception if read_vector failed

### DIFF
--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -211,8 +211,7 @@ in file {1}""".format(
 
         return uproot.source.futures.ResourceFuture(task)
 
-    @staticmethod
-    def callbacker(futures, results):
+    def callbacker(self, futures, results):
         """
         Returns an XRootD callback function to fill the ``futures`` and
         ``results``.
@@ -220,7 +219,7 @@ in file {1}""".format(
 
         def callback(status, response, hosts):
             if status.error:
-                raise OSError(status.message)
+                self._xrd_error(status)
 
             for chunk in response.chunks:
                 start, stop = chunk.offset, chunk.offset + chunk.length
@@ -337,7 +336,7 @@ class XRootDSource(uproot.source.chunk.Source):
                 futures[start, stop] = partfuture
                 global_futures[start, stop] = partfuture
 
-            callback = self.ResourceClass.callbacker(futures, results)
+            callback = self._resource.callbacker(futures, results)
 
             status = self._resource.file.vector_read(
                 chunks=request_ranges, callback=callback

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -221,7 +221,7 @@ in file {1}""".format(
         def callback(status, response, hosts):
             if status.error:
                 raise OSError(status.message)
-            
+
             for chunk in response.chunks:
                 start, stop = chunk.offset, chunk.offset + chunk.length
                 results[start, stop] = chunk.buffer

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -219,6 +219,9 @@ in file {1}""".format(
         """
 
         def callback(status, response, hosts):
+            if status.error:
+                raise OSError(status.message)
+            
             for chunk in response.chunks:
                 start, stop = chunk.offset, chunk.offset + chunk.length
                 results[start, stop] = chunk.buffer


### PR DESCRIPTION
In
https://github.com/scikit-hep/uproot4/blob/fc32791d3cb420ed95ded64ce544a6ca1484f481/uproot/source/xrootd.py#L221-L225

If the readv request fails, then a `NoneType` `response` can be returned to the `callback` function, which causes a cryptic traceback to be printed complaining that the `response` object has no `chunks` attribute.

This PR doesn't fix any underlying issue, but printing an error message from the xrootd server will show what is going wrong.