### PR TITLE
feat: add bytecount mask as part of read_object_any

### DIFF
--- a/uproot/deserialization.py
+++ b/uproot/deserialization.py
@@ -239,6 +239,16 @@ def read_object_any(chunk, cursor, context, file, selffile, parent, as_class=Non
             return parent  # return parent
 
         elif tag not in cursor.refs:
+            # copied from numbytes_version
+            if bcnt & uproot.const.kByteCountMask:
+                # Note this extra 4 bytes: the num_bytes field doesn't count itself,
+                # but we count the Model.start_cursor position from the point just
+                # before these two fields (since num_bytes might not exist, it's a more
+                # stable point than after num_bytes).
+                #                                                 |
+                #                                                 V
+                bcnt = int(bcnt & ~uproot.const.kByteCountMask) + 4
+
             # jump past this object
             cursor.move_to(cursor.origin + beg + bcnt + 4)
             return None  # return null


### PR DESCRIPTION
Running into issues where `bcnt` is absurdly large and it might be due to missing behavior in the `uproot4` implementation of `read_object_any` compared to ROOT's: https://github.com/root-project/root/blob/c4aa801d24d0b1eeb6c1623fd18160ef2397ee54/io/io/src/TBufferFile.cxx#L2764-L2765

Specifically, I expect around 1080 bytes for this object serialized in a ROOT file, but `bcnt` is `1073742891`.

```
(Pdb) mycursor.fields(chunk, _numbytes_version_1, context, move=False)
(1073742891, 0)
(Pdb) num_bytes = numpy.int64(1073742891)
(Pdb) bool(num_bytes & uproot.const.kByteCountMask)
True
(Pdb) int(num_bytes & ~uproot.const.kByteCountMask) + 4
1071
```

so there's clearly perhaps missing behavior in masking it to get the proper bytecount out.