### PR TITLE
Allow all sources and caches to be pickled

### DIFF
--- a/tests/test_0302-pickle.py
+++ b/tests/test_0302-pickle.py
@@ -1,0 +1,67 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pickle
+import sys
+import os
+
+import pytest
+import skhep_testdata
+
+import uproot
+
+
+def test_pickle_roundtrip_mmap():
+    with uproot.open(skhep_testdata.data_path("uproot-small-dy-withoffsets.root")) as f:
+        pkl = pickle.dumps(f["tree"])
+
+    branch = pickle.loads(pkl)["Muon_pt"]
+    muonpt1 = branch.array(library="np", entry_start=10, entry_stop=20)
+    assert [x.tolist() for x in muonpt1] == [
+        [20.60145378112793],
+        [50.36957550048828, 41.21387481689453, 3.1869382858276367],
+        [51.685970306396484, 35.227813720703125],
+        [],
+        [],
+        [],
+        [],
+        [23.073759078979492],
+        [32.921417236328125, 8.922308921813965, 4.368383407592773],
+        [51.9132194519043, 31.930095672607422],
+    ]
+
+
+@pytest.mark.network
+def test_pickle_roundtrip_http():
+    with uproot.open("https://scikit-hep.org/uproot3/examples/Zmumu.root") as f:
+        pkl = pickle.dumps(f["events"])
+
+    tree = pickle.loads(pkl)
+    assert tree.num_entries == 2304
+    assert list(tree["M"].array(entry_stop=10)) == [
+        82.4626915551,
+        83.6262040052,
+        83.3084646667,
+        82.1493728809,
+        90.4691230355,
+        89.7576631707,
+        89.7739431721,
+        90.4855320463,
+        91.7737014813,
+        91.9488195857,
+    ]
+
+
+@pytest.mark.network
+@pytest.mark.xrootd
+def test_pickle_roundtrip_xrootd():
+    pytest.importorskip("XRootD")
+    with uproot.open(
+        "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root"
+    ) as f:
+        pkl = pickle.dumps(f["Events"])
+
+    tree = pickle.loads(pkl)
+    assert tree.num_entries == 29308627
+    assert set(tree["run"].array(entry_stop=10)) == {194778}

--- a/uproot/cache.py
+++ b/uproot/cache.py
@@ -57,6 +57,18 @@ class LRUCache(MutableMapping):
         self._data = {}
         self._lock = threading.Lock()
 
+    def __getstate__(self):
+        return {
+            "_limit": self._limit,
+        }
+
+    def __setstate__(self, state):
+        self._limit = state["_limit"]
+        self._current = 0
+        self._order = []
+        self._data = {}
+        self._lock = threading.Lock()
+
     def __repr__(self):
         if self._limit is None:
             limit = "(no limit)"

--- a/uproot/source/chunk.py
+++ b/uproot/source/chunk.py
@@ -322,6 +322,7 @@ for file path {2}""".format(
                         self._source.file_path,
                     )
                 )
+            self._future = None
 
     @property
     def raw_data(self):

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -242,30 +242,42 @@ class XRootDSource(uproot.source.chunk.Source):
     ResourceClass = XRootDResource
 
     def __init__(self, file_path, **options):
-        timeout = options["timeout"]
-        max_num_elements = options["max_num_elements"]
-        num_workers = options["num_workers"]
+        self._timeout = options["timeout"]
+        self._desired_max_num_elements = options["max_num_elements"]
+        self._num_workers = options["num_workers"]
         self._num_requests = 0
         self._num_requested_chunks = 0
         self._num_requested_bytes = 0
 
         self._file_path = file_path
-        self._timeout = timeout
         self._num_bytes = None
+        self._open()
 
-        self._resource = XRootDResource(file_path, timeout)
+    def _open(self):
+        self._resource = XRootDResource(self._file_path, self._timeout)
 
         # this ThreadPool does not need a resource, it's only used to submit
         # futures that wait for chunks that have been split to merge them.
         self._executor = uproot.source.futures.ResourceThreadPoolExecutor(
-            [None for i in range(num_workers)]
+            [None for i in range(self._num_workers)]
         )
 
         self._max_num_elements, self._max_element_size = get_server_config(
             self._resource.file
         )
-        if max_num_elements is not None:
-            self._max_num_elements = min(self._max_num_elements, max_num_elements)
+        if self._desired_max_num_elements is not None:
+            self._max_num_elements = min(
+                self._max_num_elements, self._desired_max_num_elements
+            )
+
+    def __getstate__(self):
+        state = dict(self.__dict__)
+        state.pop("_executor")
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self._open()
 
     def __repr__(self):
         path = repr(self._file_path)
@@ -411,22 +423,31 @@ class MultithreadedXRootDSource(uproot.source.chunk.MultithreadedSource):
     ResourceClass = XRootDResource
 
     def __init__(self, file_path, **options):
-        num_workers = options["num_workers"]
-        timeout = options["timeout"]
+        self._num_workers = options["num_workers"]
+        self._timeout = options["timeout"]
         self._num_requests = 0
         self._num_requested_chunks = 0
         self._num_requested_bytes = 0
 
         self._file_path = file_path
         self._num_bytes = None
-        self._timeout = timeout
 
+    def _open(self):
         self._executor = uproot.source.futures.ResourceThreadPoolExecutor(
             [
-                XRootDResource(file_path, timeout)
-                for x in uproot._util.range(num_workers)
+                XRootDResource(self._file_path, self._timeout)
+                for x in uproot._util.range(self._num_workers)
             ]
         )
+
+    def __getstate__(self):
+        state = dict(self.__dict__)
+        state.pop("_executor")
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self._open()
 
     @property
     def timeout(self):

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -431,6 +431,7 @@ class MultithreadedXRootDSource(uproot.source.chunk.MultithreadedSource):
 
         self._file_path = file_path
         self._num_bytes = None
+        self._open()
 
     def _open(self):
         self._executor = uproot.source.futures.ResourceThreadPoolExecutor(


### PR DESCRIPTION
Cutting off at the resource acquisition.
The only negative I can think of is it might take people by surprise that the pickle does not completely contain the original data. But I also hope they do not expect it to behave like that.. probably worth a warning in the docs?