### PR TITLE
Add support for basic HTTP authentication

### DIFF
--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -42,7 +42,7 @@ def open(
             rather than a file. Path objects are interpreted strictly as
             filesystem paths or URLs.
             Examples: ``"rel/file.root"``, ``"C:\\abs\\file.root"``,
-            ``"http://where/what.root"``, 
+            ``"http://where/what.root"``,
             ``"https://username:password@where/secure.root"``,
             ``"rel/file.root:tdirectory/ttree"``, ``Path("rel:/file.root")``,
             ``Path("/abs/path:stuff.root")``
@@ -117,10 +117,10 @@ def open(
       ``TTrees``.
 
     For remote ROOT files served over HTTP(S), basic authentication is supported.
-    In this case, the credentials may be provided part of the URL in, as in 
-    ``https://username:password@example.org/secure/protected.root.`` Note that 
+    In this case, the credentials may be provided part of the URL in, as in
+    ``https://username:password@example.org/secure/protected.root.`` Note that
     for security reasons, it is recommended basic authentication only be used
-    for HTTPS resources. 
+    for HTTPS resources.
     """
     if isinstance(path, dict) and len(path) == 1:
         ((file_path, object_path),) = path.items()

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -42,8 +42,10 @@ def open(
             rather than a file. Path objects are interpreted strictly as
             filesystem paths or URLs.
             Examples: ``"rel/file.root"``, ``"C:\\abs\\file.root"``,
-            ``"http://where/what.root"``, ``"rel/file.root:tdirectory/ttree"``,
-            ``Path("rel:/file.root")``, ``Path("/abs/path:stuff.root")``
+            ``"http://where/what.root"``, 
+            ``"https://username:password@where/secure.root"``,
+            ``"rel/file.root:tdirectory/ttree"``, ``Path("rel:/file.root")``,
+            ``Path("/abs/path:stuff.root")``
         object_cache (None, MutableMapping, or int): Cache of objects drawn
             from ROOT directories (e.g histograms, TTrees, other directories);
             if None, do not use a cache; if an int, create a new cache of this
@@ -113,6 +115,12 @@ def open(
       array from ``TTrees``.
     * :doc:`uproot.behaviors.TBranch.lazy`: returns a lazily read array from
       ``TTrees``.
+
+    For remote ROOT files served over HTTP(S), basic authentication is supported.
+    In this case, the credentials may be provided part of the URL in, as in 
+    ``https://username:password@example.org/secure/protected.root.`` Note that 
+    for security reasons, it is recommended basic authentication only be used
+    for HTTPS resources. 
     """
     if isinstance(path, dict) and len(path) == 1:
         ((file_path, object_path),) = path.items()

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -34,6 +34,7 @@ import uproot
 import uproot.source.chunk
 import uproot.source.futures
 
+import base64
 
 def make_connection(parsed_url, timeout):
     """
@@ -79,6 +80,17 @@ def full_path(parsed_url):
     else:
         return parsed_url.path
 
+def basic_auth_headers(parsed_url): 
+    """
+    Returns the headers required for basic authorization, if parsed_url contains 
+    a username / password pair, otherwise returns an empty dict
+    """ 
+    if parsed_url.username==None or parsed_url.password==None: 
+        return {} 
+    ret =  { "Authorization" : "Basic " + base64.b64encode( (parsed_url.username + ":" + parsed_url.password).encode("utf-8")).decode("utf-8") } 
+    return ret
+
+
 
 def get_num_bytes(file_path, parsed_url, timeout):
     """
@@ -90,7 +102,8 @@ def get_num_bytes(file_path, parsed_url, timeout):
     Returns the number of bytes in the file by making a HEAD request.
     """
     connection = make_connection(parsed_url, timeout)
-    connection.request("HEAD", full_path(parsed_url))
+    auth_headers = basic_auth_headers(parsed_url); 
+    connection.request("HEAD", full_path(parsed_url), headers=auth_headers)
     response = connection.getresponse()
 
     while 300 <= response.status < 400:
@@ -99,7 +112,7 @@ def get_num_bytes(file_path, parsed_url, timeout):
             if k.lower() == "location":
                 redirect_url = urlparse(x)
                 connection = make_connection(redirect_url, timeout)
-                connection.request("HEAD", full_path(redirect_url))
+                connection.request("HEAD", full_path(redirect_url), headers = auth_headers)
                 response = connection.getresponse()
                 break
         else:
@@ -154,6 +167,7 @@ class HTTPResource(uproot.source.chunk.Resource):
         self._file_path = file_path
         self._timeout = timeout
         self._parsed_url = urlparse(file_path)
+        self._auth_headers = basic_auth_headers(self._parsed_url) 
 
     @property
     def timeout(self):
@@ -168,6 +182,13 @@ class HTTPResource(uproot.source.chunk.Resource):
         A ``urllib.parse.ParseResult`` version of the ``file_path``.
         """
         return self._parsed_url
+
+    @property
+    def auth_headers(self): 
+        """
+        Returns a dict containing auth headers, if any for this resource
+        """
+        return self._auth_headers
 
     def __enter__(self):
         return self
@@ -199,7 +220,7 @@ class HTTPResource(uproot.source.chunk.Resource):
                     redirect.request(
                         "GET",
                         full_path(redirect_url),
-                        headers={"Range": "bytes={0}-{1}".format(start, stop - 1)},
+                        headers={**{"Range": "bytes={0}-{1}".format(start, stop - 1)}, **self.auth_headers },
                     )
                     return self.get(redirect, start, stop)
 
@@ -240,7 +261,7 @@ for URL {1}""".format(
         connection.request(
             "GET",
             full_path(source.parsed_url),
-            headers={"Range": "bytes={0}-{1}".format(start, stop - 1)},
+            headers={**{"Range": "bytes={0}-{1}".format(start, stop - 1)}, **source.auth_headers},
         )
 
         def task(resource):
@@ -281,7 +302,7 @@ for URL {1}""".format(
         connection[0].request(
             "GET",
             full_path(source.parsed_url),
-            headers={"Range": "bytes=" + ", ".join(range_strings)},
+            headers={**{"Range": "bytes=" + ", ".join(range_strings)}, **source.auth_headers},
         )
 
         def task(resource):
@@ -300,7 +321,7 @@ for URL {1}""".format(
                             connection[0].request(
                                 "GET",
                                 full_path(redirect_url),
-                                headers={"Range": "bytes=" + ", ".join(range_strings)},
+                                headers={**{"Range": "bytes=" + ", ".join(range_strings)}, **source.auth_headers},
                             )
                             task(resource)
                             return
@@ -650,6 +671,13 @@ class HTTPSource(uproot.source.chunk.Source):
         return self._executor.workers[0].resource.parsed_url
 
     @property
+    def auth_headers(self):
+        """
+        Dict containing auth headers, if any
+        """
+        return self._executor.workers[0].resource.auth_headers
+
+    @property
     def fallback(self):
         """
         If None, the source has not encountered an unsuccessful multipart GET
@@ -715,3 +743,11 @@ class MultithreadedHTTPSource(uproot.source.chunk.MultithreadedSource):
         A ``urllib.parse.ParseResult`` version of the ``file_path``.
         """
         return self._executor.workers[0].resource.parsed_url
+
+    @property
+    def auth_headers(self):
+        """
+        Dict containing auth headers, if any
+        """
+        return self._executor.workers[0].resource.auth_headers
+

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -220,7 +220,7 @@ class HTTPResource(uproot.source.chunk.Resource):
                     redirect.request(
                         "GET",
                         full_path(redirect_url),
-                        headers={**{"Range": "bytes={0}-{1}".format(start, stop - 1)}, **self.auth_headers },
+                        headers=dict({"Range": "bytes={0}-{1}".format(start, stop - 1)}, **self.auth_headers),
                     )
                     return self.get(redirect, start, stop)
 
@@ -261,7 +261,7 @@ for URL {1}""".format(
         connection.request(
             "GET",
             full_path(source.parsed_url),
-            headers={**{"Range": "bytes={0}-{1}".format(start, stop - 1)}, **source.auth_headers},
+            headers=dict({"Range": "bytes={0}-{1}".format(start, stop - 1)}, **source.auth_headers),
         )
 
         def task(resource):
@@ -302,7 +302,7 @@ for URL {1}""".format(
         connection[0].request(
             "GET",
             full_path(source.parsed_url),
-            headers={**{"Range": "bytes=" + ", ".join(range_strings)}, **source.auth_headers},
+            headers=dict({"Range": "bytes=" + ", ".join(range_strings)}, **source.auth_headers),
         )
 
         def task(resource):
@@ -321,7 +321,7 @@ for URL {1}""".format(
                             connection[0].request(
                                 "GET",
                                 full_path(redirect_url),
-                                headers={**{"Range": "bytes=" + ", ".join(range_strings)}, **source.auth_headers},
+                                headers=dict({"Range": "bytes=" + ", ".join(range_strings)}, **source.auth_headers),
                             )
                             task(resource)
                             return

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -85,7 +85,7 @@ def basic_auth_headers(parsed_url):
     Returns the headers required for basic authorization, if parsed_url contains 
     a username / password pair, otherwise returns an empty dict
     """ 
-    if parsed_url.username==None or parsed_url.password==None: 
+    if parsed_url.username is None or parsed_url.password is None: 
         return {} 
     ret =  { "Authorization" : "Basic " + base64.b64encode( (parsed_url.username + ":" + parsed_url.password).encode("utf-8")).decode("utf-8") } 
     return ret

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -86,14 +86,15 @@ def basic_auth_headers(parsed_url):
     """
     Returns the headers required for basic authorization, if parsed_url contains
     a username / password pair, otherwise returns an empty dict
-    """ 
-    if parsed_url.username is None or parsed_url.password is None: 
-        return {} 
-    ret =  { "Authorization" : "Basic " + 
-              base64.b64encode( 
-                (parsed_url.username + ":" + 
-                 parsed_url.password).encode("utf-8")).decode("utf-8")
-            } 
+    """
+    if parsed_url.username is None or parsed_url.password is None:
+        return {}
+    ret = {
+        "Authorization": "Basic "
+        + base64.b64encode(
+            (parsed_url.username + ":" + parsed_url.password).encode("utf-8")
+        ).decode("utf-8")
+    }
     return ret
 
 
@@ -227,7 +228,10 @@ class HTTPResource(uproot.source.chunk.Resource):
                     redirect.request(
                         "GET",
                         full_path(redirect_url),
-                        headers=dict({"Range": "bytes={0}-{1}".format(start, stop - 1)}, **self.auth_headers),
+                        headers=dict(
+                            {"Range": "bytes={0}-{1}".format(start, stop - 1)},
+                            **self.auth_headers
+                        ),
                     )
                     return self.get(redirect, start, stop)
 
@@ -268,7 +272,10 @@ for URL {1}""".format(
         connection.request(
             "GET",
             full_path(source.parsed_url),
-            headers=dict({"Range": "bytes={0}-{1}".format(start, stop - 1)}, **source.auth_headers),
+            headers=dict(
+                {"Range": "bytes={0}-{1}".format(start, stop - 1)},
+                **source.auth_headers
+            ),
         )
 
         def task(resource):
@@ -309,7 +316,9 @@ for URL {1}""".format(
         connection[0].request(
             "GET",
             full_path(source.parsed_url),
-            headers=dict({"Range": "bytes=" + ", ".join(range_strings)}, **source.auth_headers),
+            headers=dict(
+                {"Range": "bytes=" + ", ".join(range_strings)}, **source.auth_headers
+            ),
         )
 
         def task(resource):
@@ -328,7 +337,10 @@ for URL {1}""".format(
                             connection[0].request(
                                 "GET",
                                 full_path(redirect_url),
-                                headers=dict({"Range": "bytes=" + ", ".join(range_strings)}, **source.auth_headers),
+                                headers=dict(
+                                    {"Range": "bytes=" + ", ".join(range_strings)},
+                                    **source.auth_headers
+                                ),
                             )
                             task(resource)
                             return

--- a/src/uproot/version.py
+++ b/src/uproot/version.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import
 
 import re
 
-__version__ = "4.1.0rc1"
+__version__ = "4.0.7"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
`ROOT`'s `TFile::Open` supports transparent access not just to HTTP, but also HTTP with basic authentication, by embedding the username and password in the URL, e.g. `http(s)://username:password@example.org/path/to/file.root`. This provides a some level of security to your precious data which you may not want to make public (yet?). In practice, hosting files this way with some credentials widely known to a collaboration is used a fair amount to expose data in academic clusters. 

This pull request adds equivalent functionality to uproot. `urllib`'s parser already parses the username and password from an URL, so we can grab the credentials from the parsed_url when available and append them to the headers. Note that this is only secure at all when using HTTP, as otherwise any interloper can snoop the base64-encoded username and password. I didn't implement it this way, but it may be preferable to not allow basic auth on non-HTTPS connections. 

I have lightly tested this, and I assume I haven't hit all the possible corner cases (like, I assume either the normal or the fallback mode worked for me, but not both). 

Here is what a test might look like, although you probably shouldn't use my URL's because I can't guarantee that they'll be available for eternity:

```
import uproot

def test():
  # test file with no auth needed
  with uproot.open('https://users.rcc.uchicago.edu/~cozzyd/uproot-test/not-so-secret-sauce/mundane.root') as f:
    assert ( f['hrandom'].all_members['fTitle'] =='Random Numbers')
  # test file with auth needed
  with uproot.open('https://DarkHelmet:12345@users.rcc.uchicago.edu/~cozzyd/uproot-test/secret-sauce/top-secret.root') as f:
    assert (f['hmeaning'].all_members['fTitle']=='Meaning of Life') 
```

I have only tested this on Python3... it's possible it may not work on Python2 due to the differences in strings (I suspect the line that does the base64 encoding may fail on Python2, but I'm not sure how to make it compatible with both, or if what I do on that line is even sane).  