### PR TITLE
ci: use guidelines for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,32 +1,40 @@
 name: Deploy to PyPI
 
 on:
+  workflow_dispatch:
   release:
-    types: [created]
+    types:
+    - published
 
 jobs:
-  deploy:
-
+  dist:
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Build wheel and SDist
+      run: pipx run build
+
+    - name: Check metadata
+      run: pipx run twine check dist/*
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*
+
+
+  publish:
+    needs: [dist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
 
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.pypi_username }}
-          TWINE_PASSWORD: ${{ secrets.pypi_password }}
-        run: |
-          python setup.py sdist
-          python setup.py bdist_wheel --universal
-          twine upload dist/*
+    - uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: ${{ secrets.pypi_username }}
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,5 +36,4 @@ jobs:
 
     - uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
-        user: ${{ secrets.pypi_username }}
         password: ${{ secrets.pypi_password }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [metadata]
 name = uproot
 description = ROOT I/O in pure Python and NumPy.
@@ -50,6 +47,9 @@ package_dir =
 
 [options.packages.find]
 where = src
+
+[bdist_wheel]
+universal = 1
 
 [tool:pytest]
 addopts = -vv -rs -Wd

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal=1
+
 [metadata]
 name = uproot
 description = ROOT I/O in pure Python and NumPy.


### PR DESCRIPTION
Following our guidelines.

@jpivarski  We should set up a scikit-hep token to upload just this package instead of using a username, which is not as safe. I can make this change (I'll need to remove the username and add the generated token as the password).