### PR TITLE
Detect XRootD versions before 4.11.1

### DIFF
--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -117,15 +117,29 @@ def older_xrootd(min_version):
     return False: that is, they're assumed to be new, so that no warnings
     are raised.
     """
-    try:
-        dist = pkg_resources.get_distribution("XRootD")
-    except pkg_resources.DistributionNotFound:
+    version = xrootd_version()
+    if version is None:
         return False
     else:
         try:
-            return LooseVersion(dist.version) < LooseVersion(min_version)
+            return LooseVersion(version) < LooseVersion(min_version)
         except TypeError:
             return False
+
+
+def xrootd_version():
+    """
+    Gets the XRootD version if installed, otherwise returns None.
+    """
+    try:
+        version = pkg_resources.get_distribution("XRootD").version
+    except pkg_resources.DistributionNotFound:
+        try:
+            # Versions before 4.11.1 used pyxrootd as the package name
+            version = pkg_resources.get_distribution("pyxrootd").version
+        except pkg_resources.DistributionNotFound:
+            version = None
+    return version
 
 
 def lzma():

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -168,7 +168,9 @@ class _OpenDefaults(dict):
             # See https://github.com/scikit-hep/uproot4/issues/294
             if uproot.extras.older_xrootd("5.2.0"):
                 message = (
-                    "XRootD {0} is not fully supported; ".format(uproot.extras.xrootd_version())
+                    "XRootD {0} is not fully supported; ".format(
+                        uproot.extras.xrootd_version()
+                    )
                     + """either upgrade to 5.2.0+ or set
 
     open.defaults["xrootd_handler"] = uproot.MultithreadedXRootDSource

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -15,8 +15,6 @@ import sys
 import uuid
 import warnings
 
-import pkg_resources
-
 try:
     from collections.abc import Mapping, MutableMapping
 except ImportError:

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -167,9 +167,8 @@ class _OpenDefaults(dict):
         if where == "xrootd_handler" and where not in self:
             # See https://github.com/scikit-hep/uproot4/issues/294
             if uproot.extras.older_xrootd("5.2.0"):
-                dist = pkg_resources.get_distribution("XRootD")
                 message = (
-                    "XRootD {0} is not fully supported; ".format(dist.version)
+                    "XRootD {0} is not fully supported; ".format(uproot.extras.xrootd_version())
                     + """either upgrade to 5.2.0+ or set
 
     open.defaults["xrootd_handler"] = uproot.MultithreadedXRootDSource


### PR DESCRIPTION
Resolves #486. Checks for the package name `pyxrootd` if searching for `XRootD` fails.