### PR TITLE
Remove underscore prefixes from data members uproot.model.TTable

### DIFF
--- a/src/uproot/models/TTable.py
+++ b/src/uproot/models/TTable.py
@@ -246,6 +246,12 @@ in file {1}""".format(
         )
         self._data = numpy.frombuffer(buf, dtype=dtype)
 
+    @property
+    def data(self):
+        view = self._data.view()
+        view.flags.writeable = False
+        return view
+
     base_names_versions = []
     member_names = ["fN", "fMaxIndex", "fSize"]
     class_flags = {"has_read_object_any": True}

--- a/tests/test_0418-read-TTable.py
+++ b/tests/test_0418-read-TTable.py
@@ -61,4 +61,4 @@ def test_geant_dot_root(geant_branch):
     items = dict(
         (obj.all_members["fName"], obj) for obj in geant_branch.members["fObj"]
     )
-    assert items["g2t_pythia"]._data["subprocess_id"] == 1
+    assert items["g2t_pythia"].data["subprocess_id"] == 1


### PR DESCRIPTION
My original plan to "publish" them was to do so by adding `@property` accessors without the underscore, but to simply rename might be even better.