### PR TITLE
Include the tests suite in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README*.md LICENSE CONTRIBUTING.md
+recursive-include tests *.py


### PR DESCRIPTION
This PR updates the `MANIFEST.in` to include the `tests/` directory in source distributions (tarballs). This should enable downstream package builders (e.g. conda-forge) to run the test suite to validate packages.