### PR TITLE
The 'xrootd_handler' key must be set regardless of whether there's a warning about its choice of value.

### DIFF
--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -172,12 +172,13 @@ class _OpenDefaults(dict):
                     "XRootD {0} is not fully supported; ".format(dist.version)
                     + """either upgrade to 5.2.0+ or set
 
-                open.defaults["xrootd_handler"] = uproot.MultithreadedXRootDSource
-            """
+    open.defaults["xrootd_handler"] = uproot.MultithreadedXRootDSource
+"""
                 )
                 warnings.warn(message, FutureWarning)
-            else:
-                self["xrootd_handler"] = uproot.source.xrootd.XRootDSource
+
+            # The key should still be set, regardless of whether we see the warning.
+            self["xrootd_handler"] = uproot.source.xrootd.XRootDSource
 
         return dict.__getitem__(self, where)
 


### PR DESCRIPTION
Thanks, @henryiii!

(There will be a 4.1.1 soon enough.)