### PR TITLE
Recursively fix forms for objects that require ak.from_iter

### DIFF
--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -665,6 +665,11 @@ def awkward_form_remove_uproot(awkward, form):
 # going through ak.from_iter, the integer dtypes will be int64 and the
 # floating dtypes will be float64 because that's what ak.from_iter makes.
 def recursively_fix_awkward_form_of_iter(awkward, interpretation, form):
+    """
+    Given an interpretation of a TBranch, fixup any form corresponding to
+    a component that cannot be read directly by awkward and needs to go
+    through ak.from_iter
+    """
     import uproot.interpretation
 
     if isinstance(interpretation, uproot.interpretation.grouped.AsGrouped):

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -664,6 +664,29 @@ def awkward_form_remove_uproot(awkward, form):
 # FIXME: Until we get Awkward reading these bytes directly, rather than
 # going through ak.from_iter, the integer dtypes will be int64 and the
 # floating dtypes will be float64 because that's what ak.from_iter makes.
+def recursively_fix_awkward_form_of_iter(awkward, interpretation, form):
+    import uproot.interpretation
+
+    if isinstance(interpretation, uproot.interpretation.grouped.AsGrouped):
+        fixed = {}
+        for key, subinterpretation in interpretation.subbranches.items():
+            fixed[key] = recursively_fix_awkward_form_of_iter(
+                awkward, subinterpretation, form.content(key)
+            )
+        return awkward.forms.RecordForm(
+            fixed,
+            form.has_identities,
+            form.parameters,
+        )
+    elif isinstance(interpretation, uproot.interpretation.objects.AsObjects):
+        if uproot.interpretation.objects.awkward_can_optimize(interpretation, form):
+            return form
+        else:
+            return uproot._util.awkward_form_of_iter(awkward, form)
+    else:
+        return form
+
+
 def awkward_form_of_iter(awkward, form):
     """
     Fix an ``ak.forms.Form`` object for a given iterable.

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -639,11 +639,9 @@ def lazy(
 
                 interpretation = branchid_interpretation[branch.cache_key]
                 form = interpretation.awkward_form(obj.file, index_format="i64")
-                if isinstance(interpretation, uproot.interpretation.objects.AsObjects):
-                    if not uproot.interpretation.objects.awkward_can_optimize(
-                        interpretation, form
-                    ):
-                        form = uproot._util.awkward_form_of_iter(awkward, form)
+                form = uproot._util.recursively_fix_awkward_form_of_iter(
+                    awkward, interpretation, form
+                )
 
                 generator = awkward.layout.ArrayGenerator(
                     branch.array,

--- a/src/uproot/models/TRef.py
+++ b/src/uproot/models/TRef.py
@@ -193,8 +193,16 @@ in file {1}""".format(
         contents["fSize"] = uproot._util.awkward_form(
             numpy.dtype("i4"), file, index_format, header, tobject_header, breadcrumbs
         )
-        contents["refs"] = uproot._util.awkward_form(
-            numpy.dtype("i4"), file, index_format, header, tobject_header, breadcrumbs
+        contents["refs"] = awkward.forms.ListOffsetForm(
+            index_format,
+            uproot._util.awkward_form(
+                numpy.dtype("i4"),
+                file,
+                index_format,
+                header,
+                tobject_header,
+                breadcrumbs,
+            ),
         )
         return awkward.forms.RecordForm(
             contents, parameters={"__record__": "TRefArray"}


### PR DESCRIPTION
If a sub-branch cannot be optimized by awkward, the parent cannot either and must have its form fixed for use with lazy arrays.