### PR TITLE
Float16_t with up to 32 bits is allowed (not just 16).

### DIFF
--- a/src/uproot/interpretation/identify.py
+++ b/src/uproot/interpretation/identify.py
@@ -240,7 +240,7 @@ def _float16_or_double32(branch, context, leaf, is_float16, dims):
         right = title.index("]")
 
     except (ValueError, AttributeError):
-        low, high, num_bits = 0, 0, 0
+        low, high, num_bits = 0, 0, "no brackets"  # distinct from "None"
 
     else:
         source = title[left : right + 1]
@@ -280,19 +280,19 @@ def _float16_or_double32(branch, context, leaf, is_float16, dims):
             )
 
     if not is_float16:
-        if num_bits == 0:
+        if num_bits == "no brackets":
             return uproot.interpretation.numerical.AsDtype(
                 numpy.dtype((">f4", dims)), numpy.dtype(("f8", dims))
             )
-        elif num_bits is None:
+        elif num_bits is None or not 2 <= num_bits <= 32:
             return uproot.interpretation.numerical.AsDouble32(low, high, 32, dims)
         else:
             return uproot.interpretation.numerical.AsDouble32(low, high, num_bits, dims)
 
     else:
-        if num_bits == 0:
+        if num_bits == "no brackets":
             return uproot.interpretation.numerical.AsFloat16(low, high, 12, dims)
-        elif num_bits is None:
+        elif num_bits is None or not 2 <= num_bits <= 32:
             return uproot.interpretation.numerical.AsFloat16(low, high, 32, dims)
         else:
             return uproot.interpretation.numerical.AsFloat16(low, high, num_bits, dims)

--- a/src/uproot/interpretation/numerical.py
+++ b/src/uproot/interpretation/numerical.py
@@ -624,8 +624,8 @@ class AsFloat16(TruncatedNumerical):
         self._num_bits = num_bits
         self._to_dims = to_dims
 
-        if not uproot._util.isint(num_bits) or not 2 <= num_bits <= 16:
-            raise TypeError("num_bits must be an integer between 2 and 16 (inclusive)")
+        if not uproot._util.isint(num_bits) or not 2 <= num_bits <= 32:
+            raise TypeError("num_bits must be an integer between 2 and 32 (inclusive)")
         if high <= low and not self.is_truncated:
             raise ValueError(
                 "high ({0}) must be strictly greater than low ({1})".format(high, low)


### PR DESCRIPTION
Tested on files made by https://root.cern/doc/master/float16_8C_source.html with

```c++
   Float16_t fI14; //[-pi,pi,14] saved as a 14 bit unsigned int
```

replacing `14` with `20`, `32`, `33`, `0`, `1`, and `2`. Values outside of the legal range, `2 <= num_bits <= 32`, are _left in the file_ and have to be mapped to `32`, even for `Float16_t`.