### PR TITLE
Leaf-lists (structs) and non-leaf-lists in the same Pandas DataFrame.

### DIFF
--- a/src/uproot/interpretation/library.py
+++ b/src/uproot/interpretation/library.py
@@ -970,9 +970,9 @@ class Pandas(Library):
                 newarrays, newnames = {}, []
                 for x in names:
                     if not isinstance(x, tuple):
-                        y = (x,) + (None,) * (longest - 1)
+                        y = (x,) + ("",) * (longest - 1)
                     else:
-                        y = x + (None,) * (longest - len(x))
+                        y = x + ("",) * (longest - len(x))
                     newarrays[y] = arrays[x]
                     newnames.append(y)
                 arrays = newarrays


### PR DESCRIPTION
Pandas turns the "None" values of a MultiIndex into NaN, and then they're not good keys for dict lookup. The "filler" to use when leaf-lists (multiple levels of column name structure) and non-leaf-lists (single level) are mixed must be empty strings, rather than "None".