### PR TITLE
Treat self-built XRootD version strings

### DIFF
--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -106,9 +106,10 @@ def XRootD_client():
 def older_xrootd(min_version):
     """
     Check if the installed XRootD bindings are newer than a given version
-    without importing. Defaults to False if XRootD is not installed. Self-built
-    XRootD has different version strings, starting with 'v'; False is returned
-    in this case.
+    without importing. Defaults to False if XRootD is not installed. Unrecognized
+    versions (i.e. self-built XRootD, whose version numbers are strings)
+    return False: that is, they're assumed to be new, so that no warnings
+    are raised.
     """
     try:
         dist = pkg_resources.get_distribution("XRootD")
@@ -117,7 +118,7 @@ def older_xrootd(min_version):
     else:
         try:
             return LooseVersion(dist.version) < LooseVersion(min_version)
-        except Exception:
+        except TypeError:
             return False
 
 

--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -106,14 +106,19 @@ def XRootD_client():
 def older_xrootd(min_version):
     """
     Check if the installed XRootD bindings are newer than a given version
-    without importing. Defaults to False if XRootD is not installed.
+    without importing. Defaults to False if XRootD is not installed. Self-built
+    XRootD has different version strings, starting with 'v'; False is returned
+    in this case.
     """
     try:
         dist = pkg_resources.get_distribution("XRootD")
     except pkg_resources.DistributionNotFound:
         return False
     else:
-        return LooseVersion(dist.version) < LooseVersion(min_version)
+        if dist.version.startswith("v"):
+            return False
+        else:
+            return LooseVersion(dist.version) < LooseVersion(min_version)
 
 
 def lzma():

--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -115,10 +115,10 @@ def older_xrootd(min_version):
     except pkg_resources.DistributionNotFound:
         return False
     else:
-        if dist.version.startswith("v"):
-            return False
-        else:
+        try:
             return LooseVersion(dist.version) < LooseVersion(min_version)
+        except Exception:
+            return False
 
 
 def lzma():


### PR DESCRIPTION
When one builds XRootD, the version number differs from the standard `x.y.z` - it is, e.g., `v20210712-58b374f12`, which causes `LooseVersion` to raise `TypeError`.

Fixes #394