### PR TITLE
Some more memberwise stuff

### DIFF
--- a/uproot/containers.py
+++ b/uproot/containers.py
@@ -829,7 +829,7 @@ class AsVector(AsContainer):
                 length = maybe_length
                 # FIXME no idea what the other 2 bytes is
                 assert 2 + values_num_bytes + _stl_vector_header.size == num_bytes
-                stuff = cursor.field(  # ignore: F841
+                stuff = cursor.field(  # noqa: F841
                     chunk, struct.Struct(">h"), context
                 )
                 # print("mystery bytes:", stuff)

--- a/uproot/deserialization.py
+++ b/uproot/deserialization.py
@@ -132,7 +132,7 @@ def numbytes_version(chunk, cursor, context, move=True):
         num_bytes = None
         version = cursor.field(chunk, _numbytes_version_2, context, move=move)
 
-    is_memberwise = version & uproot.const.kStreamedMemberWise
+    is_memberwise = bool(version & uproot.const.kStreamedMemberWise)
     if is_memberwise:
         version = version & ~uproot.const.kStreamedMemberWise
 

--- a/uproot/interpretation/identify.py
+++ b/uproot/interpretation/identify.py
@@ -58,7 +58,7 @@ def _ftype_to_dtype(fType):
     elif fType == uproot.const.kDouble:
         return numpy.dtype(">f8")
     else:
-        raise NotNumerical()
+        raise NotNumerical(f"Unrecognized fType: {fType}")
 
 
 def _leaf_to_dtype(leaf):

--- a/uproot/interpretation/identify.py
+++ b/uproot/interpretation/identify.py
@@ -58,7 +58,7 @@ def _ftype_to_dtype(fType):
     elif fType == uproot.const.kDouble:
         return numpy.dtype(">f8")
     else:
-        raise NotNumerical(f"Unrecognized fType: {fType}")
+        raise NotNumerical("Unrecognized fType: {}".format(fType))
 
 
 def _leaf_to_dtype(leaf):

--- a/uproot/model.py
+++ b/uproot/model.py
@@ -1092,6 +1092,9 @@ class DispatchByVersion(object):
         returns a :doc:`uproot.model.UnknownClassVersion` (adding it to
         ``uproo4.unknown_classes`` if it's not already there).
         """
+        if version in cls.known_versions:
+            return cls.known_versions[version]
+
         classname, _ = classname_decode(cls.__name__)
         classname = classname_regularize(classname)
         streamer = file.streamer_named(classname, version)


### PR DESCRIPTION
I've been trying to read some CMS edm collections, and played around a bit, finding at least one memberwise interpretation successful, with a header like `>h: version` `>I: length` `>I: values_num_bytes`, e.g.
```
--+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+-
  0  10   0   0  16   1  64  22 127 198   0   9   0   0   0   0   0   0   0   0
--- --- --- --- --- ---   @ --- --- --- --- --- --- --- --- --- --- --- --- ---
```
for a class that indeed was version 10 and had the right amount of bytes. This class had a very simple set of members (just one):
```python
    _stl_container0 = uproot.containers.AsVector(False, numpy.dtype("u1"))
    base_names_versions = []
    member_names = ['data_']
    class_flags = {}
```
@kratsg might be interested.