### PR TITLE
Conditionally apply XRootD workarounds based on it's version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,8 @@ download_url = https://github.com/scikit-hep/uproot4/releases
 [options]
 packages = find:
 install_requires =
-    setuptools
     numpy
+    setuptools
 python_requires = >=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ download_url = https://github.com/scikit-hep/uproot4/releases
 [options]
 packages = find:
 install_requires =
+    setuptools
     numpy
 python_requires = >=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 package_dir =

--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -11,9 +11,10 @@ error messages containing instructions on how to install the library.
 from __future__ import absolute_import
 
 import atexit
-import pkg_resources
-from distutils.version import LooseVersion
 import os
+from distutils.version import LooseVersion
+
+import pkg_resources
 
 
 def awkward():

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -161,7 +161,7 @@ def open(
 
 open.defaults = {
     "file_handler": uproot.source.file.MemmapSource,
-    "xrootd_handler": uproot.source.xrootd.MultithreadedXRootDSource,
+    "xrootd_handler": uproot.source.xrootd.XRootDSource,
     "http_handler": uproot.source.http.HTTPSource,
     "object_handler": uproot.source.object.ObjectSource,
     "timeout": 30,
@@ -171,6 +171,9 @@ open.defaults = {
     "begin_chunk_size": 403,  # the smallest a ROOT file can be
     "minimal_ttree_metadata": True,
 }
+# See https://github.com/scikit-hep/uproot4/issues/294
+if uproot.extras.older_xrootd("5.2.0"):
+    open.defaults["xrootd_handler"] = uproot.source.xrootd.MultithreadedXRootDSource
 
 
 must_be_attached = [

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -13,6 +13,9 @@ from __future__ import absolute_import
 import struct
 import sys
 import uuid
+import warnings
+
+import pkg_resources
 
 try:
     from collections.abc import Mapping, MutableMapping
@@ -173,7 +176,14 @@ open.defaults = {
 }
 # See https://github.com/scikit-hep/uproot4/issues/294
 if uproot.extras.older_xrootd("5.2.0"):
-    open.defaults["xrootd_handler"] = uproot.source.xrootd.MultithreadedXRootDSource
+    dist = pkg_resources.get_distribution("XRootD")
+    message = """XRootD {0} is not fully supported; either upgrade to 5.2.0+ or set
+
+    open.defaults["xrootd_handler"] = uproot.MultithreadedXRootDSource
+""".format(
+        dist.version
+    )
+    warnings.warn(message, FutureWarning)
 
 
 must_be_attached = [

--- a/src/uproot/source/xrootd.py
+++ b/src/uproot/source/xrootd.py
@@ -77,15 +77,27 @@ class XRootDResource(uproot.source.chunk.Resource):
     """
 
     def __init__(self, file_path, timeout):
-        XRootD_client = uproot.extras.XRootD_client()
         self._file_path = file_path
         self._timeout = timeout
+        self._open()
+
+    def _open(self):
+        XRootD_client = uproot.extras.XRootD_client()
 
         self._file = XRootD_client.File()
 
         status, dummy = self._file.open(self._file_path, timeout=self._xrd_timeout())
         if status.error:
             self._xrd_error(status)
+
+    def __getstate__(self):
+        state = dict(self.__dict__)
+        state.pop("_file")
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self._open()
 
     def _xrd_timeout(self):
         if self._timeout is None:


### PR DESCRIPTION
Now that there are versions assigned for the two XRootD workarounds I think it would be better to apply them conditionally. There are a few ways of doing this but I think using `pkg_resources` is the simplest while maintaining support for Python 2.