### PR TITLE
Remove more cycles and release heavy stuff early

### DIFF
--- a/tests/test_0017-multi-basket-multi-branch-fetch.py
+++ b/tests/test_0017-multi-basket-multi-branch-fetch.py
@@ -133,6 +133,7 @@ def test_ranges_or_baskets_to_arrays():
             interpretation_executor,
             library,
             arrays,
+            False,
         )
         assert arrays[branch.cache_key].tolist() == [
             -15,

--- a/uproot/behaviors/TBranch.py
+++ b/uproot/behaviors/TBranch.py
@@ -3458,13 +3458,11 @@ def _ranges_or_baskets_to_arrays(
         obj = notifications.get()
 
         if isinstance(obj, uproot.source.chunk.Chunk):
-            chunk = obj
-            args = range_args[(chunk.start, chunk.stop)]
-            decompression_executor.submit(chunk_to_basket, chunk, *args)
+            args = range_args[(obj.start, obj.stop)]
+            decompression_executor.submit(chunk_to_basket, obj, *args)
 
         elif isinstance(obj, uproot.models.TBasket.Model_TBasket):
-            basket = obj
-            interpretation_executor.submit(basket_to_array, basket)
+            interpretation_executor.submit(basket_to_array, obj)
 
         elif obj is None:
             pass
@@ -3474,6 +3472,8 @@ def _ranges_or_baskets_to_arrays(
 
         else:
             raise AssertionError(obj)
+
+        obj = None  # release before blocking
 
 
 def _fix_asgrouped(arrays, expression_context, branchid_interpretation, library, how):

--- a/uproot/behaviors/TBranch.py
+++ b/uproot/behaviors/TBranch.py
@@ -1128,6 +1128,7 @@ class HasBranches(Mapping):
             interpretation_executor,
             library,
             arrays,
+            False,
         )
 
         # no longer needed; save memory
@@ -1361,6 +1362,7 @@ class HasBranches(Mapping):
                     interpretation_executor,
                     library,
                     arrays,
+                    True,
                 )
 
                 _fix_asgrouped(
@@ -2083,6 +2085,7 @@ class TBranch(HasBranches):
             interpretation_executor,
             library,
             arrays,
+            False,
         )
 
         _fix_asgrouped(
@@ -3347,6 +3350,7 @@ def _ranges_or_baskets_to_arrays(
     interpretation_executor,
     library,
     arrays,
+    update_ranges_or_baskets,
 ):
     notifications = queue.Queue()
 
@@ -3401,7 +3405,8 @@ def _ranges_or_baskets_to_arrays(
                 branch,
             )
             original_index = range_original_index[(chunk.start, chunk.stop)]
-            replace(ranges_or_baskets, original_index, basket)
+            if update_ranges_or_baskets:
+                replace(ranges_or_baskets, original_index, basket)
         except Exception:
             notifications.put(sys.exc_info())
         else:
@@ -3436,6 +3441,8 @@ def _ranges_or_baskets_to_arrays(
                         branch.file.file_path,
                     )
                 )
+
+            basket = None
 
             if len(basket_arrays) == branchid_num_baskets[branch.cache_key]:
                 arrays[branch.cache_key] = interpretation.final_array(

--- a/uproot/model.py
+++ b/uproot/model.py
@@ -459,6 +459,8 @@ class Model(object):
         object (i.e. if this object is in the other's
         :ref:`uproot.model.Model.bases`).
         """
+        if self._concrete is None:
+            return self
         return self._concrete
 
     @property
@@ -746,10 +748,7 @@ class Model(object):
         self._cursor = cursor.copy()
         self._file = selffile
         self._parent = parent
-        if concrete is None:
-            self._concrete = self
-        else:
-            self._concrete = concrete
+        self._concrete = concrete
 
         self._members = {}
         self._bases = []

--- a/uproot/models/TBranch.py
+++ b/uproot/models/TBranch.py
@@ -43,7 +43,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -54,7 +54,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         (
@@ -71,20 +71,20 @@ in file {1}""".format(
             self._members["fZipBytes"],
         ) = cursor.fields(chunk, _tbranch10_format1, context)
         self._members["fBranches"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fLeaves"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._cursor_baskets = cursor.copy()
         if file.options["minimal_ttree_metadata"]:
             if not cursor.skip_over(chunk, context):
                 file.class_named("TObjArray").read(
-                    chunk, cursor, context, file, self._file, self._concrete
+                    chunk, cursor, context, file, self._file, self.concrete
                 )
         else:
             self._members["fBaskets"] = file.class_named("TObjArray").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
         tmp = _tbranch10_dtype1
         if context.get("speedbump", True):
@@ -109,7 +109,7 @@ in file {1}""".format(
             cursor.skip_after(self)
         else:
             self._members["fFileName"] = file.class_named("TString").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
 
     @property
@@ -171,7 +171,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -182,7 +182,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         (
@@ -200,20 +200,20 @@ in file {1}""".format(
             self._members["fZipBytes"],
         ) = cursor.fields(chunk, _tbranch11_format1, context)
         self._members["fBranches"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fLeaves"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._cursor_baskets = cursor.copy()
         if file.options["minimal_ttree_metadata"]:
             if not cursor.skip_over(chunk, context):
                 file.class_named("TObjArray").read(
-                    chunk, cursor, context, file, self._file, self._concrete
+                    chunk, cursor, context, file, self._file, self.concrete
                 )
         else:
             self._members["fBaskets"] = file.class_named("TObjArray").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
         tmp = _tbranch11_dtype1
         if context.get("speedbump", True):
@@ -238,7 +238,7 @@ in file {1}""".format(
             cursor.skip_after(self)
         else:
             self._members["fFileName"] = file.class_named("TString").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
 
     @property
@@ -301,7 +301,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -312,7 +312,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         (
@@ -330,20 +330,20 @@ in file {1}""".format(
             self._members["fZipBytes"],
         ) = cursor.fields(chunk, _tbranch12_format1, context)
         self._members["fBranches"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fLeaves"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._cursor_baskets = cursor.copy()
         if file.options["minimal_ttree_metadata"]:
             if not cursor.skip_over(chunk, context):
                 file.class_named("TObjArray").read(
-                    chunk, cursor, context, file, self._file, self._concrete
+                    chunk, cursor, context, file, self._file, self.concrete
                 )
         else:
             self._members["fBaskets"] = file.class_named("TObjArray").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
         tmp = _tbranch12_dtype1
         if context.get("speedbump", True):
@@ -368,7 +368,7 @@ in file {1}""".format(
             cursor.skip_after(self)
         else:
             self._members["fFileName"] = file.class_named("TString").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
 
     @property
@@ -432,7 +432,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -443,7 +443,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         (
@@ -454,7 +454,7 @@ in file {1}""".format(
             self._members["fEntryNumber"],
         ) = cursor.fields(chunk, _tbranch13_format1, context)
         self._members["fIOFeatures"] = file.class_named("ROOT::TIOFeatures").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         (
             self._members["fOffset"],
@@ -466,20 +466,20 @@ in file {1}""".format(
             self._members["fZipBytes"],
         ) = cursor.fields(chunk, _tbranch13_format2, context)
         self._members["fBranches"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fLeaves"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._cursor_baskets = cursor.copy()
         if file.options["minimal_ttree_metadata"]:
             if not cursor.skip_over(chunk, context):
                 file.class_named("TObjArray").read(
-                    chunk, cursor, context, file, self._file, self._concrete
+                    chunk, cursor, context, file, self._file, self.concrete
                 )
         else:
             self._members["fBaskets"] = file.class_named("TObjArray").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
         tmp = _tbranch13_dtype1
         if context.get("speedbump", True):
@@ -504,7 +504,7 @@ in file {1}""".format(
             cursor.skip_after(self)
         else:
             self._members["fFileName"] = file.class_named("TString").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
 
     @property
@@ -580,18 +580,18 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._cursor_baskets = self._bases[0]._cursor_baskets
         self._members["fClassName"] = file.class_named("TString").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fParentName"] = file.class_named("TString").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fClonesName"] = file.class_named("TString").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         (
             self._members["fCheckSum"],
@@ -602,10 +602,10 @@ in file {1}""".format(
             self._members["fMaximum"],
         ) = cursor.fields(chunk, _tbranchelement8_format1, context)
         self._members["fBranchCount"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fBranchCount2"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
 
     base_names_versions = [("TBranch", 10)]
@@ -652,18 +652,18 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._cursor_baskets = self._bases[0]._cursor_baskets
         self._members["fClassName"] = file.class_named("TString").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fParentName"] = file.class_named("TString").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fClonesName"] = file.class_named("TString").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         (
             self._members["fCheckSum"],
@@ -674,10 +674,10 @@ in file {1}""".format(
             self._members["fMaximum"],
         ) = cursor.fields(chunk, _tbranchelement9_format1, context)
         self._members["fBranchCount"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fBranchCount2"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
 
     base_names_versions = [("TBranch", 12)]
@@ -724,18 +724,18 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._cursor_baskets = self._bases[0]._cursor_baskets
         self._members["fClassName"] = file.class_named("TString").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fParentName"] = file.class_named("TString").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fClonesName"] = file.class_named("TString").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         (
             self._members["fCheckSum"],
@@ -746,10 +746,10 @@ in file {1}""".format(
             self._members["fMaximum"],
         ) = cursor.fields(chunk, _tbranchelement10_format1, context)
         self._members["fBranchCount"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fBranchCount2"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
 
     base_names_versions = [("TBranch", 12)]
@@ -805,11 +805,11 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fClassName"] = file.class_named("TString").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
 
     base_names_versions = [("TBranch", 13)]

--- a/uproot/models/THashList.py
+++ b/uproot/models/THashList.py
@@ -33,7 +33,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 

--- a/uproot/models/TLeaf.py
+++ b/uproot/models/TLeaf.py
@@ -35,7 +35,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         (
@@ -46,7 +46,7 @@ in file {1}""".format(
             self._members["fIsUnsigned"],
         ) = cursor.fields(chunk, _tleaf2_format0, context)
         self._members["fLeafCount"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
 
     base_names_versions = [("TNamed", 1)]
@@ -95,7 +95,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
@@ -141,7 +141,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
@@ -187,7 +187,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
@@ -233,7 +233,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
@@ -279,7 +279,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
@@ -325,7 +325,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
@@ -371,7 +371,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
@@ -417,7 +417,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fMinimum"], self._members["fMaximum"] = cursor.fields(
@@ -461,7 +461,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fMinimum"] = cursor.float16(chunk, 12, context)
@@ -503,7 +503,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fMinimum"] = cursor.double32(chunk, context)
@@ -548,7 +548,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fID"], self._members["fType"] = cursor.fields(

--- a/uproot/models/TList.py
+++ b/uproot/models/TList.py
@@ -41,7 +41,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 

--- a/uproot/models/TNamed.py
+++ b/uproot/models/TNamed.py
@@ -32,7 +32,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 

--- a/uproot/models/TObjArray.py
+++ b/uproot/models/TObjArray.py
@@ -42,7 +42,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 
@@ -107,7 +107,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 

--- a/uproot/models/TObjString.py
+++ b/uproot/models/TObjString.py
@@ -32,7 +32,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._data = cursor.string(chunk, context)

--- a/uproot/models/TTree.py
+++ b/uproot/models/TTree.py
@@ -41,7 +41,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -52,7 +52,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -63,7 +63,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -74,7 +74,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         (
@@ -93,35 +93,35 @@ in file {1}""".format(
             self._members["fEstimate"],
         ) = cursor.fields(chunk, _ttree16_format1, context)
         self._members["fBranches"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fLeaves"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fAliases"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
 
         if file.options["minimal_ttree_metadata"]:
             cursor.skip_after(self)
         else:
             self._members["fIndexValues"] = file.class_named("TArrayD").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fIndex"] = file.class_named("TArrayI").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fTreeIndex"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fFriends"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fUserInfo"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fBranchRef"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
 
     @property
@@ -191,7 +191,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -202,7 +202,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -213,7 +213,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -224,7 +224,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         (
@@ -244,34 +244,34 @@ in file {1}""".format(
             self._members["fEstimate"],
         ) = cursor.fields(chunk, _ttree17_format1, context)
         self._members["fBranches"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fLeaves"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fAliases"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         if file.options["minimal_ttree_metadata"]:
             cursor.skip_after(self)
         else:
             self._members["fIndexValues"] = file.class_named("TArrayD").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fIndex"] = file.class_named("TArrayI").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fTreeIndex"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fFriends"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fUserInfo"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fBranchRef"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
 
     @property
@@ -342,7 +342,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -353,7 +353,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -364,7 +364,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -375,7 +375,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         (
@@ -397,34 +397,34 @@ in file {1}""".format(
             self._members["fEstimate"],
         ) = cursor.fields(chunk, _ttree18_format1, context)
         self._members["fBranches"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fLeaves"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fAliases"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         if file.options["minimal_ttree_metadata"]:
             cursor.skip_after(self)
         else:
             self._members["fIndexValues"] = file.class_named("TArrayD").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fIndex"] = file.class_named("TArrayI").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fTreeIndex"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fFriends"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fUserInfo"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fBranchRef"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
 
     @property
@@ -499,7 +499,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -510,7 +510,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -521,7 +521,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -532,7 +532,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         (
@@ -567,34 +567,34 @@ in file {1}""".format(
             chunk, self.member("fNClusterRange"), tmp, context
         )
         self._members["fBranches"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fLeaves"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fAliases"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         if file.options["minimal_ttree_metadata"]:
             cursor.skip_after(self)
         else:
             self._members["fIndexValues"] = file.class_named("TArrayD").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fIndex"] = file.class_named("TArrayI").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fTreeIndex"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fFriends"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fUserInfo"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fBranchRef"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
 
     @property
@@ -672,7 +672,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -683,7 +683,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -694,7 +694,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases.append(
@@ -705,7 +705,7 @@ in file {1}""".format(
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         (
@@ -740,37 +740,37 @@ in file {1}""".format(
             chunk, self.member("fNClusterRange"), tmp, context
         )
         self._members["fIOFeatures"] = file.class_named("ROOT::TIOFeatures").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fBranches"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fLeaves"] = file.class_named("TObjArray").read(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         self._members["fAliases"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
         if file.options["minimal_ttree_metadata"]:
             cursor.skip_after(self)
         else:
             self._members["fIndexValues"] = file.class_named("TArrayD").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fIndex"] = file.class_named("TArrayI").read(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fTreeIndex"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fFriends"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fUserInfo"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
             self._members["fBranchRef"] = uproot.deserialization.read_object_any(
-                chunk, cursor, context, file, self._file, self._concrete
+                chunk, cursor, context, file, self._file, self.concrete
             )
 
     @property

--- a/uproot/streamers.py
+++ b/uproot/streamers.py
@@ -392,7 +392,7 @@ class Model_TStreamerInfo(uproot.model.Model):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._bases[0]._members["fName"] = _canonical_typename(
@@ -404,7 +404,7 @@ class Model_TStreamerInfo(uproot.model.Model):
         )
 
         self._members["fElements"] = uproot.deserialization.read_object_any(
-            chunk, cursor, context, file, self._file, self._concrete
+            chunk, cursor, context, file, self._file, self.concrete
         )
 
     def _dependencies(self, streamers, out):
@@ -498,7 +498,7 @@ class Model_TStreamerElement(uproot.model.Model):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 
@@ -558,7 +558,7 @@ class Model_TStreamerArtificial(Model_TStreamerElement):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 
@@ -654,7 +654,7 @@ class Model_TStreamerBase(Model_TStreamerElement):
     ):
         read_members.append(
             "        self._bases.append(c({0}, {1}).read(chunk, cursor, "
-            "context, file, self._file, self._parent, concrete=self._concrete))".format(
+            "context, file, self._file, self._parent, concrete=self.concrete))".format(
                 repr(self.name), repr(self.base_version)
             )
         )
@@ -682,7 +682,7 @@ class Model_TStreamerBase(Model_TStreamerElement):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         if self._instance_version >= 2:
@@ -789,7 +789,7 @@ class Model_TStreamerBasicPointer(Model_TStreamerElement):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fCountVersion"] = cursor.field(
@@ -937,7 +937,7 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         if (
@@ -1046,7 +1046,7 @@ class Model_TStreamerLoop(Model_TStreamerElement):
                     repr(self.count_name)
                 ),
                 "            self._members[{0}] = c({1}).read(chunk, cursor, "
-                "context, file, self._file, self._concrete)".format(
+                "context, file, self._file, self.concrete)".format(
                     repr(self.name), repr(self.typename.rstrip("*"))
                 ),
             ]
@@ -1086,7 +1086,7 @@ class Model_TStreamerLoop(Model_TStreamerElement):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fCountVersion"] = cursor.field(
@@ -1154,7 +1154,7 @@ class Model_TStreamerSTL(Model_TStreamerElement):
         )
         read_members.append(
             "        self._members[{0}] = self._stl_container{1}.read("
-            "chunk, cursor, context, file, self._file, self._concrete)"
+            "chunk, cursor, context, file, self._file, self.concrete)"
             "".format(repr(self.name), len(containers))
         )
 
@@ -1184,7 +1184,7 @@ class Model_TStreamerSTL(Model_TStreamerElement):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
         self._members["fSTLtype"], self._members["fCtype"] = cursor.fields(
@@ -1224,7 +1224,7 @@ class Model_TStreamerSTLstring(Model_TStreamerSTL):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 
@@ -1255,7 +1255,7 @@ class TStreamerPointerTypes(object):
         if self.fType == uproot.const.kObjectp or self.fType == uproot.const.kAnyp:
             read_members.append(
                 "        self._members[{0}] = c({1}).read(chunk, cursor, context, "
-                "file, self._file, self._concrete)".format(
+                "file, self._file, self.concrete)".format(
                     repr(self.name), repr(self.typename.rstrip("*"))
                 )
             )
@@ -1324,7 +1324,7 @@ class Model_TStreamerObjectAnyPointer(TStreamerPointerTypes, Model_TStreamerElem
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 
@@ -1347,7 +1347,7 @@ class Model_TStreamerObjectPointer(TStreamerPointerTypes, Model_TStreamerElement
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 
@@ -1378,7 +1378,7 @@ class TStreamerObjectTypes(object):
     ):
         read_members.append(
             "        self._members[{0}] = c({1}).read(chunk, cursor, context, "
-            "file, self._file, self._concrete)".format(
+            "file, self._file, self.concrete)".format(
                 repr(self.name), repr(self.typename.rstrip("*"))
             )
         )
@@ -1424,7 +1424,7 @@ class Model_TStreamerObject(TStreamerObjectTypes, Model_TStreamerElement):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 
@@ -1447,7 +1447,7 @@ class Model_TStreamerObjectAny(TStreamerObjectTypes, Model_TStreamerElement):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 
@@ -1470,7 +1470,7 @@ class Model_TStreamerString(TStreamerObjectTypes, Model_TStreamerElement):
                 file,
                 self._file,
                 self._parent,
-                concrete=self._concrete,
+                concrete=self.concrete,
             )
         )
 


### PR DESCRIPTION
Targeting specifically Chunk and TBasket objects, because they are some of the heaviest intermediate results.

Testing with the following:
```python
import uproot
import psutil
import time
import tqdm
import gc

def getmallinfo():
    import ctypes
    class MallInfo(ctypes.Structure):
        _fields_ = [(name, ctypes.c_int)
                    for name in ('arena', 'ordblks', 'smblks', 'hblks', 'hblkhd',
                                'usmblks', 'fsmblks', 'uordblks', 'fordblks',
                                'keepcost')]

    libc = ctypes.CDLL("libc.so.6")
    mallinfo = libc.mallinfo
    mallinfo.argtypes = []
    mallinfo.restype = MallInfo
    return mallinfo()


uproot.open.defaults["num_workers"] = 10

usage = []
def collect_usage(asize):
    otype = uproot.source.chunk.Chunk
    mallinfo = getmallinfo()
    usage.append({
        "dt": time.time() - tstart,
        "rss": process.memory_info().rss,
        "arraysize": asize,
        "ordblks": mallinfo.ordblks,
        "uordblks": mallinfo.uordblks,
        "fordblks": mallinfo.fordblks,
        "nobj": sum(isinstance(o, otype) for o in gc.get_objects()),
    })

process = psutil.Process()
tstart = time.time()
collect_usage(0)
fn = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root:Events"
with uproot.open(fn, object_cache=None, array_cache=None) as tree:
    steps = tree.common_entry_offsets()
    steps = [s for s in zip(steps[:-1], steps[1:]) if s[1] < (tree.num_entries // 10)]
    for start, stop in tqdm.tqdm(steps):
        nbytes = sum(
            branch.array(entry_start=start, entry_stop=stop).nbytes
            for branch in tree
        )
        collect_usage(nbytes)

collect_usage(0)
import pandas
usage = pandas.DataFrame(usage).set_index("dt")
```

Initially the TBasket cycles take a while to be garbage collected, so they pile up and even if gc cleans up, glibc malloc might decide to keep the arena block around (fordblocks = free ordinary blocks, I think):
![image](https://user-images.githubusercontent.com/6587412/110070409-899b4c80-7d3f-11eb-9dcc-a0fabbe5c758.png)


After refactoring `Model.concrete` we have overall lower and much less varied memory usage:
![image](https://user-images.githubusercontent.com/6587412/110070348-67093380-7d3f-11eb-856f-5c8c2841c9e4.png)


Lastly, try to make sure the TBaskets are released sooner (not a huge change)
![arrays_fixbasket_oneatatime_dropearly](https://user-images.githubusercontent.com/6587412/110070208-142f7c00-7d3f-11eb-9298-be7611df4fd5.png)
