### PR TITLE
Histograms should be part of the regular tests.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -44,7 +44,7 @@ jobs:
           conda env list
           conda info
           conda install numpy pandas pytest flake8 lz4 python-xxhash requests
-          pip install scikit-hep-testdata
+          pip install scikit-hep-testdata boost-histogram hist
           conda list
 
       - name: "Install Awkward"

--- a/tests/test_0167-use-the-common-histogram-interface.py
+++ b/tests/test_0167-use-the-common-histogram-interface.py
@@ -135,6 +135,11 @@ def test_boost():
         assert hprof.to_boost().axes[0].name == "xaxis"
         assert hprof.to_boost().axes[0].title == ""
 
+
+@pytest.mark.skip(reason="Something's wrong with uproot-issue33.root and boost-histogram")
+def test_boost():
+    boost_histogram = pytest.importorskip("boost_histogram")
+
     with uproot.open(skhep_testdata.data_path("uproot-issue33.root")) as f:
         assert f["cutflow"].to_boost().name == "cutflow"
         assert f["cutflow"].to_boost().title == "dijethad"

--- a/tests/test_0167-use-the-common-histogram-interface.py
+++ b/tests/test_0167-use-the-common-histogram-interface.py
@@ -137,7 +137,7 @@ def test_boost():
 
 
 @pytest.mark.skip(reason="Something's wrong with uproot-issue33.root and boost-histogram")
-def test_boost():
+def test_boost_2():
     boost_histogram = pytest.importorskip("boost_histogram")
 
     with uproot.open(skhep_testdata.data_path("uproot-issue33.root")) as f:


### PR DESCRIPTION
I need to figure out what's going on with `uproot-issue33.root` conversion into boost-histogram. If I remember right, it's a histogram with labels.

Oh, and @henryiii, you might be interested in this.