### PR TITLE
Recreate truncates if file exists

### DIFF
--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -100,10 +100,8 @@ def recreate(file_path, **options):
     """
     file_path = uproot._util.regularize_path(file_path)
     if uproot._util.isstr(file_path):
-        if not os.path.exists(file_path):
-            with open(file_path, "a") as tmp:
-                tmp.seek(0)
-                tmp.truncate()
+        # Truncate file
+        open(file_path, "w").close()
         sink = uproot.sink.file.FileSink(file_path)
     else:
         sink = uproot.sink.file.FileSink.from_object(file_path)


### PR DESCRIPTION
(As discussed before on Gitter)
Truncate the file to 0 bytes opened with uproot.recreate before writing contents. This behavior agrees with ROOT Recreate.
The previous code lines seemed to intend to do this, however assumingly due to an erroneous 'not', this was not done.
If the file does not exist, an empty file is created. This is the same behavior as before.