### PR TITLE
Set leaf title to 'branchname[countername]' for jagged arrays.

### DIFF
--- a/src/uproot/writing/_cascadetree.py
+++ b/src/uproot/writing/_cascadetree.py
@@ -947,6 +947,9 @@ class Tree(object):
             else:
                 dims = "".join("[" + str(x) + "]" for x in datum["shape"])
 
+            if datum["counter"] is not None:
+                dims = "[" + datum["counter"]["fName"] + "]" + dims
+
             # single TLeaf
             leaf_name = datum["fName"].encode(errors="surrogateescape")
             leaf_title = (datum["fName"] + dims).encode(errors="surrogateescape")


### PR DESCRIPTION
Although PyROOT's iteration only looks at the `fLeafCount` member to determine the number of subentries, `TTree::Scan`, `TTree::Draw`, and `TTreeReader` all seem to be parsing the text of the leaf to determine how to count the subentries.

See discussion in #457.