### PR TITLE
Shutdown the ThreadPoolExecutor in XRootDSource on exit (stop leaking threads in XRootDSource)

### DIFF
--- a/src/uproot/source/xrootd.py
+++ b/src/uproot/source/xrootd.py
@@ -404,7 +404,6 @@ class XRootDSource(uproot.source.chunk.Source):
         self._executor.shutdown()
         self._resource.__exit__(exception_type, exception_value, traceback)
 
-
     @property
     def num_bytes(self):
         if self._num_bytes is None:

--- a/src/uproot/source/xrootd.py
+++ b/src/uproot/source/xrootd.py
@@ -401,7 +401,9 @@ class XRootDSource(uproot.source.chunk.Source):
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
+        self._executor.shutdown()
         self._resource.__exit__(exception_type, exception_value, traceback)
+
 
     @property
     def num_bytes(self):


### PR DESCRIPTION
Looking at the changes from #334 i noticed that the `HTTPSource` calls `shutdown` on it's `ResourceThreadPoolExecutor`. I also have to do that for the `ResourceThreadPoolExecutor` i introduced in #243 because `XRootDSource` also has it's own `__exit__` method. It also has to be the `shutdown` method of the executor and not `__exit__`, because `__exit__` will try to call `__exit__` on the Resources and i set the resources in the `ResourceThreadPoolExecutor` of `XRootDSource` to `None`, because it's just there to merge chunks from vector reads that had to be split up.

Before that fix, reading with `XRootDSource` was also leaking threads:

```python
# test_uproot_xrd.py
import uproot

for i in range(10):
    with uproot.open(
        "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root:Events",
        xrootd_handler=uproot.XRootDSource,
    ) as tree:
        print(tree["Muon_pt"].array(entry_stop=5000))
```

```
prmon --interval 0.1 -- python test_uproot_xrd.py
prmon_plot.py --input prmon.txt --xvar wtime --yvar nthreads
```

![image](https://user-images.githubusercontent.com/3707225/115120130-1a568080-9fac-11eb-836b-3494157fddda.png)

After the fix it seems to be fine:

![image](https://user-images.githubusercontent.com/3707225/115120147-2fcbaa80-9fac-11eb-8391-726932170b0d.png)
