### PR TITLE
[MemmapSource] Remove unnecessary(?) copies

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -2540,6 +2540,12 @@ in file {3}""".format(
         Returns a :doc:`uproot.source.chunk.Chunk` and
         :doc:`uproot.source.cursor.Cursor` as a 2-tuple for a given
         ``basket_num``.
+
+        If the file source is :doc:`uproot.source.file.MemmapSource`
+        and the file gets closed, accessing the Chunk would cause
+        a segfault. If that's a possibility, be sure to call
+        :doc:`uproot.source.chunk.Chunk.detach_memmap` to ensure
+        that any memmap-derived data gets copied for safety.
         """
         if 0 <= basket_num < self._num_normal_baskets:
             start = self.member("fBasketSeek")[basket_num]

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -2616,16 +2616,21 @@ in file {3}""".format(
             start = self.member("fBasketSeek")[basket_num]
             stop = start + uproot.reading._key_format_big.size
             cursor = uproot.source.cursor.Cursor(start)
+
+            # Chunk will not be retained; we don't have to detach_memmap()
             chunk = self._file.source.chunk(start, stop)
+
             return uproot.reading.ReadOnlyKey(
                 chunk, cursor, {}, self._file, self, read_strings=False
             )
+
         elif 0 <= basket_num < self.num_baskets:
             raise ValueError(
                 "branch {0} basket {1} is an embedded basket, which has no TKey".format(
                     repr(self.name), basket_num
                 )
             )
+
         else:
             raise IndexError(
                 """branch {0} has {1} baskets; cannot get basket chunk {2}

--- a/src/uproot/models/TBasket.py
+++ b/src/uproot/models/TBasket.py
@@ -252,6 +252,9 @@ class Model_TBasket(uproot.model.Model):
             num_entries = self._members["fNevBuf"]
             key_length = self._members["fKeylen"]
 
+            # Embedded TBaskets are always uncompressed; be sure to copy any memmap arrays
+            chunk = chunk.detach_memmap()
+
             if maybe_entry_size * num_entries + key_length != self._members["fLast"]:
                 raw_byte_offsets = cursor.bytes(
                     chunk, 8 + self.num_entries * 4, context
@@ -294,6 +297,9 @@ class Model_TBasket(uproot.model.Model):
                     context,
                 )
             else:
+                # Uncompressed; be sure to copy any memmap arrays
+                chunk = chunk.detach_memmap()
+
                 self._raw_data = cursor.bytes(chunk, uncompressed_bytes, context)
 
             if self.border != uncompressed_bytes:

--- a/src/uproot/source/file.py
+++ b/src/uproot/source/file.py
@@ -149,7 +149,7 @@ class MemmapSource(uproot.source.chunk.Source):
             self._num_requested_chunks += 1
             self._num_requested_bytes += stop - start
 
-            data = numpy.array(self._file[start:stop], copy=True)
+            data = self._file[start:stop]
             future = uproot.source.futures.TrivialFuture(data)
             return uproot.source.chunk.Chunk(self, start, stop, future)
 
@@ -167,7 +167,7 @@ class MemmapSource(uproot.source.chunk.Source):
 
             chunks = []
             for start, stop in ranges:
-                data = numpy.array(self._file[start:stop], copy=True)
+                data = self._file[start:stop]
                 future = uproot.source.futures.TrivialFuture(data)
                 chunk = uproot.source.chunk.Chunk(self, start, stop, future)
                 notifications.put(chunk)

--- a/src/uproot/source/file.py
+++ b/src/uproot/source/file.py
@@ -151,7 +151,7 @@ class MemmapSource(uproot.source.chunk.Source):
 
             data = self._file[start:stop]
             future = uproot.source.futures.TrivialFuture(data)
-            return uproot.source.chunk.Chunk(self, start, stop, future)
+            return uproot.source.chunk.Chunk(self, start, stop, future, is_memmap=True)
 
         else:
             return self._fallback.chunk(start, stop)
@@ -169,7 +169,9 @@ class MemmapSource(uproot.source.chunk.Source):
             for start, stop in ranges:
                 data = self._file[start:stop]
                 future = uproot.source.futures.TrivialFuture(data)
-                chunk = uproot.source.chunk.Chunk(self, start, stop, future)
+                chunk = uproot.source.chunk.Chunk(
+                    self, start, stop, future, is_memmap=True
+                )
                 notifications.put(chunk)
                 chunks.append(chunk)
             return chunks

--- a/tests/test_0519-remove-memmap-copy.py
+++ b/tests/test_0519-remove-memmap-copy.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+from __future__ import absolute_import
+
+import pytest
+import skhep_testdata
+
+import uproot
+
+
+def test():
+    file = uproot.open(skhep_testdata.data_path("uproot-Zmumu-uncompressed.root"))
+    basket = file["events/px1"].basket(0)
+    file.close()
+    assert basket.data[0] == 192

--- a/tests/test_0519-remove-memmap-copy.py
+++ b/tests/test_0519-remove-memmap-copy.py
@@ -9,7 +9,10 @@ import uproot
 
 
 def test():
-    file = uproot.open(skhep_testdata.data_path("uproot-Zmumu-uncompressed.root"))
-    basket = file["events/px1"].basket(0)
-    file.close()
+    with uproot.open(
+        skhep_testdata.data_path("uproot-Zmumu-uncompressed.root")
+    ) as file:
+        basket = file["events/px1"].basket(0)
+
+    # without PR #519, this would be a segfault
     assert basket.data[0] == 192


### PR DESCRIPTION
Dear `uproot4` developers,

this PR removes unnecessary(?) copies of the `numpy.memmap`. This should be safe, as `self._file` is only opened in `r`-mode, see: https://github.com/scikit-hep/uproot4/blob/8ae497a89ec92f06724980fccafa1c4286ce6040/src/uproot/source/file.py#L113 `uproot3` also did not do copies on the `numpy.memmaps`: https://github.com/scikit-hep/uproot3/blob/master/uproot3/source/memmap.py#L54-L57

Since this is a very fundamental piece of code I would really appreciate your feedback here!
(I hope I did not overlook a trivial reason why now a copy is needed.)

Thank you very much for reviewing!

Best, Peter