### PR TITLE
mark test 0220 with network tag

### DIFF
--- a/tests/test_0220-contiguous-byte-ranges-in-http.py
+++ b/tests/test_0220-contiguous-byte-ranges-in-http.py
@@ -8,6 +8,7 @@ import pytest
 import uproot
 
 
+@pytest.mark.network
 def test():
     with uproot.open(
         "https://starterkit.web.cern.ch/starterkit/data/advanced-python-2019/RD_distribution.root:tree"


### PR DESCRIPTION
This test is missing the pytest network mark despite trying to access a webserver at cern.ch