### PR TITLE
chore: drop Python 2 syntax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.29.1
+  hooks:
+  - id: pyupgrade
+    args: ["--py36-plus"]
+
 - repo: https://github.com/psf/black
   rev: 21.12b0
   hooks:

--- a/dev/make-models.py
+++ b/dev/make-models.py
@@ -112,7 +112,7 @@ class {uproot.model.classname_encode(classname)}(uproot.model.DispatchByVersion)
                 f"""        uproot._writing.RawStreamerInfo(
             None,
             {full},
-            {repr(streamer_name)},
+            {streamer_name!r},
             {streamer_version},
         ),"""
             )
@@ -145,11 +145,11 @@ class {uproot.model.classname_encode(obj.classname)}(uproot.model.DispatchByVers
 
     for classname, _ in superclasses:
         print(  # noqa: T001
-            f"uproot.classes[{repr(classname)}] = {uproot.model.classname_encode(classname)}"
+            f"uproot.classes[{classname!r}] = {uproot.model.classname_encode(classname)}"
         )
 
     for key in keys:
         obj = f[key]
         print(  # noqa: T001
-            f"uproot.classes[{repr(obj.classname)}] = {uproot.model.classname_encode(obj.classname)}"
+            f"uproot.classes[{obj.classname!r}] = {uproot.model.classname_encode(obj.classname)}"
         )

--- a/docs-sphinx/make_changelog.py
+++ b/docs-sphinx/make_changelog.py
@@ -10,13 +10,11 @@ import subprocess
 tagslist_text = subprocess.run(
     ["git", "show-ref", "--tags"], stdout=subprocess.PIPE
 ).stdout
-tagslist = dict(
-    [
-        (k, v)
-        for k, v in re.findall(rb"([0-9a-f]{40}) refs/tags/([0-9\.rc]+)", tagslist_text)
-        if not v.startswith(b"0.")
-    ]
-)
+tagslist = {
+    k: v
+    for k, v in re.findall(rb"([0-9a-f]{40}) refs/tags/([0-9\.rc]+)", tagslist_text)
+    if not v.startswith(b"0.")
+}
 
 subjects_text = subprocess.run(
     ["git", "log", "--format='format:%H %s'"], stdout=subprocess.PIPE
@@ -27,10 +25,10 @@ github_connection = http.client.HTTPSConnection("api.github.com")
 github_releases = []
 numpages = int(math.ceil(len(tagslist) / 30.0))
 for pageid in range(numpages):
-    print("Requesting GitHub data, page {0} of {1}".format(pageid + 1, numpages))
+    print(f"Requesting GitHub data, page {pageid + 1} of {numpages}")
     github_connection.request(
         "GET",
-        r"/repos/scikit-hep/uproot4/releases?page={0}&per_page=30".format(pageid + 1),
+        fr"/repos/scikit-hep/uproot4/releases?page={pageid + 1}&per_page=30",
         headers={"User-Agent": "uproot4-changelog"},
     )
     github_releases_text = github_connection.getresponse().read()
@@ -67,8 +65,8 @@ pypi_connection = http.client.HTTPSConnection("pypi.org")
 
 
 def pypi_exists(tag):
-    print("Looking for release {0} on PyPI...".format(tag))
-    pypi_connection.request("HEAD", "/project/uproot/{0}/".format(tag))
+    print(f"Looking for release {tag} on PyPI...")
+    pypi_connection.request("HEAD", f"/project/uproot/{tag}/")
     response = pypi_connection.getresponse()
     response.read()
     return response.status == 200
@@ -84,15 +82,13 @@ with open("changelog.rst", "w") as outfile:
     for taghash, subject in subjects:
         if taghash in tagslist:
             tag = tagslist[taghash].decode()
-            tagurl = "https://github.com/scikit-hep/uproot4/releases/tag/{0}".format(
-                tag
-            )
+            tagurl = f"https://github.com/scikit-hep/uproot4/releases/tag/{tag}"
 
             if numprs == 0:
                 outfile.write("*(no pull requests)*\n")
             numprs = 0
 
-            header_text = "\nRelease `{0} <{1}>`__\n".format(tag, tagurl)
+            header_text = f"\nRelease `{tag} <{tagurl}>`__\n"
             outfile.write(header_text)
             outfile.write("=" * len(header_text) + "\n\n")
 
@@ -103,20 +99,18 @@ with open("changelog.rst", "w") as outfile:
 
             assets = []
             if pypi_exists(tag):
-                assets.append(
-                    "`pip <https://pypi.org/project/uproot/{0}/>`__".format(tag)
-                )
+                assets.append(f"`pip <https://pypi.org/project/uproot/{tag}/>`__")
             if tag in tarballs:
-                assets.append("`tar <{0}>`__".format(tarballs[tag]))
+                assets.append(f"`tar <{tarballs[tag]}>`__")
             if tag in zipballs:
-                assets.append("`zip <{0}>`__".format(zipballs[tag]))
+                assets.append(f"`zip <{zipballs[tag]}>`__")
             if len(assets) == 0:
                 assets_text = ""
             else:
-                assets_text = " ({0})".format(", ".join(assets))
+                assets_text = " ({})".format(", ".join(assets))
 
             if len(date_text) + len(assets_text) > 0:
-                outfile.write("{0}{1}\n\n".format(date_text, assets_text))
+                outfile.write(f"{date_text}{assets_text}\n\n")
 
             if tag in releases:
                 text = (
@@ -154,7 +148,7 @@ with open("changelog.rst", "w") as outfile:
 
             text = m.group(1).decode().strip()
             prnum = m.group(2).decode()
-            prurl = "https://github.com/scikit-hep/uproot4/pull/{0}".format(prnum)
+            prurl = f"https://github.com/scikit-hep/uproot4/pull/{prnum}"
 
             known = [prnum]
             for issue in re.findall(
@@ -202,13 +196,9 @@ with open("changelog.rst", "w") as outfile:
             if len(addresses) == 0:
                 addresses_text = ""
             else:
-                addresses_text = " (**also:** {0})".format(", ".join(addresses))
+                addresses_text = " (**also:** {})".format(", ".join(addresses))
 
-            outfile.write(
-                "* PR `#{0} <{1}>`__: {2}{3}\n".format(
-                    prnum, prurl, text, addresses_text
-                )
-            )
+            outfile.write(f"* PR `#{prnum} <{prurl}>`__: {text}{addresses_text}\n")
 
             first = False
 

--- a/docs-sphinx/prepare_docstrings.py
+++ b/docs-sphinx/prepare_docstrings.py
@@ -76,8 +76,8 @@ main.write(
     :caption: Main Interface
     :hidden:
 
-{0}""".format(
-        "".join("    {0}\n".format(x) for x in common)
+{}""".format(
+        "".join(f"    {x}\n" for x in common)
     )
 )
 toctree = open("uproot.toctree", "w")
@@ -94,7 +94,7 @@ toctree2 = None
 def ensure(filename, content):
     overwrite = not os.path.exists(filename)
     if not overwrite:
-        overwrite = open(filename, "r").read() != content
+        overwrite = open(filename).read() != content
     if overwrite:
         open(filename, "w").write(content)
         sys.stderr.write(filename + " (OVERWRITTEN)\n")
@@ -190,7 +190,7 @@ def handle_class(classname, cls):
                     fill.append("")
                     if basecls is not cls:
                         fill.append(
-                            "Inherited from :doc:`{0}`.".format(
+                            "Inherited from :doc:`{}`.".format(
                                 basecls.__module__ + "." + basecls.__name__
                             )
                         )
@@ -213,7 +213,7 @@ def handle_class(classname, cls):
 
     fullfilename = importlib.import_module(cls.__module__).__file__
     shortfilename = fullfilename[fullfilename.rindex("uproot/") :]
-    link = "`{0} <https://github.com/scikit-hep/uproot4/blob/{1}/src/{2}>`__".format(
+    link = "`{} <https://github.com/scikit-hep/uproot4/blob/{}/src/{}>`__".format(
         cls.__module__, latest_commit, shortfilename
     )
     try:
@@ -232,30 +232,30 @@ def handle_class(classname, cls):
         inheritance_header = """.. table::
     :class: note
 
-    +-{0}-+
-    | **Inheritance order:** {1}|
-    +={2}=+
+    +-{}-+
+    | **Inheritance order:** {}|
+    +={}=+
     | """.format(
             "-" * longest_cell, " " * (longest_cell - 22), "=" * longest_cell
         )
         inheritance_footer = """ |
-    +-{0}-+""".format(
+    +-{}-+""".format(
             "-" * longest_cell
         )
         inheritance = [x + " " * (longest_cell - len(x)) for x in inheritance]
         inheritance_sep = """ |
     | """
 
-    content = """{0}
-{1}
+    content = """{}
+{}
 
-Defined in {2} on {3}.
+Defined in {} on {}.
 
-{4}
+{}
 
-.. autoclass:: {5}
+.. autoclass:: {}
 
-{6}
+{}
 """.format(
         title,
         "=" * len(title),
@@ -285,19 +285,19 @@ def handle_function(functionname, cls):
 
     fullfilename = importlib.import_module(cls.__module__).__file__
     shortfilename = fullfilename[fullfilename.rindex("uproot/") :]
-    link = "`{0} <https://github.com/scikit-hep/uproot4/blob/{1}/src/{2}>`__".format(
+    link = "`{} <https://github.com/scikit-hep/uproot4/blob/{}/src/{}>`__".format(
         cls.__module__, latest_commit, shortfilename
     )
     linelink = "`line {0} <https://github.com/scikit-hep/uproot4/blob/{1}/src/{2}#L{0}>`__".format(
         inspect.getsourcelines(cls)[1], latest_commit, shortfilename
     )
 
-    content = """{0}
-{1}
+    content = """{}
+{}
 
-Defined in {2} on {3}.
+Defined in {} on {}.
 
-.. autofunction:: {4}
+.. autofunction:: {}
 """.format(
         title, "=" * len(title), link, linelink, functionname
     )
@@ -317,7 +317,7 @@ for modulename in order:
         toctree2 = open(modulename + ".toctree", "w")
         toctree2.write(
             """.. toctree::
-    :caption: {0}
+    :caption: {}
     :hidden:
 
 """.format(
@@ -328,10 +328,8 @@ for modulename in order:
     handle_module(modulename, module)
     if module.__file__.endswith("__init__.py") and modulename != "uproot":
         for submodulename in sorted(
-            [
-                modulename + "." + name
-                for loader, name, is_pkg in pkgutil.walk_packages(module.__path__)
-            ]
+            modulename + "." + name
+            for loader, name, is_pkg in pkgutil.walk_packages(module.__path__)
         ):
             submodule = importlib.import_module(submodulename)
             handle_module(submodulename, submodule)

--- a/src/uproot/__init__.py
+++ b/src/uproot/__init__.py
@@ -72,7 +72,6 @@ The submodules of Uproot are:
 isort:skip_file
 """
 
-from __future__ import absolute_import
 
 from uproot.version import __version__
 import uproot.const

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -5,7 +5,6 @@ This module defines utilities for internal use. This is not a public interface
 and may be changed without notice.
 """
 
-from __future__ import absolute_import
 
 import datetime
 import glob
@@ -71,7 +70,7 @@ def ensure_str(x):
     elif isinstance(x, str):
         return x
     else:
-        raise TypeError("expected a string, not {0}".format(type(x)))
+        raise TypeError(f"expected a string, not {type(x)}")
 
 
 def ensure_numpy(array, types=(numpy.bool_, numpy.integer, numpy.floating)):
@@ -86,9 +85,7 @@ def ensure_numpy(array, types=(numpy.bool_, numpy.integer, numpy.floating)):
         except (ValueError, numpy.VisibleDeprecationWarning):
             raise TypeError("cannot be converted to a NumPy array")
         if not issubclass(out.dtype.type, types):
-            raise TypeError(
-                "cannot be converted to a NumPy array of type {0}".format(types)
-            )
+            raise TypeError(f"cannot be converted to a NumPy array of type {types}")
         return out
 
 
@@ -145,7 +142,7 @@ def regularize_filter(filter):
     else:
         raise TypeError(
             "filter must be None, callable, a regex string between slashes, or a "
-            "glob pattern, not {0}".format(repr(filter))
+            "glob pattern, not {}".format(repr(filter))
         )
 
 
@@ -214,7 +211,7 @@ def regularize_rename(rename):
 
     raise TypeError(
         "rename must be None, callable, a '/from/to/' regex, an iterable of "
-        "regex rules, or a dict, not {0}".format(repr(rename))
+        "regex rules, or a dict, not {}".format(repr(rename))
     )
 
 
@@ -355,7 +352,7 @@ def file_path_to_source_class(file_path, options):
         return out, file_path
 
     else:
-        raise ValueError("URI scheme not recognized: {0}".format(file_path))
+        raise ValueError(f"URI scheme not recognized: {file_path}")
 
 
 if isinstance(__builtins__, dict):
@@ -457,7 +454,7 @@ def memory_size(data, error_message=None):
     if error_message is None:
         raise TypeError(
             "number of bytes or memory size string with units "
-            "(such as '100 MB') required, not {0}".format(repr(data))
+            "(such as '100 MB') required, not {}".format(repr(data))
         )
     else:
         raise TypeError(error_message)
@@ -520,7 +517,7 @@ def awkward_form(
                     '"float64"'
                 )
             else:
-                raise AssertionError("{0}: {1}".format(repr(model), type(model)))
+                raise AssertionError(f"{repr(model)}: {type(model)}")
 
         return _primitive_awkward_form[model]
 
@@ -597,11 +594,11 @@ def awkward_form_remove_uproot(awkward, form):
         )
     elif isinstance(form, awkward.forms.RecordForm):
         return awkward.forms.RecordForm(
-            dict(
-                (k, awkward_form_remove_uproot(awkward, v))
+            {
+                k: awkward_form_remove_uproot(awkward, v)
                 for k, v in form.contents.items()
                 if not k.startswith("@")
-            ),
+            },
             form.has_identities,
             parameters,
         )
@@ -634,7 +631,7 @@ def awkward_form_remove_uproot(awkward, form):
             parameters,
         )
     else:
-        raise RuntimeError("unrecognized form: {0}".format(type(form)))
+        raise RuntimeError(f"unrecognized form: {type(form)}")
 
 
 # FIXME: Until we get Awkward reading these bytes directly, rather than
@@ -745,9 +742,7 @@ def awkward_form_of_iter(awkward, form):
         return out
     elif isinstance(form, awkward.forms.RecordForm):
         return awkward.forms.RecordForm(
-            dict(
-                (k, awkward_form_of_iter(awkward, v)) for k, v in form.contents.items()
-            ),
+            {k: awkward_form_of_iter(awkward, v) for k, v in form.contents.items()},
             form.has_identities,
             form.parameters,
         )
@@ -780,7 +775,7 @@ def awkward_form_of_iter(awkward, form):
             form.parameters,
         )
     else:
-        raise RuntimeError("unrecognized form: {0}".format(type(form)))
+        raise RuntimeError(f"unrecognized form: {type(form)}")
 
 
 def damerau_levenshtein(a, b, ratio=False):
@@ -844,7 +839,7 @@ def code_to_datetime(code):
         ((code & 0b00000000001111100000000000000000) >> 17),
         ((code & 0b00000000000000011111000000000000) >> 12),
         ((code & 0b00000000000000000000111111000000) >> 6),
-        ((code & 0b00000000000000000000000000111111)),
+        (code & 0b00000000000000000000000000111111),
     )
 
 

--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -12,21 +12,19 @@ import numbers
 import os
 import platform
 import re
-import sys
 import warnings
 from collections.abc import Iterable
 from urllib.parse import unquote, urlparse
 
 import numpy
 
-py36 = sys.version_info[0] == 3 and sys.version_info[1] <= 6
 win = platform.system().lower().startswith("win")
 
 
 def tobytes(array):
     """
     Calls ``array.tobytes()`` or its older equivalent, ``array.tostring()``,
-    depending on what's available in this NumPy version.
+    depending on what's available in this NumPy version. (tobytes added in 1.9)
     """
     if hasattr(array, "tobytes"):
         return array.tobytes()
@@ -454,7 +452,7 @@ def memory_size(data, error_message=None):
     if error_message is None:
         raise TypeError(
             "number of bytes or memory size string with units "
-            "(such as '100 MB') required, not {}".format(repr(data))
+            f"(such as '100 MB') required, not {data!r}"
         )
     else:
         raise TypeError(error_message)
@@ -517,7 +515,7 @@ def awkward_form(
                     '"float64"'
                 )
             else:
-                raise AssertionError(f"{repr(model)}: {type(model)}")
+                raise AssertionError(f"{model!r}: {type(model)}")
 
         return _primitive_awkward_form[model]
 

--- a/src/uproot/behavior.py
+++ b/src/uproot/behavior.py
@@ -6,7 +6,6 @@ Behaviors are defined by specially named classes in specially named modules
 that get auto-detected by :doc:`uproot.behavior.behavior_of`.
 """
 
-from __future__ import absolute_import
 
 import pkgutil
 
@@ -47,12 +46,10 @@ def behavior_of(classname):
     if name not in globals():
         if name in behavior_of._module_names:
             exec(
-                compile(
-                    "import uproot.behaviors.{0}".format(name), "<dynamic>", "exec"
-                ),
+                compile(f"import uproot.behaviors.{name}", "<dynamic>", "exec"),
                 globals(),
             )
-            module = eval("uproot.behaviors.{0}".format(name))
+            module = eval(f"uproot.behaviors.{name}")
             behavior_cls = getattr(module, name, None)
             if behavior_cls is not None:
                 globals()[name] = behavior_cls

--- a/src/uproot/behaviors/RooCurve.py
+++ b/src/uproot/behaviors/RooCurve.py
@@ -4,7 +4,6 @@
 This module defines the behaviors of ``RooCurve``.
 """
 
-from __future__ import absolute_import
 
 import numpy
 

--- a/src/uproot/behaviors/RooHist.py
+++ b/src/uproot/behaviors/RooHist.py
@@ -4,7 +4,6 @@
 This module defines the behaviors of ``RooHist``.
 """
 
-from __future__ import absolute_import
 
 import numpy
 

--- a/src/uproot/behaviors/TAxis.py
+++ b/src/uproot/behaviors/TAxis.py
@@ -20,7 +20,7 @@ class AxisTraits:
         self._axis = axis
 
     def __repr__(self):
-        return f"AxisTraits({repr(self._axis)})"
+        return f"AxisTraits({self._axis!r})"
 
     @property
     def circular(self):

--- a/src/uproot/behaviors/TAxis.py
+++ b/src/uproot/behaviors/TAxis.py
@@ -4,12 +4,11 @@
 This module defines the behaviors of ``TAxis``, an axis of a histogram or profile plot.
 """
 
-from __future__ import absolute_import
 
 import numpy
 
 
-class AxisTraits(object):
+class AxisTraits:
     """
     Describes read-only properties of a histogram axis.
 
@@ -21,7 +20,7 @@ class AxisTraits(object):
         self._axis = axis
 
     def __repr__(self):
-        return "AxisTraits({0})".format(repr(self._axis))
+        return f"AxisTraits({repr(self._axis)})"
 
     @property
     def circular(self):
@@ -40,7 +39,7 @@ class AxisTraits(object):
         return fLabels is not None and len(fLabels) == fNbins
 
 
-class TAxis(object):
+class TAxis:
     """
     Describes a histogram axis.
     """
@@ -84,8 +83,7 @@ class TAxis(object):
             for x in fLabels:
                 yield str(x)
         else:
-            for low, high in self.intervals():
-                yield low, high
+            yield from self.intervals()
 
     def __contains__(self, x):
         """

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -1877,7 +1877,7 @@ class HasBranches(Mapping):
         elif uproot._util.isstr(where):
             where = uproot._util.ensure_str(where)
         else:
-            raise TypeError(f"where must be an integer or a string, not {repr(where)}")
+            raise TypeError(f"where must be an integer or a string, not {where!r}")
 
         if where.startswith("/"):
             recursive = False

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -11,7 +11,6 @@ See :doc:`uproot.models.TBranch` for deserialization of the ``TBranch``
 objects themselves.
 """
 
-from __future__ import absolute_import
 
 import glob
 import itertools
@@ -32,7 +31,7 @@ from uproot._util import no_filter
 np_uint8 = numpy.dtype("u1")
 
 
-class _NoClose(object):
+class _NoClose:
     def __init__(self, hasbranches):
         self.hasbranches = hasbranches
 
@@ -66,9 +65,9 @@ def iterate(
     report=False,
     custom_classes=None,
     allow_missing=False,
-    **options  # NOTE: a comma after **options breaks Python 2
+    **options,  # NOTE: a comma after **options breaks Python 2
 ):
-    u"""
+    """
     Args:
         files: See below.
         expressions (None, str, or list of str): Names of ``TBranches`` or
@@ -239,9 +238,9 @@ def concatenate(
     how=None,
     custom_classes=None,
     allow_missing=False,
-    **options  # NOTE: a comma after **options breaks Python 2
+    **options,  # NOTE: a comma after **options breaks Python 2
 ):
-    u"""
+    """
     Args:
         files: See below.
         expressions (None, str, or list of str): Names of ``TBranches`` or
@@ -397,9 +396,9 @@ def lazy(
     library="ak",
     custom_classes=None,
     allow_missing=False,
-    **options  # NOTE: a comma after **options breaks Python 2
+    **options,  # NOTE: a comma after **options breaks Python 2
 ):
-    u"""
+    """
     Args:
         files: See below.
         filter_name (None, glob string, regex string in ``"/pattern/i"`` syntax, function of str \u2192 bool, or iterable of the above): A
@@ -575,10 +574,10 @@ def lazy(
 
     if count == 0:
         raise ValueError(
-            "allow_missing=True and no TTrees found in\n\n    {0}".format(
+            "allow_missing=True and no TTrees found in\n\n    {}".format(
                 "\n    ".join(
                     "{"
-                    + "{0}: {1}".format(
+                    + "{}: {}".format(
                         repr(f.file_path if isinstance(f, HasBranches) else f),
                         repr(f.object_path if isinstance(f, HasBranches) else o),
                     )
@@ -590,10 +589,10 @@ def lazy(
 
     if len(common_keys) == 0 or not (all(is_self) or not any(is_self)):
         raise ValueError(
-            "TTrees in\n\n    {0}\n\nhave no TBranches in common".format(
+            "TTrees in\n\n    {}\n\nhave no TBranches in common".format(
                 "\n    ".join(
                     "{"
-                    + "{0}: {1}".format(
+                    + "{}: {}".format(
                         repr(f.file_path if isinstance(f, HasBranches) else f),
                         repr(f.object_path if isinstance(f, HasBranches) else o),
                     )
@@ -650,7 +649,7 @@ def lazy(
                     ),  # , interpretation
                     length,
                 )
-                cache_key = "{0}:{1}:{2}-{3}:{4}".format(
+                cache_key = "{}:{}:{}-{}:{}".format(
                     branch.cache_key,
                     interpretation.cache_key,
                     start,
@@ -690,7 +689,7 @@ def lazy(
     return awkward.Array(out)
 
 
-class Report(object):
+class Report:
     """
     Args:
         source (:doc:`uproot.behaviors.TBranch.HasBranches`): The
@@ -729,7 +728,7 @@ class Report(object):
         self._global_offset = global_offset
 
     def __repr__(self):
-        return "<Report start={0} stop={1} source={2}>".format(
+        return "<Report start={} stop={} source={}>".format(
             self.global_entry_start,
             self.global_entry_stop,
             repr(self._source.file.file_path + ":" + self._source.object_path),
@@ -985,7 +984,7 @@ class HasBranches(Mapping):
         library="ak",
         how=None,
     ):
-        u"""
+        """
         Args:
             expressions (None, str, or list of str): Names of ``TBranches`` or
                 aliases to convert to arrays or mathematical expressions of them.
@@ -1085,7 +1084,7 @@ class HasBranches(Mapping):
 
         def get_from_cache(branchname, interpretation):
             if array_cache is not None:
-                cache_key = "{0}:{1}:{2}:{3}-{4}:{5}".format(
+                cache_key = "{}:{}:{}:{}-{}:{}".format(
                     self.cache_key,
                     branchname,
                     interpretation.cache_key,
@@ -1151,7 +1150,7 @@ class HasBranches(Mapping):
                         checked.add(branch.cache_key)
                         interpretation = branchid_interpretation[branch.cache_key]
                         if branch is not None:
-                            cache_key = "{0}:{1}:{2}:{3}-{4}:{5}".format(
+                            cache_key = "{}:{}:{}:{}-{}:{}".format(
                                 self.cache_key,
                                 expression,
                                 interpretation.cache_key,
@@ -1198,7 +1197,7 @@ class HasBranches(Mapping):
         how=None,
         report=False,
     ):
-        u"""
+        """
         Args:
             expressions (None, str, or list of str): Names of ``TBranches`` or
                 aliases to convert to arrays or mathematical expressions of them.
@@ -1274,7 +1273,7 @@ class HasBranches(Mapping):
         keys = _keys_deep(self)
         if isinstance(self, TBranch) and expressions is None and len(keys) == 0:
             filter_branch = uproot._util.regularize_filter(filter_branch)
-            for x in self.parent.iterate(
+            yield from self.parent.iterate(
                 expressions=expressions,
                 cut=cut,
                 filter_name=filter_name,
@@ -1290,8 +1289,7 @@ class HasBranches(Mapping):
                 library=library,
                 how=how,
                 report=report,
-            ):
-                yield x
+            )
 
         else:
             entry_start, entry_stop = _regularize_entries_start_stop(
@@ -1414,7 +1412,7 @@ class HasBranches(Mapping):
         recursive=True,
         full_paths=True,
     ):
-        u"""
+        """
         Args:
             filter_name (None, glob string, regex string in ``"/pattern/i"`` syntax, function of str \u2192 bool, or iterable of the above): A
                 filter to select ``TBranches`` by name.
@@ -1450,7 +1448,7 @@ class HasBranches(Mapping):
         filter_branch=no_filter,
         recursive=True,
     ):
-        u"""
+        """
         Args:
             filter_name (None, glob string, regex string in ``"/pattern/i"`` syntax, function of str \u2192 bool, or iterable of the above): A
                 filter to select ``TBranches`` by name.
@@ -1487,7 +1485,7 @@ class HasBranches(Mapping):
         recursive=True,
         full_paths=True,
     ):
-        u"""
+        """
         Args:
             filter_name (None, glob string, regex string in ``"/pattern/i"`` syntax, function of str \u2192 bool, or iterable of the above): A
                 filter to select ``TBranches`` by name.
@@ -1525,7 +1523,7 @@ class HasBranches(Mapping):
         recursive=True,
         full_paths=True,
     ):
-        u"""
+        """
         Args:
             filter_name (None, glob string, regex string in ``"/pattern/i"`` syntax, function of str \u2192 bool, or iterable of the above): A
                 filter to select ``TBranches`` by name.
@@ -1563,7 +1561,7 @@ class HasBranches(Mapping):
         recursive=True,
         full_paths=True,
     ):
-        u"""
+        """
         Args:
             filter_name (None, glob string, regex string in ``"/pattern/i"`` syntax, function of str \u2192 bool, or iterable of the above): A
                 filter to select ``TBranches`` by name.
@@ -1598,7 +1596,7 @@ class HasBranches(Mapping):
         filter_branch=no_filter,
         recursive=True,
     ):
-        u"""
+        """
         Args:
             filter_name (None, glob string, regex string in ``"/pattern/i"`` syntax, function of str \u2192 bool, or iterable of the above): A
                 filter to select ``TBranches`` by name.
@@ -1635,7 +1633,7 @@ class HasBranches(Mapping):
         recursive=True,
         full_paths=True,
     ):
-        u"""
+        """
         Args:
             filter_name (None, glob string, regex string in ``"/pattern/i"`` syntax, function of str \u2192 bool, or iterable of the above): A
                 filter to select ``TBranches`` by name.
@@ -1663,7 +1661,7 @@ class HasBranches(Mapping):
             pass
         else:
             raise TypeError(
-                "filter_branch must be None or a function: TBranch -> bool, not {0}".format(
+                "filter_branch must be None or a function: TBranch -> bool, not {}".format(
                     repr(filter_branch)
                 )
             )
@@ -1688,7 +1686,7 @@ class HasBranches(Mapping):
                     full_paths=full_paths,
                 ):
                     if full_paths:
-                        k2 = "{0}/{1}".format(branch.name, k1)
+                        k2 = f"{branch.name}/{k1}"
                     else:
                         k2 = k1
                     if filter_name is no_filter or _filter_name_deep(
@@ -1704,7 +1702,7 @@ class HasBranches(Mapping):
         recursive=True,
         full_paths=True,
     ):
-        u"""
+        """
         Args:
             filter_name (None, glob string, regex string in ``"/pattern/i"`` syntax, function of str \u2192 bool, or iterable of the above): A
                 filter to select ``TBranches`` by name.
@@ -1833,7 +1831,7 @@ class HasBranches(Mapping):
         filter_branch=no_filter,
         recursive=True,
     ):
-        u"""
+        """
         Args:
             filter_name (None, glob string, regex string in ``"/pattern/i"`` syntax, function of str \u2192 bool, or iterable of the above): A
                 filter to select ``TBranches`` by name.
@@ -1879,9 +1877,7 @@ class HasBranches(Mapping):
         elif uproot._util.isstr(where):
             where = uproot._util.ensure_str(where)
         else:
-            raise TypeError(
-                "where must be an integer or a string, not {0}".format(repr(where))
-            )
+            raise TypeError(f"where must be an integer or a string, not {repr(where)}")
 
         if where.startswith("/"):
             recursive = False
@@ -1932,8 +1928,7 @@ class HasBranches(Mapping):
                 )
 
     def __iter__(self):
-        for x in self.branches:
-            yield x
+        yield from self.branches
 
     def __len__(self):
         return len(self.branches)
@@ -1960,11 +1955,11 @@ class TBranch(HasBranches):
 
     def __repr__(self):
         if len(self) == 0:
-            return "<{0} {1} at 0x{2:012x}>".format(
+            return "<{} {} at 0x{:012x}>".format(
                 self.classname, repr(self.name), id(self)
             )
         else:
-            return "<{0} {1} ({2} subbranches) at 0x{3:012x}>".format(
+            return "<{} {} ({} subbranches) at 0x{:012x}>".format(
                 self.classname, repr(self.name), len(self), id(self)
             )
 
@@ -1978,7 +1973,7 @@ class TBranch(HasBranches):
         array_cache="inherit",
         library="ak",
     ):
-        u"""
+        """
         Args:
             interpretation (None or :doc:`uproot.interpretation.Interpretation`): An
                 interpretation of the ``TBranch`` data as an array. If None, the
@@ -2040,7 +2035,7 @@ class TBranch(HasBranches):
 
         def get_from_cache(branchname, interpretation):
             if array_cache is not None:
-                cache_key = "{0}:{1}:{2}:{3}-{4}:{5}".format(
+                cache_key = "{}:{}:{}:{}-{}:{}".format(
                     self.cache_key,
                     branchname,
                     interpretation.cache_key,
@@ -2098,7 +2093,7 @@ class TBranch(HasBranches):
         )
 
         if array_cache is not None:
-            cache_key = "{0}:{1}:{2}:{3}-{4}:{5}".format(
+            cache_key = "{}:{}:{}:{}-{}:{}".format(
                 self.cache_key,
                 self.name,
                 interpretation.cache_key,
@@ -2144,7 +2139,7 @@ class TBranch(HasBranches):
             sep = ":"
         else:
             sep = "/"
-        return "{0}{1}{2}".format(self.parent.object_path, sep, self.name)
+        return f"{self.parent.object_path}{sep}{self.name}"
 
     @property
     def cache_key(self):
@@ -2157,7 +2152,7 @@ class TBranch(HasBranches):
                 sep = ":"
             else:
                 sep = "/"
-            self._cache_key = "{0}{1}{2}({3})".format(
+            self._cache_key = "{}{}{}({})".format(
                 self.parent.cache_key, sep, self.name, self.index
             )
         return self._cache_key
@@ -2261,9 +2256,9 @@ class TBranch(HasBranches):
             )
         ):
             raise ValueError(
-                """entries in normal baskets ({0}) plus embedded baskets ({1}) """
-                """don't add up to expected number of entries ({2})
-in file {3}""".format(
+                """entries in normal baskets ({}) plus embedded baskets ({}) """
+                """don't add up to expected number of entries ({})
+in file {}""".format(
                     num_entries_normal,
                     sum(basket.num_entries for basket in self.embedded_baskets),
                     self.num_entries,
@@ -2298,9 +2293,9 @@ in file {3}""".format(
 
         else:
             raise IndexError(
-                """branch {0} has {1} baskets; cannot get starting entry """
-                """for basket {2}
-in file {3}""".format(
+                """branch {} has {} baskets; cannot get starting entry """
+                """for basket {}
+in file {}""".format(
                     repr(self.name), self.num_baskets, basket_num, self._file.file_path
                 )
             )
@@ -2517,8 +2512,8 @@ in file {3}""".format(
             return self.embedded_baskets[basket_num - self._num_normal_baskets]
         else:
             raise IndexError(
-                """branch {0} has {1} baskets; cannot get basket {2}
-in file {3}""".format(
+                """branch {} has {} baskets; cannot get basket {}
+in file {}""".format(
                     repr(self.name), self.num_baskets, basket_num, self._file.file_path
                 )
             )
@@ -2543,9 +2538,9 @@ in file {3}""".format(
             return chunk, cursor
         elif 0 <= basket_num < self.num_baskets:
             raise IndexError(
-                """branch {0} has {1} normal baskets; cannot get chunk and """
-                """cursor for basket {2} because only normal baskets have cursors
-in file {3}""".format(
+                """branch {} has {} normal baskets; cannot get chunk and """
+                """cursor for basket {} because only normal baskets have cursors
+in file {}""".format(
                     repr(self.name),
                     self._num_normal_baskets,
                     basket_num,
@@ -2554,9 +2549,9 @@ in file {3}""".format(
             )
         else:
             raise IndexError(
-                """branch {0} has {1} baskets; cannot get cursor and chunk """
-                """for basket {2}
-in file {3}""".format(
+                """branch {} has {} baskets; cannot get cursor and chunk """
+                """for basket {}
+in file {}""".format(
                     repr(self.name), self.num_baskets, basket_num, self._file.file_path
                 )
             )
@@ -2578,8 +2573,8 @@ in file {3}""".format(
             ].compressed_bytes
         else:
             raise IndexError(
-                """branch {0} has {1} baskets; cannot get basket chunk {2}
-in file {3}""".format(
+                """branch {} has {} baskets; cannot get basket chunk {}
+in file {}""".format(
                     repr(self.name), self.num_baskets, basket_num, self._file.file_path
                 )
             )
@@ -2620,15 +2615,15 @@ in file {3}""".format(
 
         elif 0 <= basket_num < self.num_baskets:
             raise ValueError(
-                "branch {0} basket {1} is an embedded basket, which has no TKey".format(
+                "branch {} basket {} is an embedded basket, which has no TKey".format(
                     repr(self.name), basket_num
                 )
             )
 
         else:
             raise IndexError(
-                """branch {0} has {1} baskets; cannot get basket chunk {2}
-in file {3}""".format(
+                """branch {} has {} baskets; cannot get basket chunk {}
+in file {}""".format(
                     repr(self.name), self.num_baskets, basket_num, self._file.file_path
                 )
             )
@@ -2961,7 +2956,7 @@ def _regularize_object_path(
             object_cache=None,
             array_cache=None,
             custom_classes=custom_classes,
-            **options  # NOTE: a comma after **options breaks Python 2
+            **options,  # NOTE: a comma after **options breaks Python 2
         ).root_directory
         if object_path is None:
             trees = file.keys(filter_classname="TTree", cycle=False)
@@ -2971,7 +2966,7 @@ def _regularize_object_path(
                 else:
                     raise ValueError(
                         """no TTrees found
-in file {0}""".format(
+in file {}""".format(
                             file_path
                         )
                     )
@@ -3121,7 +3116,7 @@ def _regularize_branchname(
         ):
             raise ValueError(
                 "a branch cannot be loaded with multiple interpretations: "
-                "{0} and {1}".format(
+                "{} and {}".format(
                     repr(branchid_interpretation[branch.cache_key]),
                     repr(interpretation),
                 )
@@ -3187,15 +3182,13 @@ def _regularize_expression(
         ):
             if symbol in symbol_path:
                 raise ValueError(
-                    """symbol {0} is recursively defined with aliases:
+                    """symbol {} is recursively defined with aliases:
 
-    {1}
+    {}
 
-in file {2} at {3}""".format(
+in file {} at {}""".format(
                         repr(symbol),
-                        "\n    ".join(
-                            "{0}: {1}".format(k, v) for k, v in aliases.items()
-                        ),
+                        "\n    ".join(f"{k}: {v}" for k, v in aliases.items()),
                         hasbranches.file.file_path,
                         hasbranches.object_path,
                     )
@@ -3347,7 +3340,7 @@ def _regularize_expressions(
             "expressions must be None (for all branches), a string (single "
             "branch or expression), a list of strings (multiple), or a dict "
             "or list of name, Interpretation pairs (branch names and their "
-            "new Interpretation), not {0}".format(repr(expressions))
+            "new Interpretation), not {}".format(repr(expressions))
         )
 
     if cut is None:
@@ -3461,9 +3454,9 @@ def _ranges_or_baskets_to_arrays(
             )
             if basket.num_entries != len(basket_arrays[basket.basket_num]):
                 raise ValueError(
-                    """basket {0} in tree/branch {1} has the wrong number of entries """
-                    """(expected {2}, obtained {3}) when interpreted as {4}
-    in file {5}""".format(
+                    """basket {} in tree/branch {} has the wrong number of entries """
+                    """(expected {}, obtained {}) when interpreted as {}
+    in file {}""".format(
                         basket.basket_num,
                         branch.object_path,
                         basket.num_entries,
@@ -3569,7 +3562,7 @@ def _regularize_step_size(
     target_num_bytes = uproot._util.memory_size(
         step_size,
         "number of entries or memory size string with units "
-        "(such as '100 MB') required, not {0}".format(repr(step_size)),
+        "(such as '100 MB') required, not {}".format(repr(step_size)),
     )
     return _hasbranches_num_entries_for(
         hasbranches, target_num_bytes, entry_start, entry_stop, branchid_interpretation
@@ -3596,8 +3589,7 @@ class _WrapDict(MutableMapping):
         del self.dict[where]
 
     def __iter__(self, where):
-        for x in self.dict:
-            yield x
+        yield from self.dict
 
     def __len__(self):
         return len(self.dict)

--- a/src/uproot/behaviors/TBranchElement.py
+++ b/src/uproot/behaviors/TBranchElement.py
@@ -5,7 +5,6 @@ This module defines the behaviors of ``TBranchElement``, which is entirely inher
 functions in :doc:`uproot.behaviors.TBranch.TBranch`.
 """
 
-from __future__ import absolute_import
 
 import uproot
 

--- a/src/uproot/behaviors/TDatime.py
+++ b/src/uproot/behaviors/TDatime.py
@@ -4,12 +4,11 @@
 This module defines the behaviors of ``TDatime``.
 """
 
-from __future__ import absolute_import
 
 import uproot
 
 
-class TDatime(object):
+class TDatime:
     """
     Behaviors for TDatime: return values as py:class:`datetime.datetime`
     """

--- a/src/uproot/behaviors/TGraph.py
+++ b/src/uproot/behaviors/TGraph.py
@@ -4,12 +4,11 @@
 This module defines the behaviors of ``TGraph``.
 """
 
-from __future__ import absolute_import
 
 import numpy
 
 
-class TGraph(object):
+class TGraph:
     """
     Behaviors for TGraph: return values as a NumPy array
     """

--- a/src/uproot/behaviors/TGraphAsymmErrors.py
+++ b/src/uproot/behaviors/TGraphAsymmErrors.py
@@ -4,7 +4,6 @@
 This module defines the behaviors of ``TGraphAsymmErrors``.
 """
 
-from __future__ import absolute_import
 
 import numpy
 
@@ -14,7 +13,7 @@ import numpy
 #  'fMinimum', 'fMaximum', 'fEXlow', 'fEXhigh', 'fEYlow', 'fEYhigh']
 
 
-class TGraphAsymmErrors(object):
+class TGraphAsymmErrors:
     """
     Behaviors for TGraphAsymmErrors: get values and errors as NumPy arrays.
     """

--- a/src/uproot/behaviors/TGraphErrors.py
+++ b/src/uproot/behaviors/TGraphErrors.py
@@ -4,10 +4,8 @@
 This module defines the behaviors of ``TGraphErrors``.
 """
 
-from __future__ import absolute_import
 
-
-class TGraphErrors(object):
+class TGraphErrors:
     """
     Behaviors for TGraphErrors: get values and errors as NumPy arrays.
     """

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -5,7 +5,6 @@ This module defines the behaviors of ``TH1`` and its subclasses (not including `
 ``TH3``, or ``TProfile``).
 """
 
-from __future__ import absolute_import
 
 import numpy
 
@@ -41,7 +40,7 @@ def _boost_axis(axis, metadata):
     return out
 
 
-class Histogram(object):
+class Histogram:
     """
     Abstract class for histograms.
     """
@@ -182,7 +181,7 @@ class Histogram(object):
         return self.values(flow=flow)
 
     def to_boost(self, metadata=boost_metadata, axis_metadata=boost_axis_metadata):
-        u"""
+        """
         Args:
             metadata (dict of str \u2192 str): Metadata to collect (keys) and
                 their C++ class member names (values).
@@ -194,7 +193,7 @@ class Histogram(object):
         raise NotImplementedError(repr(self))
 
     def to_hist(self, metadata=boost_metadata, axis_metadata=boost_axis_metadata):
-        u"""
+        """
         Args:
             metadata (dict of str \u2192 str): Metadata to collect (keys) and
                 their C++ class member names (values).

--- a/src/uproot/behaviors/TH2.py
+++ b/src/uproot/behaviors/TH2.py
@@ -5,7 +5,6 @@ This module defines the behaviors of ``TH2`` and its subclasses (not including
 ``TProfile2D`` and ``TH2Poly``).
 """
 
-from __future__ import absolute_import
 
 import numpy
 

--- a/src/uproot/behaviors/TH2Poly.py
+++ b/src/uproot/behaviors/TH2Poly.py
@@ -4,7 +4,6 @@
 This module defines the behavior of ``TH2Poly``.
 """
 
-from __future__ import absolute_import
 
 import uproot
 

--- a/src/uproot/behaviors/TH3.py
+++ b/src/uproot/behaviors/TH3.py
@@ -5,7 +5,6 @@ This module defines the behaviors of ``TH3`` and its subclasses (not including
 ``TProfile3D``).
 """
 
-from __future__ import absolute_import
 
 import numpy
 

--- a/src/uproot/behaviors/TParameter.py
+++ b/src/uproot/behaviors/TParameter.py
@@ -4,10 +4,8 @@
 This module defines the behavior of ``TParameter<T>``.
 """
 
-from __future__ import absolute_import
 
-
-class TParameter_3c_boolean_3e_(object):
+class TParameter_3c_boolean_3e_:
     """
     Behaviors for ``TParameter<boolean>``.
     """
@@ -26,7 +24,7 @@ class TParameter_3c_boolean_3e_(object):
         return float(self.member("fVal"))
 
 
-class TParameter_3c_integer_3e_(object):
+class TParameter_3c_integer_3e_:
     """
     Behaviors for ``TParameter<integer>``.
     """
@@ -48,7 +46,7 @@ class TParameter_3c_integer_3e_(object):
         return float(self.member("fVal"))
 
 
-class TParameter_3c_floating_3e_(object):
+class TParameter_3c_floating_3e_:
     """
     Behaviors for ``TParameter<floating>``.
     """

--- a/src/uproot/behaviors/TProfile.py
+++ b/src/uproot/behaviors/TProfile.py
@@ -4,7 +4,6 @@
 This module defines the behavior of ``TProfile``.
 """
 
-from __future__ import absolute_import
 
 import numpy
 

--- a/src/uproot/behaviors/TProfile2D.py
+++ b/src/uproot/behaviors/TProfile2D.py
@@ -4,7 +4,6 @@
 This module defines the behavior of ``TProfile2D``.
 """
 
-from __future__ import absolute_import
 
 import numpy
 

--- a/src/uproot/behaviors/TProfile3D.py
+++ b/src/uproot/behaviors/TProfile3D.py
@@ -4,7 +4,6 @@
 This module defines the behavior of ``TProfile3D``.
 """
 
-from __future__ import absolute_import
 
 import numpy
 

--- a/src/uproot/behaviors/TTree.py
+++ b/src/uproot/behaviors/TTree.py
@@ -5,7 +5,6 @@ This module defines the behaviors of ``TTree``, which is almost entirely inherit
 functions in :doc:`uproot.behaviors.TBranch`.
 """
 
-from __future__ import absolute_import
 
 import uproot
 
@@ -28,9 +27,9 @@ class TTree(uproot.behaviors.TBranch.HasBranches):
 
     def __repr__(self):
         if len(self) == 0:
-            return "<TTree {0} at 0x{1:012x}>".format(repr(self.name), id(self))
+            return f"<TTree {repr(self.name)} at 0x{id(self):012x}>"
         else:
-            return "<TTree {0} ({1} branches) at 0x{2:012x}>".format(
+            return "<TTree {} ({} branches) at 0x{:012x}>".format(
                 repr(self.name), len(self), id(self)
             )
 
@@ -61,7 +60,7 @@ class TTree(uproot.behaviors.TBranch.HasBranches):
         String that uniquely specifies this ``TTree`` in its path, to use as
         part of object and array cache keys.
         """
-        return "{0}{1};{2}".format(
+        return "{}{};{}".format(
             self.parent.parent.cache_key, self.name, self.parent.fCycle
         )
 
@@ -120,7 +119,7 @@ class TTree(uproot.behaviors.TBranch.HasBranches):
 
     @property
     def aliases(self):
-        u"""
+        """
         The ``TTree``'s ``fAliases``, which are used as the ``aliases``
         argument to :ref:`uproot.behaviors.TBranch.HasBranches.arrays`,
         :ref:`uproot.behaviors.TBranch.HasBranches.iterate`,
@@ -134,9 +133,7 @@ class TTree(uproot.behaviors.TBranch.HasBranches):
         if aliases is None:
             return {}
         else:
-            return dict(
-                (alias.member("fName"), alias.member("fTitle")) for alias in aliases
-            )
+            return {alias.member("fName"): alias.member("fTitle") for alias in aliases}
 
     @property
     def chunk(self):

--- a/src/uproot/behaviors/TTree.py
+++ b/src/uproot/behaviors/TTree.py
@@ -27,7 +27,7 @@ class TTree(uproot.behaviors.TBranch.HasBranches):
 
     def __repr__(self):
         if len(self) == 0:
-            return f"<TTree {repr(self.name)} at 0x{id(self):012x}>"
+            return f"<TTree {self.name!r} at 0x{id(self):012x}>"
         else:
             return "<TTree {} ({} branches) at 0x{:012x}>".format(
                 repr(self.name), len(self), id(self)

--- a/src/uproot/behaviors/__init__.py
+++ b/src/uproot/behaviors/__init__.py
@@ -24,5 +24,3 @@ the newly created object specialized methods and properties.
 
 See also :doc:`uproot.models`.
 """
-
-from __future__ import absolute_import

--- a/src/uproot/cache.py
+++ b/src/uproot/cache.py
@@ -12,7 +12,6 @@ The :doc:`uproot.cache.LRUArrayCache` implements the same policy, limiting the
 total number of bytes, as reported by ``nbytes``.
 """
 
-from __future__ import absolute_import
 
 import threading
 from collections.abc import MutableMapping
@@ -69,8 +68,8 @@ class LRUCache(MutableMapping):
         if self._limit is None:
             limit = "(no limit)"
         else:
-            limit = "({0}/{1} full)".format(self._current, self._limit)
-        return "<LRUCache {0} at 0x{1:012x}>".format(limit, id(self))
+            limit = f"({self._current}/{self._limit} full)"
+        return f"<LRUCache {limit} at 0x{id(self):012x}>"
 
     @property
     def limit(self):
@@ -159,8 +158,7 @@ class LRUCache(MutableMapping):
     def __iter__(self):
         with self._lock:
             order = list(self._order)
-        for x in order:
-            yield x
+        yield from order
 
     def __len__(self):
         with self._lock:
@@ -216,14 +214,14 @@ class LRUArrayCache(LRUCache):
             limit = None
         else:
             limit = uproot._util.memory_size(limit_bytes)
-        super(LRUArrayCache, self).__init__(limit)
+        super().__init__(limit)
 
     def __repr__(self):
         if self._limit is None:
             limit = "(no limit)"
         else:
-            limit = "({0}/{1} bytes full)".format(self._current, self._limit)
-        return "<LRUArrayCache {0} at 0x{1:012x}>".format(limit, id(self))
+            limit = f"({self._current}/{self._limit} bytes full)"
+        return f"<LRUArrayCache {limit} at 0x{id(self):012x}>"
 
     @property
     def limit(self):

--- a/src/uproot/compression.py
+++ b/src/uproot/compression.py
@@ -5,7 +5,6 @@ This module defines an interface to compression algorithms used by ROOT, as well
 as functions for compressing and decompressing a :doc:`uproot.source.chunk.Chunk`.
 """
 
-from __future__ import absolute_import
 
 import struct
 
@@ -15,7 +14,7 @@ import uproot
 import uproot.const
 
 
-class Compression(object):
+class Compression:
     """
     Abstract class for objects that describe compression algorithms and levels.
     """
@@ -24,7 +23,7 @@ class Compression(object):
         self.level = level
 
     def __repr__(self):
-        return "{0}({1})".format(type(self).__name__, self._level)
+        return f"{type(self).__name__}({self._level})"
 
     @classmethod
     def from_code(cls, code):
@@ -45,9 +44,7 @@ class Compression(object):
         elif algorithm in algorithm_codes:
             return algorithm_codes[algorithm](level)
         else:
-            raise ValueError(
-                "unrecognized compression algorithm code: {0}".format(algorithm)
-            )
+            raise ValueError(f"unrecognized compression algorithm code: {algorithm}")
 
     @property
     def code(self):
@@ -68,7 +65,7 @@ class Compression(object):
             if type(self) is cls:
                 return const, self._level
         else:
-            raise ValueError("unrecognized compression type: {0}".format(type(self)))
+            raise ValueError(f"unrecognized compression type: {type(self)}")
 
     @property
     def level(self):
@@ -85,7 +82,7 @@ class Compression(object):
             return False
 
 
-class _DecompressZLIB(object):
+class _DecompressZLIB:
     name = "ZLIB"
     _2byte = b"ZL"
     _method = b"\x08"
@@ -133,7 +130,7 @@ class ZLIB(Compression, _DecompressZLIB):
         return zlib.compress(data, self._level)
 
 
-class _DecompressLZMA(object):
+class _DecompressLZMA:
     name = "LZMA"
     _2byte = b"XZ"
     _method = b"\x00"
@@ -181,7 +178,7 @@ class LZMA(Compression, _DecompressLZMA):
         return lzma.compress(data, preset=self._level)
 
 
-class _DecompressLZ4(object):
+class _DecompressLZ4:
     name = "LZ4"
     _2byte = b"L4"
     _method = b"\x01"
@@ -231,7 +228,7 @@ class LZ4(Compression, _DecompressLZ4):
         return lz4_block.compress(data, compression=self._level, store_size=False)
 
 
-class _DecompressZSTD(object):
+class _DecompressZSTD:
     name = "ZSTD"
     _2byte = b"ZS"
     _method = b"\x01"
@@ -381,8 +378,8 @@ def decompress(
             computed_checksum = xxhash.xxh64(data).intdigest()
             if computed_checksum != expected_checksum:
                 raise ValueError(
-                    """computed checksum {0} didn't match expected checksum {1}
-in file {2}""".format(
+                    """computed checksum {} didn't match expected checksum {}
+in file {}""".format(
                         computed_checksum, expected_checksum, chunk.source.file_path
                     )
                 )
@@ -393,17 +390,17 @@ in file {2}""".format(
 
         elif algo == b"CS":
             raise ValueError(
-                """unsupported compression algorithm: {0} (according to """
+                """unsupported compression algorithm: {} (according to """
                 """ROOT comments, it hasn't been used in 20 years!
-in file {1}""".format(
+in file {}""".format(
                     algo, chunk.source.file_path
                 )
             )
 
         else:
             raise ValueError(
-                """unrecognized compression algorithm: {0}
-in file {1}""".format(
+                """unrecognized compression algorithm: {}
+in file {}""".format(
                     algo, chunk.source.file_path
                 )
             )
@@ -419,10 +416,10 @@ in file {1}""".format(
 
         if len(uncompressed_bytestring) != block_uncompressed_bytes:
             raise ValueError(
-                """after successfully decompressing {0} blocks, a block of """
-                """compressed size {1} decompressed to {2} bytes, but the """
-                """block header expects {3} bytes.
-in file {4}""".format(
+                """after successfully decompressing {} blocks, a block of """
+                """compressed size {} decompressed to {} bytes, but the """
+                """block header expects {} bytes.
+in file {}""".format(
                     num_blocks,
                     block_compressed_bytes,
                     len(uncompressed_bytestring),

--- a/src/uproot/const.py
+++ b/src/uproot/const.py
@@ -4,7 +4,6 @@
 This module defines integer constants used by serialization and deserialization routines.
 """
 
-from __future__ import absolute_import
 
 import numpy
 

--- a/src/uproot/containers.py
+++ b/src/uproot/containers.py
@@ -331,11 +331,11 @@ class AsFIXME(AsContainer):
         return hash((AsFIXME, self.message))
 
     def __repr__(self):
-        return f"AsFIXME({repr(self.message)})"
+        return f"AsFIXME({self.message!r})"
 
     @property
     def cache_key(self):
-        return f"AsFIXME({repr(self.message)})"
+        return f"AsFIXME({self.message!r})"
 
     @property
     def typename(self):
@@ -412,12 +412,12 @@ class AsString(AsContainer):
     def __repr__(self):
         args = [repr(self._header)]
         if self._length_bytes != "1-5":
-            args.append(f"length_bytes={repr(self._length_bytes)}")
+            args.append(f"length_bytes={self._length_bytes!r}")
         return "AsString({})".format(", ".join(args))
 
     @property
     def cache_key(self):
-        return f"AsString({self._header},{repr(self._length_bytes)})"
+        return f"AsString({self._header},{self._length_bytes!r})"
 
     @property
     def typename(self):

--- a/src/uproot/containers.py
+++ b/src/uproot/containers.py
@@ -7,7 +7,6 @@ This module interpretations and models for standard containers, such as
 See :doc:`uproot.interpretation` and :doc:`uproot.model`.
 """
 
-from __future__ import absolute_import
 
 import struct
 import types
@@ -37,7 +36,7 @@ def _content_cache_key(content):
         bo = uproot.interpretation.numerical._numpy_byteorder_to_cache_key[
             content.byteorder
         ]
-        return "{0}{1}{2}".format(bo, content.kind, content.itemsize)
+        return f"{bo}{content.kind}{content.itemsize}"
     elif isinstance(content, type):
         return content.__name__
     else:
@@ -103,14 +102,14 @@ def _str_with_ellipsis(tostring, length, lbracket, rbracket, limit):
     elif done:
         return lbracket + "".join(left) + "".join(right) + rbracket
     elif len(left) == 0 and len(right) == 0:
-        return lbracket + "{0}, ...".format(tostring(0)) + rbracket
+        return lbracket + f"{tostring(0)}, ..." + rbracket
     elif len(right) == 0:
         return lbracket + "".join(left) + "..." + rbracket
     else:
         return lbracket + "".join(left) + "..., " + "".join(right) + rbracket
 
 
-class AsContainer(object):
+class AsContainer:
     """
     Abstract class for all descriptions of data as containers, such as
     ``std::vector``.
@@ -204,9 +203,7 @@ class AsContainer(object):
         if value is True or value is False:
             self._header = value
         else:
-            raise TypeError(
-                "{0}.header must be True or False".format(type(self).__name__)
-            )
+            raise TypeError(f"{type(self).__name__}.header must be True or False")
 
     def read(self, chunk, cursor, context, file, selffile, parent, header=True):
         """
@@ -271,14 +268,14 @@ class AsDynamic(AsContainer):
             model = "model=" + self._model.__name__
         else:
             model = "model=" + repr(self._model)
-        return "AsDynamic({0})".format(model)
+        return f"AsDynamic({model})"
 
     @property
     def cache_key(self):
         if self._model is None:
             return "AsDynamic(None)"
         else:
-            return "AsDynamic({0})".format(_content_cache_key(self._model))
+            return f"AsDynamic({_content_cache_key(self._model)})"
 
     @property
     def typename(self):
@@ -334,11 +331,11 @@ class AsFIXME(AsContainer):
         return hash((AsFIXME, self.message))
 
     def __repr__(self):
-        return "AsFIXME({0})".format(repr(self.message))
+        return f"AsFIXME({repr(self.message)})"
 
     @property
     def cache_key(self):
-        return "AsFIXME({0})".format(repr(self.message))
+        return f"AsFIXME({repr(self.message)})"
 
     @property
     def typename(self):
@@ -415,12 +412,12 @@ class AsString(AsContainer):
     def __repr__(self):
         args = [repr(self._header)]
         if self._length_bytes != "1-5":
-            args.append("length_bytes={0}".format(repr(self._length_bytes)))
-        return "AsString({0})".format(", ".join(args))
+            args.append(f"length_bytes={repr(self._length_bytes)}")
+        return "AsString({})".format(", ".join(args))
 
     @property
     def cache_key(self):
-        return "AsString({0},{1})".format(self._header, repr(self._length_bytes))
+        return f"AsString({self._header},{repr(self._length_bytes)})"
 
     @property
     def typename(self):
@@ -527,14 +524,14 @@ class AsPointer(AsContainer):
             pointee = self._pointee.__name__
         else:
             pointee = repr(self._pointee)
-        return "AsPointer({0})".format(pointee)
+        return f"AsPointer({pointee})"
 
     @property
     def cache_key(self):
         if self._pointee is None:
             return "AsPointer(None)"
         else:
-            return "AsPointer({0})".format(_content_cache_key(self._pointee))
+            return f"AsPointer({_content_cache_key(self._pointee)})"
 
     @property
     def typename(self):
@@ -615,13 +612,13 @@ class AsArray(AsContainer):
             values = self._values.__name__
         else:
             values = repr(self._values)
-        return "AsArray({0}, {1}, {2}, {3})".format(
+        return "AsArray({}, {}, {}, {})".format(
             self.header, self.speedbump, values, self.inner_shape
         )
 
     @property
     def cache_key(self):
-        return "AsArray({0},{1},{2},{3})".format(
+        return "AsArray({},{},{},{})".format(
             self.header,
             self.speedbump,
             _content_cache_key(self._values),
@@ -630,7 +627,7 @@ class AsArray(AsContainer):
 
     @property
     def typename(self):
-        shape = "".join("[{0}]".format(d) for d in self.inner_shape)
+        shape = "".join(f"[{d}]" for d in self.inner_shape)
         return _content_typename(self._values) + "[]" + shape
 
     def awkward_form(
@@ -671,8 +668,8 @@ class AsArray(AsContainer):
 
             if is_memberwise:
                 raise NotImplementedError(
-                    """memberwise serialization of {0}
-in file {1}""".format(
+                    """memberwise serialization of {}
+in file {}""".format(
                         type(self).__name__, selffile.file_path
                     )
                 )
@@ -759,17 +756,15 @@ class AsVector(AsContainer):
             values = self._values.__name__
         else:
             values = repr(self._values)
-        return "AsVector({0}, {1})".format(self._header, values)
+        return f"AsVector({self._header}, {values})"
 
     @property
     def cache_key(self):
-        return "AsVector({0},{1})".format(
-            self._header, _content_cache_key(self._values)
-        )
+        return f"AsVector({self._header},{_content_cache_key(self._values)})"
 
     @property
     def typename(self):
-        return "std::vector<{0}>".format(_content_typename(self._values))
+        return f"std::vector<{_content_typename(self._values)}>"
 
     def awkward_form(
         self,
@@ -806,16 +801,16 @@ class AsVector(AsContainer):
             # let's hard-code in logic for std::pair<T1,T2> for now
             if not _value_typename.startswith("pair"):
                 raise NotImplementedError(
-                    """memberwise serialization of {0}({1})
-    in file {2}""".format(
+                    """memberwise serialization of {}({})
+    in file {}""".format(
                         type(self).__name__, _value_typename, selffile.file_path
                     )
                 )
 
             if not issubclass(self._values, uproot.model.DispatchByVersion):
                 raise NotImplementedError(
-                    """streamerless memberwise serialization of class {0}({1})
-    in file {2}""".format(
+                    """streamerless memberwise serialization of class {}({})
+    in file {}""".format(
                         type(self).__name__, _value_typename, selffile.file_path
                     )
                 )
@@ -925,15 +920,15 @@ class AsSet(AsContainer):
             keys = self._keys.__name__
         else:
             keys = repr(self._keys)
-        return "AsSet({0}, {1})".format(self._header, keys)
+        return f"AsSet({self._header}, {keys})"
 
     @property
     def cache_key(self):
-        return "AsSet({0},{1})".format(self._header, _content_cache_key(self._keys))
+        return f"AsSet({self._header},{_content_cache_key(self._keys)})"
 
     @property
     def typename(self):
-        return "std::set<{0}>".format(_content_typename(self._keys))
+        return f"std::set<{_content_typename(self._keys)}>"
 
     def awkward_form(
         self,
@@ -968,8 +963,8 @@ class AsSet(AsContainer):
 
         if is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, selffile.file_path
                 )
             )
@@ -1077,11 +1072,11 @@ class AsMap(AsContainer):
             values = self._values.__name__
         else:
             values = repr(self._values)
-        return "AsMap({0}, {1}, {2})".format(self._header, keys, values)
+        return f"AsMap({self._header}, {keys}, {values})"
 
     @property
     def cache_key(self):
-        return "AsMap({0},{1},{2})".format(
+        return "AsMap({},{},{})".format(
             self._header,
             _content_cache_key(self._keys),
             _content_cache_key(self._values),
@@ -1089,7 +1084,7 @@ class AsMap(AsContainer):
 
     @property
     def typename(self):
-        return "std::map<{0}, {1}>".format(
+        return "std::map<{}, {}>".format(
             _content_typename(self._keys), _content_typename(self._values)
         )
 
@@ -1190,8 +1185,8 @@ class AsMap(AsContainer):
 
         else:
             raise NotImplementedError(
-                """non-memberwise serialization of {0}
-in file {1}""".format(
+                """non-memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, selffile.file_path
                 )
             )
@@ -1226,7 +1221,7 @@ in file {1}""".format(
             return False
 
 
-class Container(object):
+class Container:
     """
     Abstract class for Python representations of C++ STL collections.
     """
@@ -1267,7 +1262,7 @@ class STLVector(Container, Sequence):
         return _str_with_ellipsis(tostring, len(self), "[", "]", limit)
 
     def __repr__(self, limit=85):
-        return "<STLVector {0} at 0x{1:012x}>".format(
+        return "<STLVector {} at 0x{:012x}>".format(
             self.__str__(limit=limit - 30), id(self)
         )
 
@@ -1325,7 +1320,7 @@ class STLSet(Container, Set):
         return _str_with_ellipsis(tostring, len(self), "{", "}", limit)
 
     def __repr__(self, limit=85):
-        return "<STLSet {0} at 0x{1:012x}>".format(
+        return "<STLSet {} at 0x{:012x}>".format(
             self.__str__(limit=limit - 30), id(self)
         )
 
@@ -1365,9 +1360,9 @@ class STLSet(Container, Set):
             return numpy.all(keys_same)
 
     def tolist(self):
-        return set(
+        return {
             x.tolist() if isinstance(x, (Container, numpy.ndarray)) else x for x in self
-        )
+        }
 
 
 class STLMap(Container, Mapping):
@@ -1422,7 +1417,7 @@ class STLMap(Container, Mapping):
         return _str_with_ellipsis(tostring, len(self), "{", "}", limit)
 
     def __repr__(self, limit=85):
-        return "<STLMap {0} at 0x{1:012x}>".format(
+        return "<STLMap {} at 0x{:012x}>".format(
             self.__str__(limit=limit - 30), id(self)
         )
 

--- a/src/uproot/deserialization.py
+++ b/src/uproot/deserialization.py
@@ -8,7 +8,6 @@ This module defines low-level routines for deserialization, including
 previously read objects.
 """
 
-from __future__ import absolute_import
 
 import struct
 import sys
@@ -36,8 +35,7 @@ def _yield_all_behaviors(cls, c):
         yield behavior_cls
     if hasattr(cls, "base_names_versions"):
         for base_name, base_version in cls.base_names_versions:
-            for x in _yield_all_behaviors(c(base_name, base_version), c):
-                yield x
+            yield from _yield_all_behaviors(c(base_name, base_version), c)
 
 
 def compile_class(file, classes, class_code, class_name):
@@ -167,7 +165,7 @@ def numbytes_check(
         observed = stop_cursor.displacement(start_cursor)
         if observed != num_bytes:
             raise DeserializationError(
-                """expected {0} bytes but cursor moved by {1} bytes (through {2})""".format(
+                """expected {} bytes but cursor moved by {} bytes (through {})""".format(
                     num_bytes, observed, classname
                 ),
                 chunk,
@@ -291,11 +289,11 @@ def read_object_any(chunk, cursor, context, file, selffile, parent, as_class=Non
                 if getattr(file, "file_path", None) is None:
                     in_file = ""
                 else:
-                    in_file = "\n\nin file {0}".format(file.file_path)
+                    in_file = f"\n\nin file {file.file_path}"
                 raise DeserializationError(
-                    """invalid class-tag reference: {0}
+                    """invalid class-tag reference: {}
 
-    Known references: {1}{2}""".format(
+    Known references: {}{}""".format(
                         ref, ", ".join(str(x) for x in cursor.refs), in_file
                     ),
                     chunk,
@@ -354,7 +352,7 @@ class DeserializationError(Exception):
         last = None
         for obj in self.context.get("breadcrumbs", ()):
             lines.append(
-                "{0}{1} version {2} as {3}.{4} ({5} bytes)".format(
+                "{}{} version {} as {}.{} ({} bytes)".format(
                     indent,
                     obj.classname,
                     obj.instance_version,
@@ -365,9 +363,9 @@ class DeserializationError(Exception):
             )
             indent = indent + "    "
             for v in getattr(obj, "_bases", []):
-                lines.append("{0}(base): {1}".format(indent, repr(v)))
+                lines.append(f"{indent}(base): {repr(v)}")
             for k, v in getattr(obj, "_members", {}).items():
-                lines.append("{0}{1}: {2}".format(indent, k, repr(v)))
+                lines.append(f"{indent}{k}: {repr(v)}")
             last = obj
 
         if last is not None:
@@ -386,7 +384,7 @@ class DeserializationError(Exception):
                             base_names.append(classname + "?")
                 if len(base_names) != 0:
                     lines.append(
-                        "Base classes for {0}: {1}".format(
+                        "Base classes for {}: {}".format(
                             last.classname, ", ".join(base_names)
                         )
                     )
@@ -402,29 +400,29 @@ class DeserializationError(Exception):
                         member_names.append(n + "?")
                 if len(member_names) != 0:
                     lines.append(
-                        "Members for {0}: {1}".format(
+                        "Members for {}: {}".format(
                             last.classname, ", ".join(member_names)
                         )
                     )
 
         in_parent = ""
         if "TBranch" in self.context:
-            in_parent = "\nin TBranch {0}".format(self.context["TBranch"].object_path)
+            in_parent = "\nin TBranch {}".format(self.context["TBranch"].object_path)
         elif "TKey" in self.context:
-            in_parent = "\nin object {0}".format(self.context["TKey"].object_path)
+            in_parent = "\nin object {}".format(self.context["TKey"].object_path)
 
         if len(lines) == 0:
-            return """{0}
-in file {1}{2}""".format(
+            return """{}
+in file {}{}""".format(
                 self.message, self.file_path, in_parent
             )
         else:
             return """while reading
 
-{0}
+{}
 
-{1}
-in file {2}{3}""".format(
+{}
+in file {}{}""".format(
                 "\n".join(lines), self.message, self.file_path, in_parent
             )
 

--- a/src/uproot/deserialization.py
+++ b/src/uproot/deserialization.py
@@ -363,9 +363,9 @@ class DeserializationError(Exception):
             )
             indent = indent + "    "
             for v in getattr(obj, "_bases", []):
-                lines.append(f"{indent}(base): {repr(v)}")
+                lines.append(f"{indent}(base): {v!r}")
             for k, v in getattr(obj, "_members", {}).items():
-                lines.append(f"{indent}{k}: {repr(v)}")
+                lines.append(f"{indent}{k}: {v!r}")
             last = obj
 
         if last is not None:

--- a/src/uproot/exceptions.py
+++ b/src/uproot/exceptions.py
@@ -5,7 +5,6 @@ This module defines Uproot-specific exceptions, such as
 :doc:`uproot.exceptions.KeyInFileError`.
 """
 
-from __future__ import absolute_import
 
 import uproot
 
@@ -33,7 +32,7 @@ class KeyInFileError(KeyError):
     def __init__(
         self, key, because="", cycle=None, keys=None, file_path=None, object_path=None
     ):
-        super(KeyInFileError, self).__init__(key)
+        super().__init__(key)
         self.key = key
         self.because = because
         self.cycle = cycle
@@ -63,25 +62,25 @@ class KeyInFileError(KeyError):
                     break
             if to_show is None:
                 to_show = "(none!)"
-            with_keys = "\n\n    Available keys: {0}\n".format(to_show)
+            with_keys = f"\n\n    Available keys: {to_show}\n"
 
         in_file = ""
         if self.file_path is not None:
-            in_file = "\nin file {0}".format(self.file_path)
+            in_file = f"\nin file {self.file_path}"
 
         in_object = ""
         if self.object_path is not None:
-            in_object = "\nin object {0}".format(self.object_path)
+            in_object = f"\nin object {self.object_path}"
 
         if self.cycle == "any":
-            return """not found: {0} (with any cycle number){1}{2}{3}{4}""".format(
+            return """not found: {} (with any cycle number){}{}{}{}""".format(
                 repr(self.key), because, with_keys, in_file, in_object
             )
         elif self.cycle is None:
-            return """not found: {0}{1}{2}{3}{4}""".format(
+            return """not found: {}{}{}{}{}""".format(
                 repr(self.key), because, with_keys, in_file, in_object
             )
         else:
-            return """not found: {0} with cycle {1}{2}{3}{4}{5}""".format(
+            return """not found: {} with cycle {}{}{}{}{}""".format(
                 repr(self.key), self.cycle, because, with_keys, in_file, in_object
             )

--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -4,7 +4,7 @@
 This module defines functions that import external libraries used by Uproot, but not
 required by an Uproot installation. (Uproot only requires NumPy).
 
-If a library cannot be imported, these functions raise ``ImportError`` with
+If a library cannot be imported, these functions raise ``ModuleNotFoundError`` with
 error messages containing instructions on how to install the library.
 """
 
@@ -22,8 +22,8 @@ def awkward():
     """
     try:
         import awkward
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """install the 'awkward' package with:
 
     pip install awkward
@@ -35,7 +35,7 @@ to output as NumPy arrays, rather than Awkward arrays.
     if LooseVersion("1") < LooseVersion(awkward.__version__) < LooseVersion("2"):
         return awkward
     else:
-        raise ImportError(
+        raise ModuleNotFoundError(
             "Uproot 4.x can only be used with Awkward 1.x; you have Awkward {}".format(
                 awkward.__version__
             )
@@ -48,8 +48,8 @@ def pandas():
     """
     try:
         import pandas
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """install the 'pandas' package with:
 
     pip install pandas
@@ -73,8 +73,8 @@ def XRootD_client():
         import XRootD
         import XRootD.client
 
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """Install XRootD python bindings with:
 
     conda install -c conda-forge xrootd
@@ -146,27 +146,9 @@ def lzma():
     Imports and returns ``lzma`` (which is part of the Python 3 standard
     library, but not Python 2).
     """
-    try:
-        import lzma
-    except ImportError:
-        try:
-            import backports.lzma as lzma
-        except ImportError:
-            raise ImportError(
-                """install the 'lzma' package with:
+    import lzma
 
-    pip install backports.lzma
-
-or
-
-    conda install backports.lzma
-
-or use Python >= 3.3."""
-            )
-        else:
-            return lzma
-    else:
-        return lzma
+    return lzma
 
 
 def lz4_block():
@@ -178,8 +160,8 @@ def lz4_block():
     try:
         import lz4.block
         import xxhash  # noqa: F401
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """install the 'lz4' and `xxhash` packages with:
 
     pip install lz4 xxhash
@@ -201,8 +183,8 @@ def xxhash():
     try:
         import lz4.block  # noqa: F401
         import xxhash
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """install the 'lz4' and `xxhash` packages with:
 
     pip install lz4 xxhash
@@ -221,8 +203,8 @@ def zstandard():
     """
     try:
         import zstandard
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """install the 'zstandard' package with:
 
     pip install zstandard
@@ -241,8 +223,8 @@ def boost_histogram():
     """
     try:
         import boost_histogram
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """install the 'boost-histogram' package with:
 
     pip install boost-histogram
@@ -261,8 +243,8 @@ def hist():
     """
     try:
         import hist
-    except ImportError:
-        raise ImportError(
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
             """install the 'hist' package with:
 
     pip install hist"""

--- a/src/uproot/extras.py
+++ b/src/uproot/extras.py
@@ -8,7 +8,6 @@ If a library cannot be imported, these functions raise ``ImportError`` with
 error messages containing instructions on how to install the library.
 """
 
-from __future__ import absolute_import
 
 import atexit
 import os
@@ -37,7 +36,7 @@ to output as NumPy arrays, rather than Awkward arrays.
         return awkward
     else:
         raise ImportError(
-            "Uproot 4.x can only be used with Awkward 1.x; you have Awkward {0}".format(
+            "Uproot 4.x can only be used with Awkward 1.x; you have Awkward {}".format(
                 awkward.__version__
             )
         )

--- a/src/uproot/interpretation/__init__.py
+++ b/src/uproot/interpretation/__init__.py
@@ -11,10 +11,8 @@ that determine the default interpretation of a
 :doc:`uproot.behaviors.TBranch.TBranch`.
 """
 
-from __future__ import absolute_import
 
-
-class Interpretation(object):
+class Interpretation:
     """
     Abstract class for all interpretations of ``TBranch`` data as arrays.
 
@@ -117,7 +115,7 @@ class Interpretation(object):
     def final_array(
         self, basket_arrays, entry_start, entry_stop, entry_offsets, library, branch
     ):
-        u"""
+        """
         Args:
             basket_arrays (dict of int \u2192 array): Mapping from ``TBasket``
                 number to the temporary array returned by

--- a/src/uproot/interpretation/grouped.py
+++ b/src/uproot/interpretation/grouped.py
@@ -6,13 +6,12 @@ temporary array for grouped data; usually applied to a ``TBranch`` that does
 not contain data but has subbranches that do.
 """
 
-from __future__ import absolute_import
 
 import uproot
 
 
 class AsGrouped(uproot.interpretation.Interpretation):
-    u"""
+    """
     Args:
         branch (:doc:`uproot.behaviors.TBranch.TBranch`): The ``TBranch`` that
             represents the group.
@@ -51,7 +50,7 @@ class AsGrouped(uproot.interpretation.Interpretation):
         return self._subbranches
 
     def __repr__(self):
-        return "AsGroup({0}, {1})".format(self._branch, self._subbranches)
+        return f"AsGroup({self._branch}, {self._subbranches})"
 
     def __eq__(self, other):
         return (
@@ -62,11 +61,11 @@ class AsGrouped(uproot.interpretation.Interpretation):
 
     @property
     def cache_key(self):
-        return "{0}({1},[{2}])".format(
+        return "{}({},[{}])".format(
             type(self).__name__,
             self._branch.name,
             ",".join(
-                "{0}:{1}".format(repr(x), y.cache_key)
+                f"{repr(x)}:{y.cache_key}"
                 for x, y in self._subbranches.items()
                 if y is not None
             ),
@@ -77,9 +76,9 @@ class AsGrouped(uproot.interpretation.Interpretation):
         if self._typename is not None:
             return self._typename
         else:
-            return "(group of {0})".format(
+            return "(group of {})".format(
                 ", ".join(
-                    "{0}:{1}".format(x, y.typename)
+                    f"{x}:{y.typename}"
                     for x, y in self._subbranches.items()
                     if y is not None
                 )
@@ -110,12 +109,12 @@ class AsGrouped(uproot.interpretation.Interpretation):
         self, data, byte_offsets, basket, branch, context, cursor_offset, library
     ):
         raise ValueError(
-            """grouping branches like {0} should not be read directly; instead read the subbranches:
+            """grouping branches like {} should not be read directly; instead read the subbranches:
 
-    {1}
+    {}
 
-in file {2}
-in object {3}""".format(
+in file {}
+in object {}""".format(
                 repr(self._branch.name),
                 ", ".join(repr(x) for x in self._subbranches),
                 self._branch.file.file_path,
@@ -127,12 +126,12 @@ in object {3}""".format(
         self, basket_arrays, entry_start, entry_stop, entry_offsets, library, branch
     ):
         raise ValueError(
-            """grouping branches like {0} should not be read directly; instead read the subbranches:
+            """grouping branches like {} should not be read directly; instead read the subbranches:
 
-    {1}
+    {}
 
-in file {2}
-in object {3}""".format(
+in file {}
+in object {}""".format(
                 repr(self._branch.name),
                 ", ".join(repr(x) for x in self._subbranches),
                 self._branch.file.file_path,

--- a/src/uproot/interpretation/grouped.py
+++ b/src/uproot/interpretation/grouped.py
@@ -65,7 +65,7 @@ class AsGrouped(uproot.interpretation.Interpretation):
             type(self).__name__,
             self._branch.name,
             ",".join(
-                f"{repr(x)}:{y.cache_key}"
+                f"{x!r}:{y.cache_key}"
                 for x, y in self._subbranches.items()
                 if y is not None
             ),

--- a/src/uproot/interpretation/identify.py
+++ b/src/uproot/interpretation/identify.py
@@ -12,7 +12,6 @@ observed in ROOT files (perhaps forever), unless a systematic study can be
 performed to exhaustively discover all cases.
 """
 
-from __future__ import absolute_import
 
 import ast
 import re
@@ -212,7 +211,7 @@ def _float16_double32_walk_ast(node, branch, source):
             )
         else:
             raise UnknownInterpretation(
-                "cannot compute streamer title {0}".format(repr(source)),
+                f"cannot compute streamer title {repr(source)}",
                 branch.file.file_path,
                 branch.object_path,
             )
@@ -221,7 +220,7 @@ def _float16_double32_walk_ast(node, branch, source):
 
     else:
         raise UnknownInterpretation(
-            "cannot compute streamer title {0}".format(repr(source)),
+            f"cannot compute streamer title {repr(source)}",
             branch.file.file_path,
             branch.object_path,
         )
@@ -248,7 +247,7 @@ def _float16_or_double32(branch, context, leaf, is_float16, dims):
             parsed = ast.parse(source).body[0].value
         except SyntaxError:
             raise UnknownInterpretation(
-                "cannot parse streamer title {0} (as Python)".format(repr(source)),
+                f"cannot parse streamer title {repr(source)} (as Python)",
                 branch.file.file_path,
                 branch.object_path,
             )
@@ -273,7 +272,7 @@ def _float16_or_double32(branch, context, leaf, is_float16, dims):
 
         else:
             raise UnknownInterpretation(
-                "cannot interpret streamer title {0} as (low, high) or "
+                "cannot interpret streamer title {} as (low, high) or "
                 "(low, high, num_bits)".format(repr(source)),
                 branch.file.file_path,
                 branch.object_path,
@@ -322,7 +321,7 @@ def interpretation_of(branch, context, simplify=True):
             typename = str(branch.streamer.typename)
         else:
             typename = None
-        subbranches = dict((x.name, x.interpretation) for x in branch.branches)
+        subbranches = {x.name: x.interpretation for x in branch.branches}
 
         if typename == "TClonesArray":
             return uproot.interpretation.numerical.AsDtype(">i4")
@@ -449,7 +448,7 @@ def interpretation_of(branch, context, simplify=True):
 
         elif len(branch.member("fLeaves")) > 1:
             raise UnknownInterpretation(
-                "more than one TLeaf ({0}) in a non-numerical TBranch".format(
+                "more than one TLeaf ({}) in a non-numerical TBranch".format(
                     len(branch.member("fLeaves"))
                 ),
                 branch.file.file_path,
@@ -536,12 +535,12 @@ def _simplify_token(token, is_token=True):
 def _parse_error(pos, typename, file):
     in_file = ""
     if file is not None:
-        in_file = "\nin file {0}".format(file.file_path)
+        in_file = f"\nin file {file.file_path}"
     raise ValueError(
-        """invalid C++ type name syntax at char {0}
+        """invalid C++ type name syntax at char {}
 
-    {1}
-{2}{3}""".format(
+    {}
+{}{}""".format(
             pos, typename, "-" * (4 + pos) + "^", in_file
         )
     )
@@ -589,9 +588,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype("?"))'.format(
-                    header
-                ),
+                f'uproot.containers.AsArray(False, {header}, numpy.dtype("?"))',
                 quote,
             ),
         )
@@ -599,9 +596,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype("?"))'.format(
-                    header
-                ),
+                f'uproot.containers.AsArray(False, {header}, numpy.dtype("?"))',
                 quote,
             ),
         )
@@ -619,7 +614,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype("u1"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype("u1"))'.format(
                     header
                 ),
                 quote,
@@ -633,7 +628,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 2,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype("u1"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype("u1"))'.format(
                     header
                 ),
                 quote,
@@ -655,7 +650,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">i2"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">i2"))'.format(
                     header
                 ),
                 quote,
@@ -665,7 +660,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">i2"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">i2"))'.format(
                     header
                 ),
                 quote,
@@ -675,7 +670,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">u2"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">u2"))'.format(
                     header
                 ),
                 quote,
@@ -689,7 +684,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 2,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">u2"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">u2"))'.format(
                     header
                 ),
                 quote,
@@ -709,7 +704,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">i4"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">i4"))'.format(
                     header
                 ),
                 quote,
@@ -719,7 +714,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">i4"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">i4"))'.format(
                     header
                 ),
                 quote,
@@ -729,7 +724,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">u4"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">u4"))'.format(
                     header
                 ),
                 quote,
@@ -743,7 +738,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 2,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">u4"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">u4"))'.format(
                     header
                 ),
                 quote,
@@ -781,7 +776,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 2,
             _parse_maybe_quote(
-                'uproot.containers.AsArray({0}, numpy.dtype(">i8"))'.format(header),
+                f'uproot.containers.AsArray({header}, numpy.dtype(">i8"))',
                 quote,
             ),
         )
@@ -794,7 +789,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 3,
             _parse_maybe_quote(
-                'uproot.containers.AsArray({0}, numpy.dtype(">u8"))'.format(header),
+                f'uproot.containers.AsArray({header}, numpy.dtype(">u8"))',
                 quote,
             ),
         )
@@ -803,7 +798,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">i8"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">i8"))'.format(
                     header
                 ),
                 quote,
@@ -813,7 +808,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">i8"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">i8"))'.format(
                     header
                 ),
                 quote,
@@ -823,7 +818,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">i8"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">i8"))'.format(
                     header
                 ),
                 quote,
@@ -833,7 +828,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">u8"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">u8"))'.format(
                     header
                 ),
                 quote,
@@ -843,7 +838,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">u8"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">u8"))'.format(
                     header
                 ),
                 quote,
@@ -857,7 +852,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 2,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">u8"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">u8"))'.format(
                     header
                 ),
                 quote,
@@ -873,7 +868,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">f4"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">f4"))'.format(
                     header
                 ),
                 quote,
@@ -883,7 +878,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">f4"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">f4"))'.format(
                     header
                 ),
                 quote,
@@ -899,7 +894,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">f8"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">f8"))'.format(
                     header
                 ),
                 quote,
@@ -909,7 +904,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                'uproot.containers.AsArray(False, {0}, numpy.dtype(">f8"))'.format(
+                'uproot.containers.AsArray(False, {}, numpy.dtype(">f8"))'.format(
                     header
                 ),
                 quote,
@@ -928,7 +923,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                "uproot.containers.AsArray(False, {0}, "
+                "uproot.containers.AsArray(False, {}, "
                 'uproot.containers.AsFIXME("Float16_t in array"))'.format(header),
                 quote,
             ),
@@ -946,7 +941,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 1,
             _parse_maybe_quote(
-                "uproot.containers.AsArray(False, {0}, "
+                "uproot.containers.AsArray(False, {}, "
                 'uproot.containers.AsFIXME("Double32_t in array '
                 '(note: Event.root fClosestDistance has an example)"))'.format(header),
                 quote,
@@ -956,7 +951,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
     elif tokens[i].group(0) == "string" or _simplify_token(tokens[i]) == "std::string":
         return (
             i + 1,
-            _parse_maybe_quote("uproot.containers.AsString({0})".format(header), quote),
+            _parse_maybe_quote(f"uproot.containers.AsString({header})", quote),
         )
     elif tokens[i].group(0) == "TString":
         return (
@@ -998,7 +993,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         return (
             i + 4,
             _parse_maybe_quote(
-                'uproot.containers.AsFIXME("std::bitset<{0}>")'.format(num_bits),
+                f'uproot.containers.AsFIXME("std::bitset<{num_bits}>")',
                 quote,
             ),
         )
@@ -1013,7 +1008,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         if quote:
             return (
                 i + 1,
-                "uproot.containers.AsVector({0}, {1})".format(header, values),
+                f"uproot.containers.AsVector({header}, {values})",
             )
         else:
             return i + 1, uproot.containers.AsVector(header, values)
@@ -1026,7 +1021,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         i = _parse_ignore_extra_arguments(tokens, i, typename, file, 2)
         _parse_expect(">", tokens, i, typename, file)
         if quote:
-            return i + 1, "uproot.containers.AsSet({0}, {1})".format(header, keys)
+            return i + 1, f"uproot.containers.AsSet({header}, {keys})"
         else:
             return i + 1, uproot.containers.AsSet(header, keys)
 
@@ -1044,7 +1039,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
         if quote:
             return (
                 i + 1,
-                "uproot.containers.AsMap({0}, {1}, {2})".format(header, keys, values),
+                f"uproot.containers.AsMap({header}, {keys}, {values})",
             )
         else:
             return i + 1, uproot.containers.AsMap(header, keys, values)
@@ -1072,9 +1067,9 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
             classname = classname[:-1]
 
         if quote:
-            cls = "c({0})".format(repr(classname))
+            cls = f"c({repr(classname)})"
             for _ in range(pointers):
-                cls = "uproot.containers.AsPointer({0})".format(cls)
+                cls = f"uproot.containers.AsPointer({cls})"
         elif file is None:
             cls = uproot.classes[classname]
             for _ in range(pointers):
@@ -1166,12 +1161,12 @@ class UnknownInterpretation(Exception):
         self.object_path = object_path
 
     def __repr__(self):
-        return "<UnknownInterpretation {0}>".format(repr(self.reason))
+        return f"<UnknownInterpretation {repr(self.reason)}>"
 
     def __str__(self):
-        return """{0}
-in file {1}
-in object {2}""".format(
+        return """{}
+in file {}
+in object {}""".format(
             self.reason, self.file_path, self.object_path
         )
 

--- a/src/uproot/interpretation/identify.py
+++ b/src/uproot/interpretation/identify.py
@@ -211,7 +211,7 @@ def _float16_double32_walk_ast(node, branch, source):
             )
         else:
             raise UnknownInterpretation(
-                f"cannot compute streamer title {repr(source)}",
+                f"cannot compute streamer title {source!r}",
                 branch.file.file_path,
                 branch.object_path,
             )
@@ -220,7 +220,7 @@ def _float16_double32_walk_ast(node, branch, source):
 
     else:
         raise UnknownInterpretation(
-            f"cannot compute streamer title {repr(source)}",
+            f"cannot compute streamer title {source!r}",
             branch.file.file_path,
             branch.object_path,
         )
@@ -247,7 +247,7 @@ def _float16_or_double32(branch, context, leaf, is_float16, dims):
             parsed = ast.parse(source).body[0].value
         except SyntaxError:
             raise UnknownInterpretation(
-                f"cannot parse streamer title {repr(source)} (as Python)",
+                f"cannot parse streamer title {source!r} (as Python)",
                 branch.file.file_path,
                 branch.object_path,
             )
@@ -1067,7 +1067,7 @@ def _parse_node(tokens, i, typename, file, quote, header, inner_header):
             classname = classname[:-1]
 
         if quote:
-            cls = f"c({repr(classname)})"
+            cls = f"c({classname!r})"
             for _ in range(pointers):
                 cls = f"uproot.containers.AsPointer({cls})"
         elif file is None:
@@ -1161,7 +1161,7 @@ class UnknownInterpretation(Exception):
         self.object_path = object_path
 
     def __repr__(self):
-        return f"<UnknownInterpretation {repr(self.reason)}>"
+        return f"<UnknownInterpretation {self.reason!r}>"
 
     def __str__(self):
         return """{}

--- a/src/uproot/interpretation/jagged.py
+++ b/src/uproot/interpretation/jagged.py
@@ -9,7 +9,6 @@ an array is being built from ``TBaskets``. Its final form is determined by
 :doc:`uproot.interpretation.library`.
 """
 
-from __future__ import absolute_import
 
 import numpy
 
@@ -88,9 +87,9 @@ class AsJagged(uproot.interpretation.Interpretation):
 
     def __repr__(self):
         if self._header_bytes == 0:
-            return "AsJagged({0})".format(repr(self._content))
+            return f"AsJagged({repr(self._content)})"
         else:
-            return "AsJagged({0}, header_bytes={1})".format(
+            return "AsJagged({}, header_bytes={})".format(
                 repr(self._content), self._header_bytes
             )
 
@@ -124,7 +123,7 @@ class AsJagged(uproot.interpretation.Interpretation):
 
     @property
     def cache_key(self):
-        return "{0}({1},{2})".format(
+        return "{}({},{})".format(
             type(self).__name__, self._content.cache_key, self._header_bytes
         )
 
@@ -331,7 +330,7 @@ class AsJagged(uproot.interpretation.Interpretation):
         return output
 
 
-class JaggedArray(object):
+class JaggedArray:
     """
     Args:
         offsets (array of ``numpy.int32``): Starting and stopping entries for
@@ -351,7 +350,7 @@ class JaggedArray(object):
         self._content = content
 
     def __repr__(self):
-        return "JaggedArray({0}, {1})".format(self._offsets, self._content)
+        return f"JaggedArray({self._offsets}, {self._content})"
 
     @property
     def offsets(self):

--- a/src/uproot/interpretation/jagged.py
+++ b/src/uproot/interpretation/jagged.py
@@ -87,7 +87,7 @@ class AsJagged(uproot.interpretation.Interpretation):
 
     def __repr__(self):
         if self._header_bytes == 0:
-            return f"AsJagged({repr(self._content)})"
+            return f"AsJagged({self._content!r})"
         else:
             return "AsJagged({}, header_bytes={})".format(
                 repr(self._content), self._header_bytes

--- a/src/uproot/interpretation/numerical.py
+++ b/src/uproot/interpretation/numerical.py
@@ -16,7 +16,6 @@ several numerical types:
   for some ``N``.
 """
 
-from __future__ import absolute_import
 
 import numpy
 
@@ -183,9 +182,9 @@ class AsDtype(Numerical):
 
     def __repr__(self):
         if self._to_dtype == self._from_dtype.newbyteorder("="):
-            return "AsDtype({0})".format(repr(str(self._from_dtype)))
+            return f"AsDtype({repr(str(self._from_dtype))})"
         else:
-            return "AsDtype({0}, {1})".format(
+            return "AsDtype({}, {})".format(
                 repr(str(self._from_dtype)), repr(str(self._to_dtype))
             )
 
@@ -271,7 +270,7 @@ class AsDtype(Numerical):
     def cache_key(self):
         def form(dtype, name):
             d, s = _dtype_shape(dtype)
-            return "{0}{1}{2}({3}{4})".format(
+            return "{}{}{}({}{})".format(
                 _numpy_byteorder_to_cache_key[d.byteorder],
                 d.kind,
                 d.itemsize,
@@ -302,7 +301,7 @@ class AsDtype(Numerical):
                 + "]"
             )
 
-        return "{0}({1},{2})".format(type(self).__name__, from_dtype, to_dtype)
+        return f"{type(self).__name__}({from_dtype},{to_dtype})"
 
     @property
     def typename(self):
@@ -318,8 +317,7 @@ class AsDtype(Numerical):
             return (
                 "struct {"
                 + " ".join(
-                    "{0} {1};".format(form(self.from_dtype[n]), n)
-                    for n in self.from_dtype.names
+                    f"{form(self.from_dtype[n])} {n};" for n in self.from_dtype.names
                 )
                 + "}"
             )
@@ -342,9 +340,9 @@ class AsDtype(Numerical):
             output = data.view(dtype).reshape((-1,) + shape)
         except ValueError:
             raise ValueError(
-                """basket {0} in tree/branch {1} has the wrong number of bytes ({2}) """
-                """for interpretation {3}
-in file {4}""".format(
+                """basket {} in tree/branch {} has the wrong number of bytes ({}) """
+                """for interpretation {}
+in file {}""".format(
                     basket.basket_num,
                     branch.object_path,
                     len(data),
@@ -505,8 +503,8 @@ class TruncatedNumerical(Numerical):
     def __repr__(self):
         args = [repr(self._low), repr(self._high), repr(self._num_bits)]
         if self._to_dims != ():
-            args.append("to_dims={0}".format(repr(self._to_dims)))
-        return "{0}({1})".format(type(self).__name__, ", ".join(args))
+            args.append(f"to_dims={repr(self._to_dims)}")
+        return "{}({})".format(type(self).__name__, ", ".join(args))
 
     def __eq__(self, other):
         return (
@@ -523,7 +521,7 @@ class TruncatedNumerical(Numerical):
 
     @property
     def cache_key(self):
-        return "{0}({1},{2},{3},{4})".format(
+        return "{}({},{},{},{})".format(
             type(self).__name__, self._low, self._high, self._num_bits, self._to_dims
         )
 
@@ -544,9 +542,9 @@ class TruncatedNumerical(Numerical):
             raw = data.view(self.from_dtype)
         except ValueError:
             raise ValueError(
-                """basket {0} in tree/branch {1} has the wrong number of bytes ({2}) """
-                """for interpretation {3} (expecting raw array of {4})
-in file {5}""".format(
+                """basket {} in tree/branch {} has the wrong number of bytes ({}) """
+                """for interpretation {} (expecting raw array of {})
+in file {}""".format(
                     basket.basket_num,
                     branch.object_path,
                     len(data),
@@ -617,9 +615,7 @@ class AsDouble32(TruncatedNumerical):
         if not uproot._util.isint(num_bits) or not 2 <= num_bits <= 32:
             raise TypeError("num_bits must be an integer between 2 and 32 (inclusive)")
         if high <= low and not self.is_truncated:
-            raise ValueError(
-                "high ({0}) must be strictly greater than low ({1})".format(high, low)
-            )
+            raise ValueError(f"high ({high}) must be strictly greater than low ({low})")
 
     @property
     def to_dtype(self):
@@ -685,9 +681,7 @@ class AsFloat16(TruncatedNumerical):
         if not uproot._util.isint(num_bits) or not 2 <= num_bits <= 32:
             raise TypeError("num_bits must be an integer between 2 and 32 (inclusive)")
         if high <= low and not self.is_truncated:
-            raise ValueError(
-                "high ({0}) must be strictly greater than low ({1})".format(high, low)
-            )
+            raise ValueError(f"high ({high}) must be strictly greater than low ({low})")
 
     @property
     def to_dtype(self):

--- a/src/uproot/interpretation/numerical.py
+++ b/src/uproot/interpretation/numerical.py
@@ -503,7 +503,7 @@ class TruncatedNumerical(Numerical):
     def __repr__(self):
         args = [repr(self._low), repr(self._high), repr(self._num_bits)]
         if self._to_dims != ():
-            args.append(f"to_dims={repr(self._to_dims)}")
+            args.append(f"to_dims={self._to_dims!r}")
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
     def __eq__(self, other):

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -19,7 +19,6 @@ while an array is being built from ``TBaskets``. Its final form is determined
 by the :doc:`uproot.interpretation.library.Library`.
 """
 
-from __future__ import absolute_import
 
 import numpy
 
@@ -84,7 +83,7 @@ class AsObjects(uproot.interpretation.Interpretation):
             model = self._model.__name__
         else:
             model = repr(self._model)
-        return "AsObjects({0})".format(model)
+        return f"AsObjects({model})"
 
     def __eq__(self, other):
         return isinstance(other, AsObjects) and self._model == other._model
@@ -96,7 +95,7 @@ class AsObjects(uproot.interpretation.Interpretation):
     @property
     def cache_key(self):
         content_key = uproot.containers._content_cache_key(self._model)
-        return "{0}({1})".format(type(self).__name__, content_key)
+        return f"{type(self).__name__}({content_key})"
 
     @property
     def typename(self):
@@ -392,7 +391,7 @@ class AsStridedObjects(uproot.interpretation.numerical.AsDtype):
         self._model = model
         self._members = members
         self._original = original
-        super(AsStridedObjects, self).__init__(_unravel_members(members))
+        super().__init__(_unravel_members(members))
 
     @property
     def model(self):
@@ -423,11 +422,11 @@ class AsStridedObjects(uproot.interpretation.numerical.AsDtype):
 
     def __repr__(self):
         if self.inner_shape:
-            return "AsStridedObjects({0}, {1})".format(
+            return "AsStridedObjects({}, {})".format(
                 self._model.__name__, self.inner_shape
             )
         else:
-            return "AsStridedObjects({0})".format(self._model.__name__)
+            return f"AsStridedObjects({self._model.__name__})"
 
     def __eq__(self, other):
         return isinstance(other, AsStridedObjects) and self._model == other._model
@@ -462,7 +461,7 @@ class AsStridedObjects(uproot.interpretation.numerical.AsDtype):
 
     @property
     def cache_key(self):
-        return "{0}({1})".format(type(self).__name__, self._model.__name__)
+        return f"{type(self).__name__}({self._model.__name__})"
 
     @property
     def typename(self):
@@ -496,7 +495,7 @@ class CannotBeAwkward(Exception):
         self.because = because
 
 
-class ObjectArray(object):
+class ObjectArray:
     """
     Args:
         model (:doc:`uproot.model.Model` or :doc:`uproot.containers.AsContainer`): The
@@ -531,7 +530,7 @@ class ObjectArray(object):
         self._detached_file = self._branch.file.detached
 
     def __repr__(self):
-        return "ObjectArray({0}, {1}, {2}, {3}, {4}, {5})".format(
+        return "ObjectArray({}, {}, {}, {}, {}, {})".format(
             self._model,
             self._branch,
             self._context,
@@ -657,7 +656,7 @@ def _strided_object(path, interpretation, data):
     return out
 
 
-class StridedObjectArray(object):
+class StridedObjectArray:
     """
     Args:
         interpretation (:doc:`uproot.interpretation.objects.AsStridedObjects`): The
@@ -699,7 +698,7 @@ class StridedObjectArray(object):
         return self._array.shape
 
     def __repr__(self):
-        return "StridedObjectArray({0}, {1})".format(self._interpretation, self._array)
+        return f"StridedObjectArray({self._interpretation}, {self._array})"
 
     def __len__(self):
         return len(self._array)

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -36,7 +36,7 @@ def awkward_can_optimize(interpretation, form):
     """
     try:
         import awkward._connect._uproot
-    except ImportError:
+    except ModuleNotFoundError:
         return False
     else:
         return awkward._connect._uproot.can_optimize(interpretation, form)

--- a/src/uproot/interpretation/strings.py
+++ b/src/uproot/interpretation/strings.py
@@ -98,7 +98,7 @@ class AsStrings(uproot.interpretation.Interpretation):
         if self._header_bytes != 0:
             args.append(f"header_bytes={self._header_bytes}")
         if self._length_bytes != "1-5":
-            args.append(f"length_bytes={repr(self._length_bytes)}")
+            args.append(f"length_bytes={self._length_bytes!r}")
         return "AsStrings({})".format(", ".join(args))
 
     def __eq__(self, other):

--- a/src/uproot/interpretation/strings.py
+++ b/src/uproot/interpretation/strings.py
@@ -13,7 +13,6 @@ an array is being built from ``TBaskets``. Its final form is determined by the
 :doc:`uproot.interpretation.library.Library`.
 """
 
-from __future__ import absolute_import
 
 import struct
 
@@ -97,10 +96,10 @@ class AsStrings(uproot.interpretation.Interpretation):
     def __repr__(self):
         args = []
         if self._header_bytes != 0:
-            args.append("header_bytes={0}".format(self._header_bytes))
+            args.append(f"header_bytes={self._header_bytes}")
         if self._length_bytes != "1-5":
-            args.append("length_bytes={0}".format(repr(self._length_bytes)))
-        return "AsStrings({0})".format(", ".join(args))
+            args.append(f"length_bytes={repr(self._length_bytes)}")
+        return "AsStrings({})".format(", ".join(args))
 
     def __eq__(self, other):
         return (
@@ -144,7 +143,7 @@ class AsStrings(uproot.interpretation.Interpretation):
 
     @property
     def cache_key(self):
-        return "{0}({1},{2})".format(
+        return "{}({},{})".format(
             type(self).__name__, self._header_bytes, repr(self._length_bytes)
         )
 
@@ -351,7 +350,7 @@ class AsStrings(uproot.interpretation.Interpretation):
         return output
 
 
-class StringArray(object):
+class StringArray:
     """
     Args:
         offsets (array of ``numpy.int32``): Starting and stopping indexes for
@@ -376,7 +375,7 @@ class StringArray(object):
             content = repr(left) + " ... " + repr(right)
         else:
             content = repr(self._content)
-        return "StringArray({0}, {1})".format(self._offsets, content)
+        return f"StringArray({self._offsets}, {content})"
 
     @property
     def offsets(self):

--- a/src/uproot/language/__init__.py
+++ b/src/uproot/language/__init__.py
@@ -9,10 +9,8 @@ The default is :doc:`uproot.language.python.PythonLanguage`.
 All languages must be subclasses of :doc:`uproot.language.Language`.
 """
 
-from __future__ import absolute_import
 
-
-class Language(object):
+class Language:
     """
     Abstract class for all languages, which are used to compute the expressions
     that are passed to :ref:`uproot.behaviors.TBranch.HasBranches.arrays` (and

--- a/src/uproot/language/python.py
+++ b/src/uproot/language/python.py
@@ -109,9 +109,9 @@ def _ast_as_branch_expression(node, keys, aliases, functions, getter):
 
     elif isinstance(node, ast.Name):
         if node.id in keys or node.id in aliases:
-            return ast.parse(f"get({repr(node.id)})").body[0].value
+            return ast.parse(f"get({node.id!r})").body[0].value
         elif node.id in functions:
-            return ast.parse(f"function[{repr(node.id)}]").body[0].value
+            return ast.parse(f"function[{node.id!r}]").body[0].value
         else:
             raise KeyError(node.id)
 
@@ -126,7 +126,7 @@ def _ast_as_branch_expression(node, keys, aliases, functions, getter):
             new_node.col_offset = getattr(node, "col_offset", 0)
             return new_node
         elif name in keys or name in aliases:
-            return ast.parse(f"get({repr(name)})").body[0].value
+            return ast.parse(f"get({name!r})").body[0].value
         else:
             # implicitly means functions and getter can't have dots in their names
             raise KeyError(name)
@@ -352,7 +352,7 @@ class PythonLanguage(uproot.language.Language):
 
         For example, ``"get('something')"``.
         """
-        return f"{self._getter}({repr(name)})"
+        return f"{self._getter}({name!r})"
 
     def free_symbols(self, expression, keys, aliases, file_path, object_path):
         """

--- a/src/uproot/language/python.py
+++ b/src/uproot/language/python.py
@@ -8,7 +8,6 @@ The :doc:`uproot.language.python.PythonLanguage` evaluates Python code. It is
 the default language.
 """
 
-from __future__ import absolute_import
 
 import ast
 
@@ -22,13 +21,13 @@ def _expression_to_node(expression, file_path, object_path):
         node = ast.parse(expression)
     except SyntaxError as err:
         raise SyntaxError(
-            err.args[0] + "\nin file {0}\nin object {1}".format(file_path, object_path),
+            err.args[0] + f"\nin file {file_path}\nin object {object_path}",
             err.args[1],
         )
 
     if len(node.body) != 1 or not isinstance(node.body[0], ast.Expr):
         raise SyntaxError(
-            "expected a single expression\nin file {0}\nin object {1}".format(
+            "expected a single expression\nin file {}\nin object {}".format(
                 file_path, object_path
             )
         )
@@ -61,8 +60,8 @@ def _walk_ast_yield_symbols(node, keys, aliases, functions, getter):
             yield node.args[0].s
         else:
             raise TypeError(
-                "expected a constant string as the only argument of {0}; "
-                "found {1}".format(repr(getter), ast.dump(node.args))
+                "expected a constant string as the only argument of {}; "
+                "found {}".format(repr(getter), ast.dump(node.args))
             )
 
     elif isinstance(node, ast.Name):
@@ -76,10 +75,9 @@ def _walk_ast_yield_symbols(node, keys, aliases, functions, getter):
     elif isinstance(node, ast.Attribute):
         name = _attribute_to_dotted_name(node)
         if name is None:
-            for y in _walk_ast_yield_symbols(
+            yield from _walk_ast_yield_symbols(
                 node.value, keys, aliases, functions, getter
-            ):
-                yield y
+            )
         elif name in keys or name in aliases:
             yield name
         else:
@@ -89,13 +87,11 @@ def _walk_ast_yield_symbols(node, keys, aliases, functions, getter):
     elif isinstance(node, ast.AST):
         for field_name in node._fields:
             x = getattr(node, field_name)
-            for y in _walk_ast_yield_symbols(x, keys, aliases, functions, getter):
-                yield y
+            yield from _walk_ast_yield_symbols(x, keys, aliases, functions, getter)
 
     elif isinstance(node, list):
         for x in node:
-            for y in _walk_ast_yield_symbols(x, keys, aliases, functions, getter):
-                yield y
+            yield from _walk_ast_yield_symbols(x, keys, aliases, functions, getter)
 
     else:
         pass
@@ -113,9 +109,9 @@ def _ast_as_branch_expression(node, keys, aliases, functions, getter):
 
     elif isinstance(node, ast.Name):
         if node.id in keys or node.id in aliases:
-            return ast.parse("get({0})".format(repr(node.id))).body[0].value
+            return ast.parse(f"get({repr(node.id)})").body[0].value
         elif node.id in functions:
-            return ast.parse("function[{0}]".format(repr(node.id))).body[0].value
+            return ast.parse(f"function[{repr(node.id)}]").body[0].value
         else:
             raise KeyError(node.id)
 
@@ -130,7 +126,7 @@ def _ast_as_branch_expression(node, keys, aliases, functions, getter):
             new_node.col_offset = getattr(node, "col_offset", 0)
             return new_node
         elif name in keys or name in aliases:
-            return ast.parse("get({0})".format(repr(name))).body[0].value
+            return ast.parse(f"get({repr(name)})").body[0].value
         else:
             # implicitly means functions and getter can't have dots in their names
             raise KeyError(name)
@@ -356,7 +352,7 @@ class PythonLanguage(uproot.language.Language):
 
         For example, ``"get('something')"``.
         """
-        return "{0}({1})".format(self._getter, repr(name))
+        return f"{self._getter}({repr(name)})"
 
     def free_symbols(self, expression, keys, aliases, file_path, object_path):
         """

--- a/src/uproot/model.py
+++ b/src/uproot/model.py
@@ -17,7 +17,6 @@ not be modeled, either because the class has no streamer or no streamer for its
 version.
 """
 
-from __future__ import absolute_import
 
 import re
 import sys
@@ -119,7 +118,7 @@ def _classname_decode_convert(hex_characters):
 
 def _classname_encode_convert(bad_characters):
     g = bad_characters.group(0)
-    return b"_" + b"".join("{0:02x}".format(x).encode() for x in g) + b"_"
+    return b"_" + b"".join(f"{x:02x}".encode() for x in g) + b"_"
 
 
 def classname_regularize(classname):
@@ -153,7 +152,7 @@ def classname_decode(encoded_classname):
     elif encoded_classname.startswith("Model_"):
         raw = encoded_classname[6:].encode()
     else:
-        raise ValueError("not an encoded classname: {0}".format(encoded_classname))
+        raise ValueError(f"not an encoded classname: {encoded_classname}")
 
     if _classname_decode_antiversion.match(raw) is not None:
         version = None
@@ -191,7 +190,7 @@ def classname_encode(classname, version=None, unknown=False):
     else:
         prefix = "Model_"
     if classname.startswith(prefix):
-        raise ValueError("classname is already encoded: {0}".format(classname))
+        raise ValueError(f"classname is already encoded: {classname}")
 
     if version is None:
         v = ""
@@ -254,7 +253,7 @@ def class_named(classname, version=None, custom_classes=None):
 
     cls = classes.get(classname)
     if cls is None:
-        raise ValueError("no class named {0} in {1}".format(classname, where))
+        raise ValueError(f"no class named {classname} in {where}")
 
     if version is not None and isinstance(cls, DispatchByVersion):
         versioned_cls = cls.class_of_version(version)
@@ -262,7 +261,7 @@ def class_named(classname, version=None, custom_classes=None):
             return versioned_cls
         else:
             raise ValueError(
-                "no class named {0} with version {1} in {2}".format(
+                "no class named {} with version {} in {}".format(
                     classname, version, where
                 )
             )
@@ -299,7 +298,7 @@ def maybe_custom_classes(classname, custom_classes):
         return custom_classes
 
 
-class Model(object):
+class Model:
     """
     Abstract class for all objects extracted from ROOT files (except for
     :doc:`uproot.reading.ReadOnlyFile`, :doc:`uproot.reading.ReadOnlyDirectory`,
@@ -364,8 +363,8 @@ class Model(object):
         if self.class_version is None:
             version = ""
         else:
-            version = " (version {0})".format(self.class_version)
-        return "<{0}{1} at 0x{2:012x}>".format(self.classname, version, id(self))
+            version = f" (version {self.class_version})"
+        return f"<{self.classname}{version} at 0x{id(self):012x}>"
 
     def __enter__(self):
         if isinstance(self._file, uproot.reading.ReadOnlyFile):
@@ -529,9 +528,9 @@ class Model(object):
         else:
             raise uproot.KeyInFileError(
                 name,
-                because="""{0}.{1} has only the following members:
+                because="""{}.{} has only the following members:
 
-    {2}
+    {}
 """.format(
                     type(self).__module__,
                     type(self).__name__,
@@ -974,7 +973,7 @@ class Model(object):
 
         if cls is None:
             raise NotImplementedError(
-                "this ROOT type is not writable: {0}".format(self.classname)
+                f"this ROOT type is not writable: {self.classname}"
             )
         else:
             out = cls.__new__(cls)
@@ -1019,7 +1018,7 @@ class Model(object):
 
     def _serialize(self, out, header, name, tobject_flags):
         raise NotImplementedError(
-            "can't write {0} instances yet ('serialize' method not implemented)".format(
+            "can't write {} instances yet ('serialize' method not implemented)".format(
                 type(self).__name__
             )
         )
@@ -1088,7 +1087,7 @@ class VersionedModel(Model):
         self.__dict__.update(instance_data)
 
 
-class DispatchByVersion(object):
+class DispatchByVersion:
     """
     A Python class that models all versions of a ROOT C++ class by maintaining
     a dict of :doc:`uproot.model.VersionedModel` classes.
@@ -1281,7 +1280,7 @@ class DispatchByVersion(object):
 
         else:
             raise ValueError(
-                """Unknown version {0} for class {1} that cannot be skipped """
+                """Unknown version {} for class {} that cannot be skipped """
                 """because its number of bytes is unknown.
 """.format(
                     version,
@@ -1366,7 +1365,7 @@ class UnknownClass(Model):
         return self._context
 
     def __repr__(self):
-        return "<Unknown {0} at 0x{1:012x}>".format(self.classname, id(self))
+        return f"<Unknown {self.classname} at 0x{id(self):012x}>"
 
     def debug(
         self, skip_bytes=0, limit_bytes=None, dtype=None, offset=0, stream=sys.stdout
@@ -1458,9 +1457,9 @@ class UnknownClass(Model):
 
         else:
             raise ValueError(
-                """unknown class {0} that cannot be skipped because its """
+                """unknown class {} that cannot be skipped because its """
                 """number of bytes is unknown
-in file {1}""".format(
+in file {}""".format(
                     self.classname, file.file_path
                 )
             )
@@ -1591,15 +1590,15 @@ class UnknownClassVersion(VersionedModel):
 
         else:
             raise ValueError(
-                """class {0} with unknown version {1} cannot be skipped """
+                """class {} with unknown version {} cannot be skipped """
                 """because its number of bytes is unknown
-in file {2}""".format(
+in file {}""".format(
                     self.classname, self._instance_version, file.file_path
                 )
             )
 
     def __repr__(self):
-        return "<{0} with unknown version {1} at 0x{2:012x}>".format(
+        return "<{} with unknown version {} at 0x{:012x}>".format(
             self.classname, self._instance_version, id(self)
         )
 

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -4,7 +4,6 @@
 This module defines a versionless model for ``ROOT::Experimental::RNTuple``.
 """
 
-from __future__ import absolute_import
 
 import queue
 import struct
@@ -27,8 +26,8 @@ class Model_ROOT_3a3a_Experimental_3a3a_RNTuple(uproot.model.Model):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )

--- a/src/uproot/models/TArray.py
+++ b/src/uproot/models/TArray.py
@@ -4,7 +4,6 @@
 This module defines versionless models for ``TArray`` and its subclasses.
 """
 
-from __future__ import absolute_import
 
 import struct
 from collections.abc import Sequence
@@ -29,8 +28,8 @@ class Model_TArray(uproot.model.Model, Sequence):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -57,8 +56,8 @@ in file {1}""".format(
         if self.class_version is None:
             version = ""
         else:
-            version = " (version {0})".format(self.class_version)
-        return "<{0}{1} {2} at 0x{3:012x}>".format(
+            version = f" (version {self.class_version})"
+        return "<{}{} {} at 0x{:012x}>".format(
             self.classname,
             version,
             numpy.array2string(

--- a/src/uproot/models/TAtt.py
+++ b/src/uproot/models/TAtt.py
@@ -4,7 +4,6 @@
 This module defines versioned models for ``TAttLine``, ``TAttFill``, and ``TAttMarker``.
 """
 
-from __future__ import absolute_import
 
 import struct
 
@@ -23,8 +22,8 @@ class Model_TAttLine_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -97,8 +96,8 @@ class Model_TAttLine_v2(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -201,8 +200,8 @@ class Model_TAttFill_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -269,8 +268,8 @@ class Model_TAttFill_v2(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -365,8 +364,8 @@ class Model_TAttMarker_v2(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -467,8 +466,8 @@ class Model_TAttAxis_v4(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -695,8 +694,8 @@ class Model_TAtt3D_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )

--- a/src/uproot/models/TBasket.py
+++ b/src/uproot/models/TBasket.py
@@ -8,7 +8,6 @@ Includes both "embedded" ``TBaskets`` (as a member of TBranch) and "free"
 ``TBaskets`` (top-level objects, located by ``TKeys``).
 """
 
-from __future__ import absolute_import
 
 import struct
 
@@ -32,7 +31,7 @@ class Model_TBasket(uproot.model.Model):
 
     def __repr__(self):
         basket_num = self._basket_num if self._basket_num is not None else "(unknown)"
-        return "<TBasket {0} of {1} at 0x{2:012x}>".format(
+        return "<TBasket {} of {} at 0x{:012x}>".format(
             basket_num, repr(self._parent.name), id(self)
         )
 

--- a/src/uproot/models/TBranch.py
+++ b/src/uproot/models/TBranch.py
@@ -7,7 +7,6 @@ See :doc:`uproot.behaviors.TBranch` for definitions of ``TTree``-reading
 functions.
 """
 
-from __future__ import absolute_import
 
 import struct
 
@@ -45,8 +44,8 @@ class Model_TBranch_v10(uproot.behaviors.TBranch.TBranch, uproot.model.Versioned
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -175,8 +174,8 @@ class Model_TBranch_v11(uproot.behaviors.TBranch.TBranch, uproot.model.Versioned
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -307,8 +306,8 @@ class Model_TBranch_v12(uproot.behaviors.TBranch.TBranch, uproot.model.Versioned
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -440,8 +439,8 @@ class Model_TBranch_v13(uproot.behaviors.TBranch.TBranch, uproot.model.Versioned
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -602,8 +601,8 @@ class Model_TBranchElement_v8(
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -676,8 +675,8 @@ class Model_TBranchElement_v9(
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -750,8 +749,8 @@ class Model_TBranchElement_v10(
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -833,8 +832,8 @@ class Model_TBranchObject_v1(
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )

--- a/src/uproot/models/TClonesArray.py
+++ b/src/uproot/models/TClonesArray.py
@@ -4,7 +4,6 @@
 This module defines a versionless model for ``TClonesArray``.
 """
 
-from __future__ import absolute_import
 
 from collections.abc import Sequence
 
@@ -21,7 +20,7 @@ class Model_TClonesArray(uproot.model.VersionedModel, Sequence):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                "memberwise serialization of {0}\nin file {1}".format(
+                "memberwise serialization of {}\nin file {}".format(
                     type(self).__name__, self.file.file_path
                 )
             )

--- a/src/uproot/models/TDatime.py
+++ b/src/uproot/models/TDatime.py
@@ -4,7 +4,6 @@
 This module defines versioned models for ``TDatime``.
 """
 
-from __future__ import absolute_import
 
 import struct
 

--- a/src/uproot/models/TGraph.py
+++ b/src/uproot/models/TGraph.py
@@ -4,7 +4,6 @@
 This module defines versioned models for ``TLeaf`` and its subclasses.
 """
 
-from __future__ import absolute_import
 
 import struct
 
@@ -38,7 +37,7 @@ class Model_TGraph_v4(uproot.behaviors.TGraph.TGraph, uproot.model.VersionedMode
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                "memberwise serialization of {0}\nin file {1}".format(
+                "memberwise serialization of {}\nin file {}".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -393,7 +392,7 @@ class Model_TGraphErrors_v3(
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                "memberwise serialization of {0}\nin file {1}".format(
+                "memberwise serialization of {}\nin file {}".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -593,7 +592,7 @@ class Model_TGraphAsymmErrors_v3(
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                "memberwise serialization of {0}\nin file {1}".format(
+                "memberwise serialization of {}\nin file {}".format(
                     type(self).__name__, self.file.file_path
                 )
             )

--- a/src/uproot/models/TH.py
+++ b/src/uproot/models/TH.py
@@ -4,7 +4,6 @@
 This module defines versioned models for ``TLeaf`` and its subclasses.
 """
 
-from __future__ import absolute_import
 
 import struct
 
@@ -153,8 +152,8 @@ class Model_TAxis_v10(uproot.behaviors.TAxis.TAxis, uproot.model.VersionedModel)
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -483,8 +482,8 @@ class Model_TH1_v8(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -1082,8 +1081,8 @@ class Model_TH2_v5(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -1256,8 +1255,8 @@ class Model_TH3_v6(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -1503,8 +1502,8 @@ class Model_TH1C_v3(uproot.behaviors.TH1.TH1, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -1679,8 +1678,8 @@ class Model_TH1D_v3(uproot.behaviors.TH1.TH1, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -1850,8 +1849,8 @@ class Model_TH1F_v3(uproot.behaviors.TH1.TH1, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -2021,8 +2020,8 @@ class Model_TH1I_v3(uproot.behaviors.TH1.TH1, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -2197,8 +2196,8 @@ class Model_TH1S_v3(uproot.behaviors.TH1.TH1, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -2373,8 +2372,8 @@ class Model_TH2C_v4(uproot.behaviors.TH2.TH2, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -2550,8 +2549,8 @@ class Model_TH2D_v4(uproot.behaviors.TH2.TH2, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -2722,8 +2721,8 @@ class Model_TH2F_v4(uproot.behaviors.TH2.TH2, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -2899,8 +2898,8 @@ class Model_TH2I_v4(uproot.behaviors.TH2.TH2, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -3076,8 +3075,8 @@ class Model_TH2S_v4(uproot.behaviors.TH2.TH2, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -3253,8 +3252,8 @@ class Model_TH3C_v4(uproot.behaviors.TH3.TH3, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -3431,8 +3430,8 @@ class Model_TH3D_v4(uproot.behaviors.TH3.TH3, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -3604,8 +3603,8 @@ class Model_TH3F_v4(uproot.behaviors.TH3.TH3, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -3782,8 +3781,8 @@ class Model_TH3I_v4(uproot.behaviors.TH3.TH3, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -3960,8 +3959,8 @@ class Model_TH3S_v4(uproot.behaviors.TH3.TH3, uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -4140,8 +4139,8 @@ class Model_TProfile_v7(
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -4394,8 +4393,8 @@ class Model_TProfile2D_v8(
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -4650,8 +4649,8 @@ class Model_TProfile3D_v8(
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )

--- a/src/uproot/models/THashList.py
+++ b/src/uproot/models/THashList.py
@@ -4,7 +4,6 @@
 This module defines a versionless model for ``THashList``.
 """
 
-from __future__ import absolute_import
 
 import uproot
 
@@ -20,8 +19,8 @@ class Model_THashList(uproot.model.Model):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -41,8 +40,8 @@ in file {1}""".format(
         if self.class_version is None:
             version = ""
         else:
-            version = " (version {0})".format(self.class_version)
-        return "<{0}{1} of {2} items at 0x{3:012x}>".format(
+            version = f" (version {self.class_version})"
+        return "<{}{} of {} items at 0x{:012x}>".format(
             self.classname,
             version,
             len(self),

--- a/src/uproot/models/TLeaf.py
+++ b/src/uproot/models/TLeaf.py
@@ -4,7 +4,6 @@
 This module defines versioned models for ``TLeaf`` and its subclasses.
 """
 
-from __future__ import absolute_import
 
 import struct
 
@@ -28,8 +27,8 @@ class Model_TLeaf_v2(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -95,8 +94,8 @@ class Model_TLeafO_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -154,8 +153,8 @@ class Model_TLeafB_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -213,8 +212,8 @@ class Model_TLeafS_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -272,8 +271,8 @@ class Model_TLeafI_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -331,8 +330,8 @@ class Model_TLeafL_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -390,8 +389,8 @@ class Model_TLeafF_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -449,8 +448,8 @@ class Model_TLeafD_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -508,8 +507,8 @@ class Model_TLeafC_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -565,8 +564,8 @@ class Model_TLeafF16_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -607,8 +606,8 @@ class Model_TLeafD32_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -652,8 +651,8 @@ class Model_TLeafElement_v1(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )

--- a/src/uproot/models/TList.py
+++ b/src/uproot/models/TList.py
@@ -4,7 +4,6 @@
 This module defines a versionless model for ``TList``.
 """
 
-from __future__ import absolute_import
 
 import struct
 from collections.abc import Sequence
@@ -22,8 +21,8 @@ class Model_TList(uproot.model.Model, Sequence):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -59,8 +58,8 @@ in file {1}""".format(
         if self.class_version is None:
             version = ""
         else:
-            version = " (version {0})".format(self.class_version)
-        return "<{0}{1} of {2} items at 0x{3:012x}>".format(
+            version = f" (version {self.class_version})"
+        return "<{}{} of {} items at 0x{:012x}>".format(
             self.classname,
             version,
             len(self),

--- a/src/uproot/models/TNamed.py
+++ b/src/uproot/models/TNamed.py
@@ -4,7 +4,6 @@
 This module defines a versionless model for ``TNamed``.
 """
 
-from __future__ import absolute_import
 
 import numpy
 
@@ -19,8 +18,8 @@ class Model_TNamed(uproot.model.Model):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -43,7 +42,7 @@ in file {1}""".format(
         title = ""
         if self._members["fTitle"] != "":
             title = " title=" + repr(self._members["fTitle"])
-        return "<TNamed {0}{1} at 0x{2:012x}>".format(
+        return "<TNamed {}{} at 0x{:012x}>".format(
             repr(self._members["fName"]), title, id(self)
         )
 
@@ -99,7 +98,7 @@ in file {1}""".format(
         if name is None:
             name = self._members["fName"]
         if name is None:
-            name = "untitled_{0}".format(Model_TNamed._untitled_count)
+            name = f"untitled_{Model_TNamed._untitled_count}"
             Model_TNamed._untitled_count += 1
         out.append(uproot.serialization.string(name))
 

--- a/src/uproot/models/TObjArray.py
+++ b/src/uproot/models/TObjArray.py
@@ -4,7 +4,6 @@
 This module defines a versionless model for ``TObjArray``.
 """
 
-from __future__ import absolute_import
 
 import struct
 from collections.abc import Sequence
@@ -31,8 +30,8 @@ class Model_TObjArray(uproot.model.Model, Sequence):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -86,8 +85,8 @@ in file {1}""".format(
         if self.class_version is None:
             version = ""
         else:
-            version = " (version {0})".format(self.class_version)
-        return "<{0}{1} of {2} items at 0x{3:012x}>".format(
+            version = f" (version {self.class_version})"
+        return "<{}{} of {} items at 0x{:012x}>".format(
             self.classname,
             version,
             len(self),
@@ -119,8 +118,8 @@ class Model_TObjArrayOfTBaskets(Model_TObjArray):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )

--- a/src/uproot/models/TObjString.py
+++ b/src/uproot/models/TObjString.py
@@ -4,7 +4,6 @@
 This module defines a versionless model for ``TObjString``.
 """
 
-from __future__ import absolute_import
 
 import uproot
 import uproot.serialization
@@ -30,8 +29,8 @@ class Model_TObjString(uproot.model.Model, str):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -79,8 +78,8 @@ in file {1}""".format(
         if self.class_version is None:
             version = ""
         else:
-            version = " (version {0})".format(self.class_version)
-        return "<{0}{1} {2} at 0x{3:012x}>".format(
+            version = f" (version {self.class_version})"
+        return "<{}{} {} at 0x{:012x}>".format(
             self.classname,
             version,
             str.__repr__(self),

--- a/src/uproot/models/TObject.py
+++ b/src/uproot/models/TObject.py
@@ -4,7 +4,6 @@
 This module defines a versionless model for ``TObject``.
 """
 
-from __future__ import absolute_import
 
 import struct
 
@@ -27,8 +26,8 @@ class Model_TObject(uproot.model.Model):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -118,7 +117,7 @@ in file {1}""".format(
         )
 
     def __repr__(self):
-        return "<TObject {0} {1} at 0x{2:012x}>".format(
+        return "<TObject {} {} at 0x{:012x}>".format(
             self._members.get("fUniqueID"), self._members.get("fBits"), id(self)
         )
 

--- a/src/uproot/models/TRef.py
+++ b/src/uproot/models/TRef.py
@@ -4,7 +4,6 @@
 This module defines versionless models of ``TRef`` and ``TRefArray``.
 """
 
-from __future__ import absolute_import
 
 import struct
 from collections.abc import Sequence
@@ -39,15 +38,15 @@ class Model_TRef(uproot.model.Model):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
         self._ref = cursor.field(chunk, _tref_format1, context)
 
     def __repr__(self):
-        return "<TRef {0}>".format(self._ref)
+        return f"<TRef {self._ref}>"
 
     @classmethod
     def strided_interpretation(
@@ -140,8 +139,8 @@ class Model_TRefArray(uproot.model.Model, Sequence):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -163,8 +162,8 @@ in file {1}""".format(
         if self.class_version is None:
             version = ""
         else:
-            version = " (version {0})".format(self.class_version)
-        return "<{0}{1} {2} at 0x{3:012x}>".format(
+            version = f" (version {self.class_version})"
+        return "<{}{} {} at 0x{:012x}>".format(
             self.classname,
             version,
             numpy.array2string(

--- a/src/uproot/models/TString.py
+++ b/src/uproot/models/TString.py
@@ -4,7 +4,6 @@
 This module defines a versionless model of ``TString``.
 """
 
-from __future__ import absolute_import
 
 import uproot
 
@@ -22,8 +21,8 @@ class Model_TString(uproot.model.Model, str):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -44,8 +43,8 @@ in file {1}""".format(
         if self.class_version is None:
             version = ""
         else:
-            version = " (version {0})".format(self.class_version)
-        return "<{0}{1} {2} at 0x{3:012x}>".format(
+            version = f" (version {self.class_version})"
+        return "<{}{} {} at 0x{:012x}>".format(
             self.classname, version, str.__repr__(self), id(self)
         )
 

--- a/src/uproot/models/TTable.py
+++ b/src/uproot/models/TTable.py
@@ -7,7 +7,6 @@ See :doc:`uproot.behaviors.TBranch` for definitions of ``TTree``-reading
 functions.
 """
 
-from __future__ import absolute_import
 
 import struct
 from collections import namedtuple
@@ -28,8 +27,8 @@ class Model_TDataSet(uproot.model.Model):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -134,8 +133,8 @@ class Model_TTableDescriptor_v4(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -194,8 +193,8 @@ class Model_TTable_v4(uproot.model.VersionedModel):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -222,9 +221,7 @@ in file {1}""".format(
             self._members["fSize"],
         ) = cursor.fields(chunk, _ttable4_format1, context)
 
-        assert (
-            sum([col.fSize for col in ioDescriptor._columns]) == self._members["fSize"]
-        )
+        assert sum(col.fSize for col in ioDescriptor._columns) == self._members["fSize"]
 
         buf = cursor.bytes(
             chunk, self._members["fSize"] * self._members["fMaxIndex"], context

--- a/src/uproot/models/TTree.py
+++ b/src/uproot/models/TTree.py
@@ -7,7 +7,6 @@ See :doc:`uproot.behaviors.TBranch` for definitions of ``TTree``-reading
 functions.
 """
 
-from __future__ import absolute_import
 
 import struct
 
@@ -49,8 +48,8 @@ class Model_TTree_v16(uproot.behaviors.TTree.TTree, uproot.model.VersionedModel)
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -201,8 +200,8 @@ class Model_TTree_v17(uproot.behaviors.TTree.TTree, uproot.model.VersionedModel)
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -354,8 +353,8 @@ class Model_TTree_v18(uproot.behaviors.TTree.TTree, uproot.model.VersionedModel)
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -513,8 +512,8 @@ class Model_TTree_v19(uproot.behaviors.TTree.TTree, uproot.model.VersionedModel)
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -688,8 +687,8 @@ class Model_TTree_v20(uproot.behaviors.TTree.TTree, uproot.model.VersionedModel)
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
@@ -895,8 +894,8 @@ class Model_ROOT_3a3a_TIOFeatures(uproot.model.Model):
     def read_members(self, chunk, cursor, context, file):
         if self.is_memberwise:
             raise NotImplementedError(
-                """memberwise serialization of {0}
-in file {1}""".format(
+                """memberwise serialization of {}
+in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )

--- a/src/uproot/models/__init__.py
+++ b/src/uproot/models/__init__.py
@@ -43,5 +43,3 @@ add them as behavior classes.
 
 See also :doc:`uproot.behaviors`.
 """
-
-from __future__ import absolute_import

--- a/src/uproot/pyroot.py
+++ b/src/uproot/pyroot.py
@@ -20,7 +20,6 @@ This module also makes it possible for PyROOT objects to be added to ROOT files
 that Uproot is writing (regardless of whether Uproot could read such objects).
 """
 
-from __future__ import absolute_import
 
 import threading
 import uuid
@@ -143,7 +142,7 @@ pyroot_to_buffer.sizer = None
 pyroot_to_buffer.buffer = None
 
 
-class _GetStreamersOnce(object):
+class _GetStreamersOnce:
     _custom_classes = {}
     _streamers = {}
     _streamer_dependencies = {}
@@ -170,7 +169,7 @@ class _GetStreamersOnce(object):
     def file_path(self):
         return None
 
-    class ArrayFile(object):
+    class ArrayFile:
         def __init__(self, array):
             self.array = array
             self.current = 0
@@ -266,7 +265,7 @@ def from_pyroot(obj):
         )
 
 
-class _PyROOTWritable(object):
+class _PyROOTWritable:
     def __init__(self, obj):
         self._obj = obj
 

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -647,7 +647,7 @@ in file {}""".format(
             )
 
     def __repr__(self):
-        return f"<ReadOnlyFile {repr(self._file_path)} at 0x{id(self):012x}>"
+        return f"<ReadOnlyFile {self._file_path!r} at 0x{id(self):012x}>"
 
     @property
     def detached(self):
@@ -1193,7 +1193,7 @@ in file {}""".format(
         ``start`` up to ``stop``.
         """
         if self.closed:
-            raise OSError(f"file {repr(self._file_path)} is closed")
+            raise OSError(f"file {self._file_path!r} is closed")
         elif (start, stop) in self._begin_chunk:
             return self._begin_chunk
         else:

--- a/src/uproot/reading.py
+++ b/src/uproot/reading.py
@@ -8,7 +8,6 @@ and the classes that are too fundamental to be models:
 and :doc:`uproot.reading.ReadOnlyKey` (``TKey``).
 """
 
-from __future__ import absolute_import
 
 import struct
 import sys
@@ -28,7 +27,7 @@ def open(
     custom_classes=None,
     decompression_executor=None,
     interpretation_executor=None,
-    **options  # NOTE: a comma after **options breaks Python 2
+    **options,  # NOTE: a comma after **options breaks Python 2
 ):
     """
     Args:
@@ -146,7 +145,7 @@ def open(
         custom_classes=custom_classes,
         decompression_executor=decompression_executor,
         interpretation_executor=interpretation_executor,
-        **options  # NOTE: a comma after **options breaks Python 2
+        **options,  # NOTE: a comma after **options breaks Python 2
     )
 
     if object_path is None:
@@ -161,7 +160,7 @@ class _OpenDefaults(dict):
             # See https://github.com/scikit-hep/uproot4/issues/294
             if uproot.extras.older_xrootd("5.2.0"):
                 message = (
-                    "XRootD {0} is not fully supported; ".format(
+                    "XRootD {} is not fully supported; ".format(
                         uproot.extras.xrootd_version()
                     )
                     + """either upgrade to 5.2.0+ or set
@@ -208,7 +207,7 @@ must_be_attached = [
 ]
 
 
-class CommonFileMethods(object):
+class CommonFileMethods:
     """
     Abstract class for :doc:`uproot.reading.ReadOnlyFile` and
     :doc:`uproot.reading.DetachedFile`. The latter is a placeholder for file
@@ -254,7 +253,7 @@ class CommonFileMethods(object):
         See :ref:`uproot.reading.CommonFileMethods.root_version_tuple` and
         :ref:`uproot.reading.CommonFileMethods.fVersion`.
         """
-        return "{0}.{1:02d}/{2:02d}".format(*self.root_version_tuple)
+        return "{}.{:02d}/{:02d}".format(*self.root_version_tuple)
 
     @property
     def root_version_tuple(self):
@@ -318,7 +317,7 @@ class CommonFileMethods(object):
         See :ref:`uproot.reading.CommonFileMethods.uuid` and
         :ref:`uproot.reading.CommonFileMethods.fUUID`.
         """
-        out = "".join("{0:02x}".format(x) for x in self._fUUID)
+        out = "".join(f"{x:02x}" for x in self._fUUID)
         return "-".join([out[0:8], out[8:12], out[12:16], out[16:20], out[20:32]])
 
     @property
@@ -556,7 +555,7 @@ class ReadOnlyFile(CommonFileMethods):
         custom_classes=None,
         decompression_executor=None,
         interpretation_executor=None,
-        **options  # NOTE: a comma after **options breaks Python 2
+        **options,  # NOTE: a comma after **options breaks Python 2
     ):
         self._file_path = file_path
         self.object_cache = object_cache
@@ -586,7 +585,7 @@ class ReadOnlyFile(CommonFileMethods):
 
         if self._options["begin_chunk_size"] < _file_header_fields_big.size:
             raise ValueError(
-                "begin_chunk_size={0} is not enough to read the TFile header ({1})".format(
+                "begin_chunk_size={} is not enough to read the TFile header ({})".format(
                     self._options["begin_chunk_size"],
                     _file_header_fields_big.size,
                 )
@@ -641,16 +640,14 @@ class ReadOnlyFile(CommonFileMethods):
 
         if magic != b"root":
             raise ValueError(
-                """not a ROOT file: first four bytes are {0}
-in file {1}""".format(
+                """not a ROOT file: first four bytes are {}
+in file {}""".format(
                     repr(magic), file_path
                 )
             )
 
     def __repr__(self):
-        return "<ReadOnlyFile {0} at 0x{1:012x}>".format(
-            repr(self._file_path), id(self)
-        )
+        return f"<ReadOnlyFile {repr(self._file_path)} at 0x{id(self):012x}>"
 
     @property
     def detached(self):
@@ -836,7 +833,7 @@ in file {1}""".format(
             for v, streamer in self.streamers[name].items():
                 if v == version:
                     if not first:
-                        stream.write(u"\n")
+                        stream.write("\n")
                     streamer.show(stream=stream)
                     first = False
 
@@ -921,8 +918,8 @@ in file {1}""".format(
 
                     else:
                         raise ValueError(
-                            """unexpected type in TList of streamers and streamer rules: {0}
-in file {1}""".format(
+                            """unexpected type in TList of streamers and streamer rules: {}
+in file {}""".format(
                                 type(x), self._file_path
                             )
                         )
@@ -1196,7 +1193,7 @@ in file {1}""".format(
         ``start`` up to ``stop``.
         """
         if self.closed:
-            raise OSError("file {0} is closed".format(repr(self._file_path)))
+            raise OSError(f"file {repr(self._file_path)} is closed")
         elif (start, stop) in self._begin_chunk:
             return self._begin_chunk
         else:
@@ -1462,7 +1459,7 @@ class ReadOnlyDirectory(Mapping):
             )
 
     def __repr__(self):
-        return "<ReadOnlyDirectory {0} at 0x{1:012x}>".format(
+        return "<ReadOnlyDirectory {} at 0x{:012x}>".format(
             repr("/" + "/".join(self._path)), id(self)
         )
 
@@ -1599,7 +1596,7 @@ class ReadOnlyDirectory(Mapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return the names of objects directly accessible
@@ -1630,7 +1627,7 @@ class ReadOnlyDirectory(Mapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return objects directly accessible in this
@@ -1661,7 +1658,7 @@ class ReadOnlyDirectory(Mapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return (name, object) pairs directly accessible
@@ -1694,7 +1691,7 @@ class ReadOnlyDirectory(Mapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return the names and classnames of objects
@@ -1726,7 +1723,7 @@ class ReadOnlyDirectory(Mapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return the names of objects directly accessible
@@ -1761,7 +1758,7 @@ class ReadOnlyDirectory(Mapping):
                     filter_name=no_filter,
                     filter_classname=filter_classname,
                 ):
-                    k2 = "{0}/{1}".format(key.name(cycle=False), k1)
+                    k2 = f"{key.name(cycle=False)}/{k1}"
                     k3 = k2[: k2.index(";")] if ";" in k2 else k2
                     if filter_name is no_filter or filter_name(k3):
                         if k2 not in seen:
@@ -1774,7 +1771,7 @@ class ReadOnlyDirectory(Mapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return objects directly accessible in this
@@ -1805,7 +1802,7 @@ class ReadOnlyDirectory(Mapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return (name, object) pairs directly accessible
@@ -1841,7 +1838,7 @@ class ReadOnlyDirectory(Mapping):
                     filter_name=no_filter,
                     filter_classname=filter_classname,
                 ):
-                    k2 = "{0}/{1}".format(key.name(cycle=False), k1)
+                    k2 = f"{key.name(cycle=False)}/{k1}"
                     k3 = k2[: k2.index(";")] if ";" in k2 else k2
                     if filter_name is no_filter or filter_name(k3):
                         if k2 not in seen:
@@ -1855,7 +1852,7 @@ class ReadOnlyDirectory(Mapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return the names and classnames of objects
@@ -1890,7 +1887,7 @@ class ReadOnlyDirectory(Mapping):
                     filter_name=no_filter,
                     filter_classname=filter_classname,
                 ):
-                    k2 = "{0}/{1}".format(key.name(cycle=False), k1)
+                    k2 = f"{key.name(cycle=False)}/{k1}"
                     k3 = k2[: k2.index(";")] if ";" in k2 else k2
                     if filter_name is no_filter or filter_name(k3):
                         if k2 not in seen:
@@ -2217,7 +2214,7 @@ _key_format_small = struct.Struct(">ihiIhhii")
 _key_format_big = struct.Struct(">ihiIhhqq")
 
 
-class ReadOnlyKey(object):
+class ReadOnlyKey:
     """
     Args:
         chunk (:doc:`uproot.source.chunk.Chunk`): Buffer of contiguous data
@@ -2309,8 +2306,8 @@ class ReadOnlyKey(object):
         if self._fName is None or self._fClassName is None:
             nameclass = ""
         else:
-            nameclass = " {0}: {1}".format(self.name(cycle=True), self.classname())
-        return "<ReadOnlyKey{0} (seek pos {1}) at 0x{2:012x}>".format(
+            nameclass = f" {self.name(cycle=True)}: {self.classname()}"
+        return "<ReadOnlyKey{} (seek pos {}) at 0x{:012x}>".format(
             nameclass, self.data_cursor.index, id(self)
         )
 
@@ -2352,7 +2349,7 @@ class ReadOnlyKey(object):
         and cycle number if ``cycle`` is True.
         """
         if cycle:
-            return "{0};{1}".format(self.fName, self.fCycle)
+            return f"{self.fName};{self.fCycle}"
         else:
             return self.fName
 
@@ -2385,11 +2382,11 @@ class ReadOnlyKey(object):
         ``TDirectory``), this returns a message with the raw seek position.
         """
         if isinstance(self._parent, ReadOnlyDirectory):
-            return "{0}{1};{2}".format(
+            return "{}{};{}".format(
                 self._parent.object_path, self.name(False), self._fCycle
             )
         else:
-            return "(seek pos {0})/{1}".format(self.data_cursor.index, self.name(False))
+            return f"(seek pos {self.data_cursor.index})/{self.name(False)}"
 
     @property
     def cache_key(self):
@@ -2397,7 +2394,7 @@ class ReadOnlyKey(object):
         String that uniquely specifies this ``TKey``, to use as part
         of object and array cache keys.
         """
-        return "{0}:{1}".format(self._file.hex_uuid, self._fSeekKey)
+        return f"{self._file.hex_uuid}:{self._fSeekKey}"
 
     @property
     def is_64bit(self):

--- a/src/uproot/serialization.py
+++ b/src/uproot/serialization.py
@@ -7,7 +7,6 @@ the opposite of :doc:`uproot.deserialization.numbytes_version`, and :doc:`uproot
 the opposite of :doc:`uproot.deserialization.read_object_any`.
 """
 
-from __future__ import absolute_import
 
 import struct
 

--- a/src/uproot/sink/__init__.py
+++ b/src/uproot/sink/__init__.py
@@ -11,5 +11,3 @@ Unlike reading, writing has no threads and the file sink can be any object with
 context manager (Python's ``with`` statement) ensures that files are properly closed
 (although files are flushed after every object-write).
 """
-
-from __future__ import absolute_import

--- a/src/uproot/sink/file.py
+++ b/src/uproot/sink/file.py
@@ -9,13 +9,12 @@ context manager (Python's ``with`` statement) to ensure that files are properly 
 (although files are flushed after every object-write).
 """
 
-from __future__ import absolute_import
 
 import numbers
 import os
 
 
-class FileSink(object):
+class FileSink:
     """
     Args:
         file_path (str): The filesystem path of the file to open.
@@ -176,7 +175,7 @@ class FileSink(object):
         if insist is True:
             if len(out) != num_bytes:
                 raise OSError(
-                    "could not read {0} bytes from the file at position {1}{2}".format(
+                    "could not read {} bytes from the file at position {}{}".format(
                         num_bytes,
                         location,
                         self.in_path,
@@ -185,7 +184,7 @@ class FileSink(object):
         elif isinstance(insist, numbers.Integral):
             if len(out) < insist:
                 raise OSError(
-                    "could not read {0} bytes from the file at position {1}{2}".format(
+                    "could not read {} bytes from the file at position {}{}".format(
                         insist,
                         location,
                         self.in_path,

--- a/src/uproot/source/__init__.py
+++ b/src/uproot/source/__init__.py
@@ -16,5 +16,3 @@ controls both I/O resources and threads.
 This module includes a :doc:`uproot.source.futures` implementation that
 connects file handles with threads.
 """
-
-from __future__ import absolute_import

--- a/src/uproot/source/chunk.py
+++ b/src/uproot/source/chunk.py
@@ -10,7 +10,6 @@ Also defines abstract classes for :doc:`uproot.source.chunk.Resource` and
 :doc:`uproot.source.chunk.Source`, the primary types of the "physical layer."
 """
 
-from __future__ import absolute_import
 
 import numbers
 
@@ -19,7 +18,7 @@ import numpy
 import uproot
 
 
-class Resource(object):
+class Resource:
     """
     Abstract class for a file handle whose lifetime may be linked to threads
     in a thread pool executor.
@@ -36,7 +35,7 @@ class Resource(object):
         return self._file_path
 
 
-class Source(object):
+class Source:
     """
     Abstract class for physically reading and writing data from a file, which
     might be remote.
@@ -150,7 +149,7 @@ class MultithreadedSource(Source):
         path = repr(self._file_path)
         if len(self._file_path) > 10:
             path = repr("..." + self._file_path[-10:])
-        return "<{0} {1} ({2} workers) at 0x{3:012x}>".format(
+        return "<{} {} ({} workers) at 0x{:012x}>".format(
             type(self).__name__, path, self.num_workers, id(self)
         )
 
@@ -216,7 +215,7 @@ def notifier(chunk, notifications):  # noqa: D103
     return notify
 
 
-class Chunk(object):
+class Chunk:
     """
     Args:
         source (:doc:`uproot.source.chunk.Source`): Source from which the
@@ -271,7 +270,7 @@ class Chunk(object):
         self._is_memmap = is_memmap
 
     def __repr__(self):
-        return "<Chunk {0}-{1}>".format(self._start, self._stop)
+        return f"<Chunk {self._start}-{self._stop}>"
 
     @property
     def source(self):
@@ -362,17 +361,17 @@ class Chunk(object):
                 requirement = True
             else:
                 raise TypeError(
-                    """insist must be a bool or an int, not {0}
-for file path {1}""".format(
+                    """insist must be a bool or an int, not {}
+for file path {}""".format(
                         repr(insist), self._source.file_path
                     )
                 )
 
             if not requirement:
                 raise OSError(
-                    """expected Chunk of length {0},
-received {1} bytes from {2}
-for file path {3}""".format(
+                    """expected Chunk of length {},
+received {} bytes from {}
+for file path {}""".format(
                         self._stop - self._start,
                         len(self._raw_data),
                         type(self._source).__name__,
@@ -423,8 +422,8 @@ for file path {3}""".format(
 
         else:
             raise uproot.deserialization.DeserializationError(
-                """attempting to get bytes {0}:{1}
-outside expected range {2}:{3} for this Chunk""".format(
+                """attempting to get bytes {}:{}
+outside expected range {}:{} for this Chunk""".format(
                     start, stop, self._start, self._stop
                 ),
                 self,
@@ -461,8 +460,8 @@ outside expected range {2}:{3} for this Chunk""".format(
 
         else:
             raise uproot.deserialization.DeserializationError(
-                """attempting to get bytes after {0}
-outside expected range {1}:{2} for this Chunk""".format(
+                """attempting to get bytes after {}
+outside expected range {}:{} for this Chunk""".format(
                     start, self._start, self._stop
                 ),
                 self,

--- a/src/uproot/source/cursor.py
+++ b/src/uproot/source/cursor.py
@@ -6,7 +6,6 @@ a thread-local pointer into a :doc:`uproot.source.chunk.Chunk` and performs
 the lowest level of interpretation (numbers, strings, raw arrays, etc.).
 """
 
-from __future__ import absolute_import
 
 import datetime
 import struct
@@ -28,7 +27,7 @@ _rntuple_string_length = struct.Struct("<I")
 _rntuple_datetime = struct.Struct("<Q")
 
 
-class Cursor(object):
+class Cursor:
     """
     Args:
         index (int): Global seek position in the ROOT file or local position
@@ -54,20 +53,20 @@ class Cursor(object):
         if self._origin == 0:
             o = ""
         else:
-            o = ", origin={0}".format(self._origin)
+            o = f", origin={self._origin}"
 
         if self._refs is None or len(self._refs) == 0:
             r = ""
         elif self._refs is None or len(self._refs) < 3:
-            r = ", {0} refs: {1}".format(
+            r = ", {} refs: {}".format(
                 len(self._refs), ", ".join(str(x) for x in self._refs)
             )
         else:
-            r = ", {0} refs: {1}...".format(
+            r = ", {} refs: {}...".format(
                 len(self._refs), ", ".join(str(x) for x in list(self._refs)[:3])
             )
 
-        return "Cursor({0}{1}{2})".format(self._index, o, r)
+        return f"Cursor({self._index}{o}{r})"
 
     @property
     def index(self):
@@ -148,7 +147,7 @@ class Cursor(object):
         ):
             raise TypeError(
                 "Cursor.skip_after can only be used on an object with a "
-                "`cursor` and `num_bytes`, not {0}".format(type(obj))
+                "`cursor` and `num_bytes`, not {}".format(type(obj))
             )
         self._index = start_cursor.index + num_bytes
 
@@ -444,8 +443,8 @@ class Cursor(object):
         while char != 0:
             if local_stop > len(remainder):
                 raise OSError(
-                    """C-style string has no terminator (null byte) in Chunk {0}:{1}
-of file path {2}""".format(
+                    """C-style string has no terminator (null byte) in Chunk {}:{}
+of file path {}""".format(
                         self._start, self._stop, self._source.file_path
                     )
                 )
@@ -541,12 +540,12 @@ of file path {2}""".format(
                 i += dtype.itemsize
                 interpreted[i - 1] = x
 
-            formatter = u"{{0:>{0}.{0}s}}".format(dtype.itemsize * 4 - 1)
+            formatter = "{{0:>{0}.{0}s}}".format(dtype.itemsize * 4 - 1)
 
         for line_start in range(0, int(numpy.ceil(len(data) / 20.0)) * 20, 20):
             line_data = data[line_start : line_start + 20]
 
-            prefix = u""
+            prefix = ""
             if dtype is not None:
                 nones = 0
                 for x in interpreted[line_start:]:
@@ -558,31 +557,27 @@ of file path {2}""".format(
                 line_interpreted = [None] * fill + interpreted[
                     line_start : line_start + 20
                 ]
-                prefix = u"    " * fill
-                interpreted_prefix = u"    " * (fill + nones + 1 - dtype.itemsize)
+                prefix = "    " * fill
+                interpreted_prefix = "    " * (fill + nones + 1 - dtype.itemsize)
 
-            stream.write(prefix + (u"--+-" * 20) + u"\n")
-            stream.write(
-                prefix + u" ".join(u"{0:3d}".format(x) for x in line_data) + u"\n"
-            )
+            stream.write(prefix + ("--+-" * 20) + "\n")
+            stream.write(prefix + " ".join(f"{x:3d}" for x in line_data) + "\n")
             stream.write(
                 prefix
-                + u" ".join(
-                    u"{0:>3s}".format(chr(x))
-                    if chr(x) in _printable_characters
-                    else u"---"
+                + " ".join(
+                    f"{chr(x):>3s}" if chr(x) in _printable_characters else "---"
                     for x in line_data
                 )
-                + u"\n"
+                + "\n"
             )
 
             if dtype is not None:
                 stream.write(
                     interpreted_prefix
-                    + u" ".join(
+                    + " ".join(
                         formatter.format(str(x))
                         for x in line_interpreted
                         if x is not None
                     )
-                    + u"\n"
+                    + "\n"
                 )

--- a/src/uproot/source/file.py
+++ b/src/uproot/source/file.py
@@ -12,7 +12,6 @@ If the filesystem or operating system does not support memory-mapped files, the
 :doc:`uproot.source.file.MultithreadedFileSource` is an automatic fallback.
 """
 
-from __future__ import absolute_import
 
 import os.path
 
@@ -112,7 +111,7 @@ class MemmapSource(uproot.source.chunk.Source):
         try:
             self._file = numpy.memmap(self._file_path, dtype=self._dtype, mode="r")
             self._fallback = None
-        except IOError:
+        except OSError:
             self._file = None
             opts = dict(self._fallback_opts)
             opts["num_workers"] = self._num_fallback_workers
@@ -136,14 +135,14 @@ class MemmapSource(uproot.source.chunk.Source):
         fallback = ""
         if self._fallback is not None:
             fallback = " with fallback"
-        return "<{0} {1}{2} at 0x{3:012x}>".format(
+        return "<{} {}{} at 0x{:012x}>".format(
             type(self).__name__, path, fallback, id(self)
         )
 
     def chunk(self, start, stop):
         if self._fallback is None:
             if self.closed:
-                raise OSError("memmap is closed for file {0}".format(self._file_path))
+                raise OSError(f"memmap is closed for file {self._file_path}")
 
             self._num_requests += 1
             self._num_requested_chunks += 1
@@ -159,7 +158,7 @@ class MemmapSource(uproot.source.chunk.Source):
     def chunks(self, ranges, notifications):
         if self._fallback is None:
             if self.closed:
-                raise OSError("memmap is closed for file {0}".format(self._file_path))
+                raise OSError(f"memmap is closed for file {self._file_path}")
 
             self._num_requests += 1
             self._num_requested_chunks += len(ranges)

--- a/src/uproot/source/futures.py
+++ b/src/uproot/source/futures.py
@@ -21,7 +21,6 @@ This module defines a Python-like Future and Executor for Uproot in three levels
 These classes implement a *subset* of Python's Future and Executor interfaces.
 """
 
-from __future__ import absolute_import
 
 import os
 import queue
@@ -40,7 +39,7 @@ def delayed_raise(exception_class, exception_value, traceback):
 ##################### use-case 1: trivial Futures/Executor (satisfying formalities)
 
 
-class TrivialFuture(object):
+class TrivialFuture:
     """
     Formally satisfies the interface for a :doc:`uproot.source.futures.Future`
     object, but it is already complete at the time when it is constructed.
@@ -56,7 +55,7 @@ class TrivialFuture(object):
         return self._result
 
 
-class TrivialExecutor(object):
+class TrivialExecutor:
     """
     Formally satisfies the interface for a
     :doc:`uproot.source.futures.ThreadPoolExecutor`, but the
@@ -65,7 +64,7 @@ class TrivialExecutor(object):
     """
 
     def __repr__(self):
-        return "<TrivialExecutor at 0x{0:012x}>".format(id(self))
+        return f"<TrivialExecutor at 0x{id(self):012x}>"
 
     def submit(self, task, *args):
         """
@@ -83,7 +82,7 @@ class TrivialExecutor(object):
 ##################### use-case 2: Python-like Futures/Executor for compute
 
 
-class Future(object):
+class Future:
     """
     Args:
         task (function): The function to evaluate.
@@ -142,7 +141,7 @@ class Worker(threading.Thread):
     """
 
     def __init__(self, work_queue):
-        super(Worker, self).__init__()
+        super().__init__()
         self.daemon = True
         self._work_queue = work_queue
 
@@ -171,7 +170,7 @@ class Worker(threading.Thread):
             future._run()
 
 
-class ThreadPoolExecutor(object):
+class ThreadPoolExecutor:
     """
     Args:
         num_workers (None or int): The number of workers to start. If None,
@@ -201,7 +200,7 @@ class ThreadPoolExecutor(object):
             worker.start()
 
     def __repr__(self):
-        return "<ThreadPoolExecutor ({0} workers) at 0x{1:012x}>".format(
+        return "<ThreadPoolExecutor ({} workers) at 0x{:012x}>".format(
             len(self._workers), id(self)
         )
 
@@ -261,7 +260,7 @@ class ResourceFuture(Future):
     """
 
     def __init__(self, task):
-        super(ResourceFuture, self).__init__(task, None)
+        super().__init__(task, None)
         self._notify = None
 
     def _set_notify(self, notify):
@@ -302,7 +301,7 @@ class ResourceWorker(Worker):
     """
 
     def __init__(self, work_queue, resource):
-        super(ResourceWorker, self).__init__(work_queue)
+        super().__init__(work_queue)
         self._resource = resource
 
     @property
@@ -353,7 +352,7 @@ class ResourceThreadPoolExecutor(ThreadPoolExecutor):
             worker.start()
 
     def __repr__(self):
-        return "<ResourceThreadPoolExecutor ({0} workers) at 0x{1:012x}>".format(
+        return "<ResourceThreadPoolExecutor ({} workers) at 0x{:012x}>".format(
             len(self._workers), id(self)
         )
 
@@ -368,7 +367,7 @@ class ResourceThreadPoolExecutor(ThreadPoolExecutor):
         assert isinstance(future, ResourceFuture)
         if self.closed:
             raise OSError(
-                "resource is closed for file {0}".format(
+                "resource is closed for file {}".format(
                     self._workers[0].resource.file_path
                 )
             )

--- a/src/uproot/source/http.py
+++ b/src/uproot/source/http.py
@@ -14,7 +14,6 @@ automatically falls back to :doc:`uproot.source.http.MultithreadedHTTPSource`.
 Despite the name, both sources support secure HTTPS (selected by URL scheme).
 """
 
-from __future__ import absolute_import
 
 import base64
 import queue
@@ -48,7 +47,7 @@ def make_connection(parsed_url, timeout):
 
     else:
         raise ValueError(
-            "unrecognized URL scheme for HTTP MultipartSource: {0}".format(
+            "unrecognized URL scheme for HTTP MultipartSource: {}".format(
                 parsed_url.scheme
             )
         )
@@ -108,8 +107,8 @@ def get_num_bytes(file_path, parsed_url, timeout):
                 break
         else:
             raise OSError(
-                """remote server responded with status {0} (redirect) without a 'location'
-for URL {1}""".format(
+                """remote server responded with status {} (redirect) without a 'location'
+for URL {}""".format(
                     response.status, file_path
                 )
             )
@@ -121,8 +120,8 @@ for URL {1}""".format(
     if response.status != 200:
         connection.close()
         raise OSError(
-            """HTTP response was {0}, rather than 200, in attempt to get file size
-in file {1}""".format(
+            """HTTP response was {}, rather than 200, in attempt to get file size
+in file {}""".format(
                 response.status, file_path
             )
         )
@@ -134,8 +133,8 @@ in file {1}""".format(
     else:
         connection.close()
         raise OSError(
-            """response headers did not include content-length: {0}
-in file {1}""".format(
+            """response headers did not include content-length: {}
+in file {}""".format(
                 dict(response.getheaders()), file_path
             )
         )
@@ -212,15 +211,14 @@ class HTTPResource(uproot.source.chunk.Resource):
                         "GET",
                         full_path(redirect_url),
                         headers=dict(
-                            {"Range": "bytes={0}-{1}".format(start, stop - 1)},
-                            **self.auth_headers
+                            {"Range": f"bytes={start}-{stop - 1}"}, **self.auth_headers
                         ),
                     )
                     return self.get(redirect, start, stop)
 
             raise OSError(
-                """remote server responded with status {0} (redirect) without a 'location'
-for URL {1}""".format(
+                """remote server responded with status {} (redirect) without a 'location'
+for URL {}""".format(
                     response.status, self._file_path
                 )
             )
@@ -228,8 +226,8 @@ for URL {1}""".format(
         if response.status != 206:
             connection.close()
             raise OSError(
-                """remote server responded with status {0}, rather than 206 (range requests)
-for URL {1}""".format(
+                """remote server responded with status {}, rather than 206 (range requests)
+for URL {}""".format(
                     response.status, self._file_path
                 )
             )
@@ -255,10 +253,7 @@ for URL {1}""".format(
         connection.request(
             "GET",
             full_path(source.parsed_url),
-            headers=dict(
-                {"Range": "bytes={0}-{1}".format(start, stop - 1)},
-                **source.auth_headers
-            ),
+            headers=dict({"Range": f"bytes={start}-{stop - 1}"}, **source.auth_headers),
         )
 
         def task(resource):
@@ -268,7 +263,7 @@ for URL {1}""".format(
 
     @staticmethod
     def multifuture(source, ranges, futures, results):
-        u"""
+        """
         Args:
             source (:doc:`uproot.source.http.HTTPSource`): The data source.
             ranges (list of (int, int) 2-tuples): Intervals to fetch
@@ -294,7 +289,7 @@ for URL {1}""".format(
 
         range_strings = []
         for start, stop in ranges:
-            range_strings.append("{0}-{1}".format(start, stop - 1))
+            range_strings.append(f"{start}-{stop - 1}")
 
         connection[0].request(
             "GET",
@@ -322,15 +317,15 @@ for URL {1}""".format(
                                 full_path(redirect_url),
                                 headers=dict(
                                     {"Range": "bytes=" + ", ".join(range_strings)},
-                                    **source.auth_headers
+                                    **source.auth_headers,
                                 ),
                             )
                             task(resource)
                             return
 
                     raise OSError(
-                        """remote server responded with status {0} (redirect) without a 'location'
-for URL {1}""".format(
+                        """remote server responded with status {} (redirect) without a 'location'
+for URL {}""".format(
                             response.status, source.file_path
                         )
                     )
@@ -404,8 +399,8 @@ for URL {1}""".format(
             range_string, size = self.next_header(response_buffer)
             if range_string is None:
                 raise OSError(
-                    """found {0} of {1} expected headers in HTTP multipart
-for URL {2}""".format(
+                    """found {} of {} expected headers in HTTP multipart
+for URL {}""".format(
                         num_found, len(futures), self._file_path
                     )
                 )
@@ -420,9 +415,9 @@ for URL {2}""".format(
 
             if len(data) != length:
                 raise OSError(
-                    """wrong chunk length {0} (expected {1}) for byte range {2} "
+                    """wrong chunk length {} (expected {}) for byte range {} "
                     "in HTTP multipart
-for URL {3}""".format(
+for URL {}""".format(
                         len(data), length, repr(range_string.decode()), self._file_path
                     )
                 )
@@ -444,15 +439,13 @@ for URL {3}""".format(
                             break
                     else:
                         range_string = range_string.decode("utf-8", "surrogateescape")
-                        expecting = ", ".join(
-                            "{0}-{1}".format(a, b - 1) for a, b in futures
-                        )
+                        expecting = ", ".join(f"{a}-{b - 1}" for a, b in futures)
                         raise OSError(
-                            """unrecognized byte range in headers of HTTP multipart: {0}
+                            """unrecognized byte range in headers of HTTP multipart: {}
 
-    expecting: {1}
+    expecting: {}
 
-for URL {2}""".format(
+for URL {}""".format(
                                 repr(range_string), expecting, self._file_path
                             )
                         )
@@ -503,7 +496,7 @@ for URL {2}""".format(
         return uproot.source.futures.ResourceFuture(task)
 
 
-class _ResponseBuffer(object):
+class _ResponseBuffer:
     CHUNK = 1024
 
     def __init__(self, stream):
@@ -591,7 +584,7 @@ class HTTPSource(uproot.source.chunk.Source):
         fallback = ""
         if self._fallback is not None:
             fallback = " with fallback"
-        return "<{0} {1}{2} at 0x{3:012x}>".format(
+        return "<{} {}{} at 0x{:012x}>".format(
             type(self).__name__, path, fallback, id(self)
         )
 
@@ -695,7 +688,7 @@ class HTTPSource(uproot.source.chunk.Source):
     def _set_fallback(self):
         self._fallback = MultithreadedHTTPSource(
             self._file_path,
-            **self._fallback_options  # NOTE: a comma after **fallback_options breaks Python 2
+            **self._fallback_options,  # NOTE: a comma after **fallback_options breaks Python 2
         )
 
 

--- a/src/uproot/source/object.py
+++ b/src/uproot/source/object.py
@@ -8,7 +8,6 @@ object) and one source :doc:`uproot.source.object.ObjectSource` which always
 has exactly one worker (we can't assume that the object is thread-safe).
 """
 
-from __future__ import absolute_import
 
 import uproot
 import uproot.source.chunk

--- a/src/uproot/source/xrootd.py
+++ b/src/uproot/source/xrootd.py
@@ -10,7 +10,6 @@ support vector-read requests; if not, it automatically falls back to
 :doc:`uproot.source.xrootd.MultithreadedXRootDSource`.
 """
 
-from __future__ import absolute_import
 
 import sys
 
@@ -53,7 +52,7 @@ def get_server_config(file):
         raise NotImplementedError
 
     data_server = XRootD_client.URL(data_server)
-    data_server = "{0}://{1}/".format(data_server.protocol, data_server.hostid)
+    data_server = f"{data_server.protocol}://{data_server.hostid}/"
 
     # Use a single query call to avoid doubling the latency
     fs = XRootD_client.FileSystem(data_server)
@@ -117,8 +116,8 @@ class XRootDResource(uproot.source.chunk.Resource):
 
         else:
             raise OSError(
-                """XRootD error: {0}
-in file {1}""".format(
+                """XRootD error: {}
+in file {}""".format(
                     status.message, self._file_path
                 )
             )
@@ -302,7 +301,7 @@ class XRootDSource(uproot.source.chunk.Source):
         path = repr(self._file_path)
         if len(self._file_path) > 10:
             path = repr("..." + self._file_path[-10:])
-        return "<{0} {1} at 0x{2:012x}>".format(type(self).__name__, path, id(self))
+        return f"<{type(self).__name__} {path} at 0x{id(self):012x}>"
 
     def chunk(self, start, stop):
         self._num_requests += 1

--- a/src/uproot/streamers.py
+++ b/src/uproot/streamers.py
@@ -324,8 +324,7 @@ class Model_TStreamerInfo(uproot.model.Model):
         class_data.append(
             "    base_names_versions = [{}]".format(
                 ", ".join(
-                    f"({repr(name)}, {version})"
-                    for name, version in base_names_versions
+                    f"({name!r}, {version})" for name, version in base_names_versions
                 )
             )
         )
@@ -958,7 +957,7 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
                 else:
                     read_members.append(
                         "        {} = cursor.fields(chunk, self._format{}, context)".format(
-                            ", ".join(f"self._members[{repr(x)}]" for x in fields[-1]),
+                            ", ".join(f"self._members[{x!r}]" for x in fields[-1]),
                             len(formats) - 1,
                         )
                     )

--- a/src/uproot/streamers.py
+++ b/src/uproot/streamers.py
@@ -5,7 +5,6 @@ This module defines models for ``TStreamerInfo`` and its elements, as well as
 routines for generating Python code for new classes from streamer data.
 """
 
-from __future__ import absolute_import
 
 import re
 import struct
@@ -141,7 +140,7 @@ class Model_TStreamerInfo(uproot.model.Model):
     """
 
     def __repr__(self):
-        return "<TStreamerInfo for {0} version {1} at 0x{2:012x}>".format(
+        return "<TStreamerInfo for {} version {} at 0x{:012x}>".format(
             self.name, self.class_version, id(self)
         )
 
@@ -164,12 +163,12 @@ class Model_TStreamerInfo(uproot.model.Model):
         bases = []
         for element in self.elements:
             if isinstance(element, Model_TStreamerBase):
-                bases.append(u"{0} (v{1})".format(element.name, element.base_version))
+                bases.append(f"{element.name} (v{element.base_version})")
         if len(bases) == 0:
-            bases = u""
+            bases = ""
         else:
-            bases = u": " + u", ".join(bases)
-        stream.write(u"{0} (v{1}){2}\n".format(self.name, self.class_version, bases))
+            bases = ": " + ", ".join(bases)
+        stream.write(f"{self.name} (v{self.class_version}){bases}\n")
         for element in self.elements:
             element.show(stream=stream)
 
@@ -306,33 +305,33 @@ class Model_TStreamerInfo(uproot.model.Model):
 
         for i, format in enumerate(formats):
             class_data.append(
-                "    _format{0} = struct.Struct('>{1}')".format(i, "".join(format))
+                "    _format{} = struct.Struct('>{}')".format(i, "".join(format))
             )
 
         for i, format in enumerate(formats_memberwise):
             class_data.append(
-                "    _format_memberwise{0} = struct.Struct('>{1}')".format(
+                "    _format_memberwise{} = struct.Struct('>{}')".format(
                     i, "".join(format)
                 )
             )
 
         for i, dt in enumerate(dtypes):
-            class_data.append("    _dtype{0} = {1}".format(i, dt))
+            class_data.append(f"    _dtype{i} = {dt}")
 
         for i, stl in enumerate(containers):
-            class_data.append("    _stl_container{0} = {1}".format(i, stl))
+            class_data.append(f"    _stl_container{i} = {stl}")
 
         class_data.append(
-            "    base_names_versions = [{0}]".format(
+            "    base_names_versions = [{}]".format(
                 ", ".join(
-                    "({0}, {1})".format(repr(name), version)
+                    f"({repr(name)}, {version})"
                     for name, version in base_names_versions
                 )
             )
         )
 
         class_data.append(
-            "    member_names = [{0}]".format(", ".join(repr(x) for x in member_names))
+            "    member_names = [{}]".format(", ".join(repr(x) for x in member_names))
         )
 
         class_data.append(
@@ -343,7 +342,7 @@ class Model_TStreamerInfo(uproot.model.Model):
 
         classname = uproot.model.classname_encode(self.name, self.class_version)
         return "\n".join(
-            ["class {0}(uproot.model.VersionedModel):".format(classname)]
+            [f"class {classname}(uproot.model.VersionedModel):"]
             + read_members
             + read_member_n
             + strided_interpretation
@@ -399,8 +398,7 @@ class Model_TStreamerInfo(uproot.model.Model):
                     base = streamers_with_name[max(streamers_with_name)]
                 else:
                     base = streamers_with_name[base_version]
-                for x in base.walk_members(streamers):
-                    yield x
+                yield from base.walk_members(streamers)
             else:
                 yield element
 
@@ -478,7 +476,7 @@ class Model_TStreamerElement(uproot.model.Model):
         Interactively display a ``TStreamerElement``.
         """
         stream.write(
-            u"    {0}: {1} ({2})\n".format(
+            "    {}: {} ({})\n".format(
                 self.name,
                 self.typename,
                 uproot.model.classname_decode(type(self).__name__)[0],
@@ -637,12 +635,12 @@ class Model_TStreamerArtificial(Model_TStreamerElement):
         member_names,
         class_flags,
     ):
-        read_member_n.append("        if member_index == {0}:".format(i))
+        read_member_n.append(f"        if member_index == {i}:")
 
         read_members.append(
             "        raise uproot.deserialization.DeserializationError("
-            "'not implemented: class members defined by {0} of type {1} in member "
-            "{2} of class {3}', chunk, cursor, context, file.file_path)".format(
+            "'not implemented: class members defined by {} of type {} in member "
+            "{} of class {}', chunk, cursor, context, file.file_path)".format(
                 type(self).__name__, self.typename, self.name, streamerinfo.name
             )
         )
@@ -650,16 +648,16 @@ class Model_TStreamerArtificial(Model_TStreamerElement):
 
         strided_interpretation.append(
             "        raise uproot.interpretation.objects.CannotBeStrided("
-            "'not implemented: class members defined by {0} of type {1} in member "
-            "{2} of class {3}')".format(
+            "'not implemented: class members defined by {} of type {} in member "
+            "{} of class {}')".format(
                 type(self).__name__, self.typename, self.name, streamerinfo.name
             )
         )
 
         awkward_form.append(
             "        raise uproot.interpretation.objects.CannotBeAwkward("
-            "'not implemented: class members defined by {0} of type {1} in member "
-            "{2} of class {3}')".format(
+            "'not implemented: class members defined by {} of type {} in member "
+            "{} of class {}')".format(
                 type(self).__name__, self.typename, self.name, streamerinfo.name
             )
         )
@@ -716,10 +714,10 @@ class Model_TStreamerBase(Model_TStreamerElement):
         member_names,
         class_flags,
     ):
-        read_member_n.append("        if member_index == {0}:".format(i))
+        read_member_n.append(f"        if member_index == {i}:")
 
         read_members.append(
-            "        self._bases.append(c({0}, {1}).read(chunk, cursor, "
+            "        self._bases.append(c({}, {}).read(chunk, cursor, "
             "context, file, self._file, self._parent, concrete=self.concrete))".format(
                 repr(self.name), repr(self.base_version)
             )
@@ -727,13 +725,13 @@ class Model_TStreamerBase(Model_TStreamerElement):
         read_member_n.append("    " + read_members[-1])
 
         strided_interpretation.append(
-            "        members.extend(file.class_named({0}, {1})."
+            "        members.extend(file.class_named({}, {})."
             "strided_interpretation(file, header, tobject_header, breadcrumbs).members)".format(
                 repr(self.name), repr(self.base_version)
             )
         )
         awkward_form.append(
-            "        contents.update(file.class_named({0}, {1}).awkward_form(file, "
+            "        contents.update(file.class_named({}, {}).awkward_form(file, "
             "index_format, header, tobject_header, breadcrumbs).contents)".format(
                 repr(self.name), repr(self.base_version)
             )
@@ -816,9 +814,9 @@ class Model_TStreamerBasicPointer(Model_TStreamerElement):
         member_names,
         class_flags,
     ):
-        read_member_n.append("        if member_index == {0}:".format(i))
+        read_member_n.append(f"        if member_index == {i}:")
 
-        read_members.append("        tmp = self._dtype{0}".format(len(dtypes)))
+        read_members.append(f"        tmp = self._dtype{len(dtypes)}")
         read_member_n.append("    " + read_members[-1])
 
         if streamerinfo.name == "TBranch" and self.name == "fBasketSeek":
@@ -837,23 +835,23 @@ class Model_TStreamerBasicPointer(Model_TStreamerElement):
             read_member_n.append("    " + read_members[-1].replace("\n", "\n    "))
 
         read_members.append(
-            "        self._members[{0}] = cursor.array(chunk, self.member({1}), "
+            "        self._members[{}] = cursor.array(chunk, self.member({}), "
             "tmp, context)".format(repr(self.name), repr(self.count_name))
         )
         read_member_n.append("    " + read_members[-1])
 
         strided_interpretation.append(
             "        raise uproot.interpretation.objects.CannotBeStrided("
-            "'class members defined by {0} of type {1} in member "
-            "{2} of class {3}')".format(
+            "'class members defined by {} of type {} in member "
+            "{} of class {}')".format(
                 type(self).__name__, self.typename, self.name, streamerinfo.name
             )
         )
 
         awkward_form.extend(
             [
-                "        contents[{0}] = ListOffsetForm(index_format, "
-                "uproot._util.awkward_form(cls._dtype{1}, file, index_format, header, "
+                "        contents[{}] = ListOffsetForm(index_format, "
+                "uproot._util.awkward_form(cls._dtype{}, file, index_format, header, "
                 "tobject_header, breadcrumbs),".format(repr(self.name), len(dtypes)),
                 "            parameters={'uproot': {'as': 'TStreamerBasicPointer', "
                 "'count_name': " + repr(self.count_name) + "}}",
@@ -914,18 +912,18 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
         member_names,
         class_flags,
     ):
-        read_member_n.append("        if member_index == {0}:".format(i))
+        read_member_n.append(f"        if member_index == {i}:")
 
         if self.typename == "Double32_t":
             read_members.append(
-                "        self._members[{0}] = cursor.double32(chunk, "
+                "        self._members[{}] = cursor.double32(chunk, "
                 "context)".format(repr(self.name))
             )
             read_member_n.append("    " + read_members[-1])
 
         elif self.typename == "Float16_t":
             read_members.append(
-                "        self._members[{0}] = cursor.float16(chunk, 12, "
+                "        self._members[{}] = cursor.float16(chunk, 12, "
                 "context)".format(repr(self.name))
             )
             read_member_n.append("    " + read_members[-1])
@@ -952,32 +950,30 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
             ):
                 if len(fields[-1]) == 1:
                     read_members.append(
-                        "        self._members[{0}] = cursor.field(chunk, "
-                        "self._format{1}, context)".format(
+                        "        self._members[{}] = cursor.field(chunk, "
+                        "self._format{}, context)".format(
                             repr(fields[-1][0]), len(formats) - 1
                         )
                     )
                 else:
                     read_members.append(
-                        "        {0} = cursor.fields(chunk, self._format{1}, context)".format(
-                            ", ".join(
-                                "self._members[{0}]".format(repr(x)) for x in fields[-1]
-                            ),
+                        "        {} = cursor.fields(chunk, self._format{}, context)".format(
+                            ", ".join(f"self._members[{repr(x)}]" for x in fields[-1]),
                             len(formats) - 1,
                         )
                     )
 
             read_member_n.append(
-                "            self._members[{0}] = cursor.field(chunk, "
-                "self._format_memberwise{1}, context)".format(
+                "            self._members[{}] = cursor.field(chunk, "
+                "self._format_memberwise{}, context)".format(
                     repr(self.name), len(formats_memberwise) - 1
                 )
             )
 
         else:
             read_members.append(
-                "        self._members[{0}] = cursor.array(chunk, {1}, "
-                "self._dtype{2}, context)".format(
+                "        self._members[{}] = cursor.array(chunk, {}, "
+                "self._dtype{}, context)".format(
                     repr(self.name), self.array_length, len(dtypes)
                 )
             )
@@ -987,15 +983,15 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
 
         if self.array_length == 0 and self.typename not in ("Double32_t", "Float16_t"):
             strided_interpretation.append(
-                "        members.append(({0}, {1}))".format(
+                "        members.append(({}, {}))".format(
                     repr(self.name), _ftype_to_dtype(self.fType)
                 )
             )
         else:
             strided_interpretation.append(
                 "        raise uproot.interpretation.objects.CannotBeStrided("
-                "'class members defined by {0} of type {1} in member "
-                "{2} of class {3}')".format(
+                "'class members defined by {} of type {} in member "
+                "{} of class {}')".format(
                     type(self).__name__, self.typename, self.name, streamerinfo.name
                 )
             )
@@ -1017,7 +1013,7 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
 
             else:
                 awkward_form.append(
-                    "        contents[{0}] = uproot._util.awkward_form({1}, "
+                    "        contents[{}] = uproot._util.awkward_form({}, "
                     "file, index_format, header, tobject_header, breadcrumbs)".format(
                         repr(self.name), _ftype_to_dtype(self.fType)
                     )
@@ -1025,8 +1021,8 @@ class Model_TStreamerBasicType(Model_TStreamerElement):
 
         else:
             awkward_form.append(
-                "        contents[{0}] = RegularForm(uproot._util.awkward_form({1}, "
-                "file, index_format, header, tobject_header, breadcrumbs), {2})".format(
+                "        contents[{}] = RegularForm(uproot._util.awkward_form({}, "
+                "file, index_format, header, tobject_header, breadcrumbs), {})".format(
                     repr(self.name), _ftype_to_dtype(self.fType), self.array_length
                 )
             )
@@ -1153,10 +1149,10 @@ class Model_TStreamerLoop(Model_TStreamerElement):
         read_members.extend(
             [
                 "        cursor.skip(6)",
-                "        for tmp in range(self.member({0})):".format(
+                "        for tmp in range(self.member({})):".format(
                     repr(self.count_name)
                 ),
-                "            self._members[{0}] = c({1}).read(chunk, cursor, "
+                "            self._members[{}] = c({}).read(chunk, cursor, "
                 "context, file, self._file, self.concrete)".format(
                     repr(self.name), repr(self.typename.rstrip("*"))
                 ),
@@ -1165,15 +1161,15 @@ class Model_TStreamerLoop(Model_TStreamerElement):
 
         strided_interpretation.append(
             "        raise uproot.interpretation.objects.CannotBeStrided("
-            "'class members defined by {0} of type {1} in member "
-            "{2} of class {3}')".format(
+            "'class members defined by {} of type {} in member "
+            "{} of class {}')".format(
                 type(self).__name__, self.typename, self.name, streamerinfo.name
             )
         )
 
         awkward_form.extend(
             [
-                "        tmp = file.class_named({0}, 'max').awkward_form(file, "
+                "        tmp = file.class_named({}, 'max').awkward_form(file, "
                 "index_format, header, tobject_header, breadcrumbs)".format(
                     repr(self.typename.rstrip("*"))
                 ),
@@ -1262,7 +1258,7 @@ class Model_TStreamerSTL(Model_TStreamerElement):
         member_names,
         class_flags,
     ):
-        read_member_n.append("        if member_index == {0}:".format(i))
+        read_member_n.append(f"        if member_index == {i}:")
 
         stl_container = uproot.interpretation.identify.parse_typename(
             self.typename,
@@ -1272,21 +1268,21 @@ class Model_TStreamerSTL(Model_TStreamerElement):
             string_header=True,
         )
         read_members.append(
-            "        self._members[{0}] = self._stl_container{1}.read("
+            "        self._members[{}] = self._stl_container{}.read("
             "chunk, cursor, context, file, self._file, self.concrete)"
             "".format(repr(self.name), len(containers))
         )
         read_member_n.append("    " + read_members[-1])
 
         strided_interpretation.append(
-            "        members.append(({0}, cls._stl_container{1}."
+            "        members.append(({}, cls._stl_container{}."
             "strided_interpretation(file, header, tobject_header, breadcrumbs)))".format(
                 repr(self.name), len(containers)
             )
         )
 
         awkward_form.append(
-            "        contents[{0}] = cls._stl_container{1}.awkward_form(file, "
+            "        contents[{}] = cls._stl_container{}.awkward_form(file, "
             "index_format, header, tobject_header, breadcrumbs)".format(
                 repr(self.name), len(containers)
             )
@@ -1357,7 +1353,7 @@ class Model_TStreamerSTLstring(Model_TStreamerSTL):
         self._serialization = _copy_bytes(chunk, start, cursor.index, cursor, context)
 
 
-class TStreamerPointerTypes(object):
+class TStreamerPointerTypes:
     """
     A class to share code between
     :doc:`uproot.streamers.Model_TStreamerObjectAnyPointer` and
@@ -1382,24 +1378,24 @@ class TStreamerPointerTypes(object):
         member_names,
         class_flags,
     ):
-        read_member_n.append("        if member_index == {0}:".format(i))
+        read_member_n.append(f"        if member_index == {i}:")
 
         if self.fType == uproot.const.kObjectp or self.fType == uproot.const.kAnyp:
             read_members.append(
-                "        self._members[{0}] = c({1}).read(chunk, cursor, context, "
+                "        self._members[{}] = c({}).read(chunk, cursor, context, "
                 "file, self._file, self.concrete)".format(
                     repr(self.name), repr(self.typename.rstrip("*"))
                 )
             )
             read_member_n.append("    " + read_members[-1])
             strided_interpretation.append(
-                "        members.append(({0}, file.class_named({1}, 'max')."
+                "        members.append(({}, file.class_named({}, 'max')."
                 "strided_interpretation(file, header, tobject_header, breadcrumbs)))".format(
                     repr(self.name), repr(self.typename.rstrip("*"))
                 )
             )
             awkward_form.append(
-                "        contents[{0}] = file.class_named({1}, 'max').awkward_form(file, "
+                "        contents[{}] = file.class_named({}, 'max').awkward_form(file, "
                 "index_format, header, tobject_header, breadcrumbs)".format(
                     repr(self.name), repr(self.typename.rstrip("*"))
                 )
@@ -1407,14 +1403,14 @@ class TStreamerPointerTypes(object):
 
         elif self.fType == uproot.const.kObjectP or self.fType == uproot.const.kAnyP:
             read_members.append(
-                "        self._members[{0}] = read_object_any(chunk, cursor, "
+                "        self._members[{}] = read_object_any(chunk, cursor, "
                 "context, file, self._file, self)".format(repr(self.name))
             )
             read_member_n.append("    " + read_members[-1])
             strided_interpretation.append(
                 "        raise uproot.interpretation.objects.CannotBeStrided("
-                "'class members defined by {0} of type {1} in member "
-                "{2} of class {3}')".format(
+                "'class members defined by {} of type {} in member "
+                "{} of class {}')".format(
                     type(self).__name__, self.typename, self.name, streamerinfo.name
                 )
             )
@@ -1423,7 +1419,7 @@ class TStreamerPointerTypes(object):
         else:
             read_members.append(
                 "        raise uproot.deserialization.DeserializationError("
-                "'not implemented: class members defined by {0} with fType {1}', "
+                "'not implemented: class members defined by {} with fType {}', "
                 "chunk, cursor, context, file.file_path)".format(
                     type(self).__name__,
                     self.fType,
@@ -1495,7 +1491,7 @@ class Model_TStreamerObjectPointer(TStreamerPointerTypes, Model_TStreamerElement
         self._serialization = _copy_bytes(chunk, start, cursor.index, cursor, context)
 
 
-class TStreamerObjectTypes(object):
+class TStreamerObjectTypes:
     """
     A class to share code between
     :doc:`uproot.streamers.Model_TStreamerObject`,
@@ -1521,10 +1517,10 @@ class TStreamerObjectTypes(object):
         member_names,
         class_flags,
     ):
-        read_member_n.append("        if member_index == {0}:".format(i))
+        read_member_n.append(f"        if member_index == {i}:")
 
         read_members.append(
-            "        self._members[{0}] = c({1}).read(chunk, cursor, context, "
+            "        self._members[{}] = c({}).read(chunk, cursor, context, "
             "file, self._file, self.concrete)".format(
                 repr(self.name), repr(self.typename.rstrip("*"))
             )
@@ -1532,13 +1528,13 @@ class TStreamerObjectTypes(object):
         read_member_n.append("    " + read_members[-1])
 
         strided_interpretation.append(
-            "        members.append(({0}, file.class_named({1}, 'max')."
+            "        members.append(({}, file.class_named({}, 'max')."
             "strided_interpretation(file, header, tobject_header, breadcrumbs)))".format(
                 repr(self.name), repr(self.typename.rstrip("*"))
             )
         )
         awkward_form.append(
-            "        contents[{0}] = file.class_named({1}, 'max').awkward_form(file, "
+            "        contents[{}] = file.class_named({}, 'max').awkward_form(file, "
             "index_format, header, tobject_header, breadcrumbs)".format(
                 repr(self.name), repr(self.typename.rstrip("*"))
             )

--- a/src/uproot/version.py
+++ b/src/uproot/version.py
@@ -9,7 +9,6 @@ The version number of Uproot's ``main`` branch in GitHub is usually one ahead
 of the latest release on PyPI.
 """
 
-from __future__ import absolute_import
 
 import re
 

--- a/src/uproot/writing/__init__.py
+++ b/src/uproot/writing/__init__.py
@@ -10,7 +10,6 @@ interaction: :doc:`uproot.writing.writable.create`, :doc:`uproot.writing.writabl
 and :doc:`uproot.writing.writable.update`.
 """
 
-from __future__ import absolute_import
 
 from uproot.writing.identify import (
     to_TArray,

--- a/src/uproot/writing/_cascade.py
+++ b/src/uproot/writing/_cascade.py
@@ -19,7 +19,6 @@ updates were not organized, redundant overwrites or even infinite cycles could o
 Thus, the structure of the cascade tree must be carefully laid out.
 """
 
-from __future__ import absolute_import
 
 import datetime
 import math
@@ -40,7 +39,7 @@ import uproot.streamers
 import uproot.writing._cascadetree
 
 
-class CascadeLeaf(object):
+class CascadeLeaf:
     """
     A leaf node in the tree of cascading, low-level writables.
 
@@ -107,7 +106,7 @@ class CascadeLeaf(object):
             self._file_dirty = False
 
 
-class CascadeNode(object):
+class CascadeNode:
     """
     A non-leaf node in the tree of cascading, low-level writables.
 
@@ -148,12 +147,12 @@ class String(CascadeLeaf):
     """
 
     def __init__(self, location, string):
-        super(String, self).__init__(location, None)
+        super().__init__(location, None)
         self._string = string
         self._serialization = uproot.serialization.string(self._string)
 
     def __repr__(self):
-        return "{0}({1}, {2})".format(
+        return "{}({}, {})".format(
             type(self).__name__,
             self._location,
             repr(self._string),
@@ -211,7 +210,7 @@ class Key(CascadeLeaf):
         created_on=None,
         big=None,
     ):
-        super(Key, self).__init__(location, None)
+        super().__init__(location, None)
         self._uncompressed_bytes = uncompressed_bytes
         self._compressed_bytes = compressed_bytes
         self._classname = classname
@@ -224,7 +223,7 @@ class Key(CascadeLeaf):
         self._big = big
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})".format(
+        return "{}({}, {}, {}, {}, {}, {}, {}, {}, {})".format(
             type(self).__name__,
             self._location,
             self._uncompressed_bytes,
@@ -431,7 +430,7 @@ class Key(CascadeLeaf):
 
         if version != cls.class_version:
             raise ValueError(
-                "Uproot can't read TKey version {0} for writing, only version {1}{2}".format(
+                "Uproot can't read TKey version {} for writing, only version {}{}".format(
                     version,
                     cls.class_version,
                     in_path,
@@ -441,7 +440,7 @@ class Key(CascadeLeaf):
         assert 0 < fNbytes <= fKeylen + fObjlen
         assert fCycle > 0
         if not is_directory_key:
-            assert fSeekKey == location, "fSeekKey {0} location {1}".format(
+            assert fSeekKey == location, "fSeekKey {} location {}".format(
                 fSeekKey, location
             )
             fSeekKey = None
@@ -481,12 +480,12 @@ class FreeSegmentsData(CascadeLeaf):
     class_version = 1
 
     def __init__(self, location, slices, end):
-        super(FreeSegmentsData, self).__init__(location, None)
+        super().__init__(location, None)
         self._slices = slices
         self._end = end
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3})".format(
+        return "{}({}, {}, {})".format(
             type(self).__name__,
             self._location,
             self._slices,
@@ -594,7 +593,7 @@ class FreeSegmentsData(CascadeLeaf):
 
             if version != cls.class_version:
                 raise ValueError(
-                    "Uproot can't read TFree version {0} for writing, only version {1}{2}".format(
+                    "Uproot can't read TFree version {} for writing, only version {}{}".format(
                         version,
                         cls.class_version,
                         in_path,
@@ -636,13 +635,13 @@ class FreeSegments(CascadeNode):
     """
 
     def __init__(self, key, data, fileheader):
-        super(FreeSegments, self).__init__(key, data, fileheader)
+        super().__init__(key, data, fileheader)
         self._key = key
         self._data = data
         self._fileheader = fileheader
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3})".format(
+        return "{}({}, {}, {})".format(
             type(self).__name__,
             self._key,
             self._data,
@@ -713,7 +712,7 @@ class FreeSegments(CascadeNode):
             if start <= original_start < stop or start < original_stop <= stop:
                 raise RuntimeError(
                     "segment of data to release overlaps one already marked as free: "
-                    "releasing [{0}, {1}) but [{2}, {3}) is free".format(
+                    "releasing [{}, {}) but [{}, {}) is free".format(
                         original_start, original_stop, start, stop
                     )
                 )
@@ -797,7 +796,7 @@ class FreeSegments(CascadeNode):
         self._fileheader.free_num_bytes = self._key.allocation + self._data.allocation
         self._fileheader.free_num_slices = len(self._data.slices)
         self._fileheader.end = self._data.end
-        super(FreeSegments, self).write(sink)
+        super().write(sink)
 
 
 _tlistheader_format = struct.Struct(">IHHIIBI")
@@ -813,12 +812,12 @@ class TListHeader(CascadeLeaf):
     class_version = 5
 
     def __init__(self, location, data_bytes, num_entries):
-        super(TListHeader, self).__init__(location, _tlistheader_format.size)
+        super().__init__(location, _tlistheader_format.size)
         self._data_bytes = data_bytes
         self._num_entries = num_entries
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3})".format(
+        return "{}({}, {}, {})".format(
             type(self).__name__, self._location, self._data_bytes, self._num_entries
         )
 
@@ -866,7 +865,7 @@ class RawStreamerInfo(CascadeLeaf):
     """
 
     def __init__(self, location, serialization, name, class_version):
-        super(RawStreamerInfo, self).__init__(location, len(serialization))
+        super().__init__(location, len(serialization))
         self._serialization = serialization
         self._name = name
         self._class_version = class_version
@@ -880,7 +879,7 @@ class RawStreamerInfo(CascadeLeaf):
         return self._class_version
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4})".format(
+        return "{}({}, {}, {}, {})".format(
             type(self).__name__,
             self._location,
             self._serialization,
@@ -907,11 +906,11 @@ class RawTListOfStrings(CascadeLeaf):
     """
 
     def __init__(self, location, serialization):
-        super(RawTListOfStrings, self).__init__(location, len(serialization))
+        super().__init__(location, len(serialization))
         self._serialization = serialization
 
     def __repr__(self):
-        return "{0}({1}, {2})".format(
+        return "{}({}, {})".format(
             type(self).__name__,
             self._location,
             self._serialization,
@@ -932,22 +931,20 @@ class TListOfStreamers(CascadeNode):
     """
 
     def __init__(self, allocation, key, header, rawstreamers, freesegments):
-        super(TListOfStreamers, self).__init__(freesegments, key, header, *rawstreamers)
+        super().__init__(freesegments, key, header, *rawstreamers)
         self._allocation = allocation
         self._key = key
         self._header = header
         self._rawstreamers = rawstreamers
         self._freesegments = freesegments
-        self._lookup = set(
-            [
-                (x.name, x.class_version)
-                for x in self._rawstreamers
-                if not isinstance(x, RawTListOfStrings)
-            ]
-        )
+        self._lookup = {
+            (x.name, x.class_version)
+            for x in self._rawstreamers
+            if not isinstance(x, RawTListOfStrings)
+        }
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5})".format(
+        return "{}({}, {}, {}, {}, {})".format(
             type(self).__name__,
             self._allocation,
             self._key,
@@ -1044,7 +1041,7 @@ class TListOfStreamers(CascadeNode):
             self._key.allocation + self._allocation
         )
 
-        super(TListOfStreamers, self).write(sink)
+        super().write(sink)
 
     @classmethod
     def deserialize(cls, raw_bytes, location, key, freesegments, file_path, uuid):
@@ -1107,7 +1104,7 @@ class TListOfStreamers(CascadeNode):
         )
 
 
-class _ReadForUpdate(object):
+class _ReadForUpdate:
     def __init__(self, file_path, uuid, get_chunk=None, tlist_of_streamers=None):
         self.file_path = file_path
         self.uuid = uuid
@@ -1166,7 +1163,7 @@ class DirectoryData(CascadeLeaf):
     """
 
     def __init__(self, location, allocation, keys):
-        super(DirectoryData, self).__init__(location, allocation)
+        super().__init__(location, allocation)
         self._dirty_keys = []
         self._dirty_keys_start = None
 
@@ -1179,7 +1176,7 @@ class DirectoryData(CascadeLeaf):
         self._keys = keys
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3})".format(
+        return "{}({}, {}, {})".format(
             type(self).__name__,
             self._location,
             self._allocation,
@@ -1378,7 +1375,7 @@ class DirectoryHeader(CascadeLeaf):
         parent_location,
         uuid,
     ):
-        super(DirectoryHeader, self).__init__(
+        super().__init__(
             location, uproot.reading._directory_format_big.size + 2 + len(uuid.bytes)
         )
         self._begin_location = begin_location
@@ -1391,7 +1388,7 @@ class DirectoryHeader(CascadeLeaf):
         self._modified_on = self._created_on
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7})".format(
+        return "{}({}, {}, {}, {}, {}, {}, {})".format(
             type(self).__name__,
             self._location,
             self._begin_location,
@@ -1534,7 +1531,7 @@ class DirectoryHeader(CascadeLeaf):
 
         if version != cls.class_version:
             raise ValueError(
-                "Uproot can't read TDirectory version {0} for writing, only version {1}{2}".format(
+                "Uproot can't read TDirectory version {} for writing, only version {}{}".format(
                     version,
                     cls.class_version,
                     in_path,
@@ -1808,9 +1805,7 @@ class RootDirectory(Directory):
     """
 
     def __init__(self, key, name, title, header, datakey, data, freesegments):
-        super(RootDirectory, self).__init__(
-            freesegments, datakey, data, key, name, title, header
-        )
+        super().__init__(freesegments, datakey, data, key, name, title, header)
         self._key = key
         self._name = name
         self._title = title
@@ -1820,7 +1815,7 @@ class RootDirectory(Directory):
         self._freesegments = freesegments
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7})".format(
+        return "{}({}, {}, {}, {}, {}, {}, {})".format(
             type(self).__name__,
             self._key,
             self._name,
@@ -1883,7 +1878,7 @@ class RootDirectory(Directory):
         self._datakey.compressed_bytes = self._datakey.uncompressed_bytes
         self._data.location = self._datakey.location + self._datakey.allocation
         self._freesegments.fileheader.begin_num_bytes = self.begin_num_bytes
-        super(RootDirectory, self).write(sink)
+        super().write(sink)
 
 
 class SubDirectory(Directory):
@@ -1895,9 +1890,7 @@ class SubDirectory(Directory):
     """
 
     def __init__(self, key, header, datakey, data, parent, freesegments):
-        super(SubDirectory, self).__init__(
-            freesegments, datakey, data, key, header, parent
-        )
+        super().__init__(freesegments, datakey, data, key, header, parent)
         self._key = key
         self._header = header
         self._datakey = datakey
@@ -1906,7 +1899,7 @@ class SubDirectory(Directory):
         self._freesegments = freesegments
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5}, {6})".format(
+        return "{}({}, {}, {}, {}, {}, {})".format(
             type(self).__name__,
             self._key,
             self._header,
@@ -1955,7 +1948,7 @@ class SubDirectory(Directory):
         self._datakey.uncompressed_bytes = self._data.allocation
         self._datakey.compressed_bytes = self._datakey.uncompressed_bytes
         self._data.location = self._datakey.location + self._datakey.allocation
-        super(SubDirectory, self).write(sink)
+        super().write(sink)
 
 
 class FileHeader(CascadeLeaf):
@@ -1989,7 +1982,7 @@ class FileHeader(CascadeLeaf):
         info_num_bytes,
         uuid,
     ):
-        super(FileHeader, self).__init__(0, 100)
+        super().__init__(0, 100)
         self._end = end
         self._free_location = free_location
         self._free_num_bytes = free_num_bytes
@@ -2003,7 +1996,7 @@ class FileHeader(CascadeLeaf):
         self._begin = 100
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})".format(
+        return "{}({}, {}, {}, {}, {}, {}, {}, {}, {})".format(
             type(self).__name__,
             self._end,
             self._free_location,
@@ -2232,7 +2225,7 @@ class FileHeader(CascadeLeaf):
         return out
 
 
-class CascadingFile(object):
+class CascadingFile:
     """
     An object that represents an entire file, the root of the cascading-node tree.
 
@@ -2254,7 +2247,7 @@ class CascadingFile(object):
         self._tlist_of_streamers = tlist_of_streamers
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4})".format(
+        return "{}({}, {}, {}, {})".format(
             type(self).__name__,
             self._fileheader,
             self._streamers,
@@ -2422,7 +2415,7 @@ def update_existing(sink, initial_directory_bytes, uuid_function):
     )
     if raw_bytes[:4] != b"root":
         raise ValueError(
-            "not a ROOT file: first four bytes are {0}{1}".format(
+            "not a ROOT file: first four bytes are {}{}".format(
                 repr(raw_bytes[:4]), sink.in_path
             )
         )

--- a/src/uproot/writing/_cascadetree.py
+++ b/src/uproot/writing/_cascadetree.py
@@ -14,7 +14,6 @@ and sometimes freeing data.
 See :doc:`uproot.writing._cascade` for a general overview of the cascading writer concept.
 """
 
-from __future__ import absolute_import
 
 import datetime
 import math
@@ -44,7 +43,7 @@ _dtype_to_char = {
 }
 
 
-class Tree(object):
+class Tree:
     """
     Writes a TTree, including all TBranches, TLeaves, and (upon ``extend``) TBaskets.
 
@@ -131,7 +130,7 @@ class Tree(object):
                         awkward = uproot.extras.awkward()
                     except ImportError as err:
                         raise TypeError(
-                            "not a NumPy dtype and 'awkward' cannot be imported: {0}\n\n{1}".format(
+                            "not a NumPy dtype and 'awkward' cannot be imported: {}\n\n{}".format(
                                 repr(branch_type), str(err)
                             )
                         )
@@ -142,7 +141,7 @@ class Tree(object):
                             branch_datashape = awkward.types.from_datashape(branch_type)
                         except Exception:
                             raise TypeError(
-                                "not a NumPy dtype or an Awkward datashape: {0}".format(
+                                "not a NumPy dtype or an Awkward datashape: {}".format(
                                     repr(branch_type)
                                 )
                             )
@@ -171,7 +170,7 @@ class Tree(object):
                             dtype = numpy.dtype(content)
                         except Exception:
                             raise TypeError(
-                                "values of a dict must be NumPy types\n\n    key {0} has type {1}".format(
+                                "values of a dict must be NumPy types\n\n    key {} has type {}".format(
                                     repr(key), repr(content)
                                 )
                             )
@@ -238,7 +237,7 @@ class Tree(object):
                                 dtype = self._branch_ak_to_np(cont)
                                 if dtype is None:
                                     raise TypeError(
-                                        "fields of a record must be NumPy types, though the record itself may be in a jagged array\n\n    field {0} has type {1}".format(
+                                        "fields of a record must be NumPy types, though the record itself may be in a jagged array\n\n    field {} has type {}".format(
                                             repr(key), str(cont)
                                         )
                                     )
@@ -256,7 +255,7 @@ class Tree(object):
                         dt = self._branch_ak_to_np(content)
                         if dt is None:
                             raise TypeError(
-                                "cannot write Awkward Array type to ROOT file:\n\n    {0}".format(
+                                "cannot write Awkward Array type to ROOT file:\n\n    {}".format(
                                     str(branch_datashape)
                                 )
                             )
@@ -288,7 +287,7 @@ class Tree(object):
                             dtype = self._branch_ak_to_np(content)
                             if dtype is None:
                                 raise TypeError(
-                                    "fields of a record must be NumPy types, though the record itself may be in a jagged array\n\n    field {0} has type {1}".format(
+                                    "fields of a record must be NumPy types, though the record itself may be in a jagged array\n\n    field {} has type {}".format(
                                         repr(key), str(content)
                                     )
                                 )
@@ -300,7 +299,7 @@ class Tree(object):
 
                 else:
                     raise TypeError(
-                        "cannot write Awkward Array type to ROOT file:\n\n    {0}".format(
+                        "cannot write Awkward Array type to ROOT file:\n\n    {}".format(
                             str(branch_datashape)
                         )
                     )
@@ -362,16 +361,14 @@ class Tree(object):
 
         letter = _dtype_to_char.get(branch_dtype)
         if letter is None:
-            raise TypeError(
-                "cannot write NumPy dtype {0} in TTree".format(branch_dtype)
-            )
+            raise TypeError(f"cannot write NumPy dtype {branch_dtype} in TTree")
 
         if branch_shape == ():
             dims = ""
         else:
             dims = "".join("[" + str(x) + "]" for x in branch_shape)
 
-        title = "{0}{1}/{2}".format(branch_name, dims, letter)
+        title = f"{branch_name}{dims}/{letter}"
 
         return {
             "fName": branch_name,
@@ -408,7 +405,7 @@ class Tree(object):
         }
 
     def __repr__(self):
-        return "{0}({1}, {2}, {3}, {4}, {5}, {6}, {7})".format(
+        return "{}({}, {}, {}, {}, {}, {}, {})".format(
             type(self).__name__,
             self._directory,
             self._name,
@@ -526,7 +523,7 @@ class Tree(object):
                 awkward = uproot.extras.awkward()
             except ImportError as err:
                 raise TypeError(
-                    "an Awkward Array was provided, but 'awkward' cannot be imported: {0}\n\n{1}".format(
+                    "an Awkward Array was provided, but 'awkward' cannot be imported: {}\n\n{}".format(
                         repr(data), str(err)
                     )
                 )
@@ -575,7 +572,7 @@ class Tree(object):
                                 awkward = uproot.extras.awkward()
                             except ImportError as err:
                                 raise TypeError(
-                                    "NumPy dtype would be dtype('O'), so we won't use NumPy, but 'awkward' cannot be imported: {0}: {1}\n\n{2}".format(
+                                    "NumPy dtype would be dtype('O'), so we won't use NumPy, but 'awkward' cannot be imported: {}: {}\n\n{}".format(
                                         k, type(v), str(err)
                                     )
                                 )
@@ -586,7 +583,7 @@ class Tree(object):
                             awkward = uproot.extras.awkward()
                         except ImportError as err:
                             raise TypeError(
-                                "NumPy dtype is dtype('O'), so we won't use NumPy, but 'awkward' cannot be imported: {0}: {1}\n\n{2}".format(
+                                "NumPy dtype is dtype('O'), so we won't use NumPy, but 'awkward' cannot be imported: {}: {}\n\n{}".format(
                                     k, type(v), str(err)
                                 )
                             )
@@ -598,7 +595,7 @@ class Tree(object):
                         awkward = uproot.extras.awkward()
                     except ImportError as err:
                         raise TypeError(
-                            "an Awkward Array was provided, but 'awkward' cannot be imported: {0}: {1}\n\n{2}".format(
+                            "an Awkward Array was provided, but 'awkward' cannot be imported: {}: {}\n\n{}".format(
                                 k, type(v), str(err)
                             )
                         )
@@ -612,7 +609,7 @@ class Tree(object):
                         if kk in provided:
                             if not numpy.array_equal(vv, provided[kk]):
                                 raise ValueError(
-                                    "branch {0} provided both as an explicit array and generated as a counter, and they disagree".format(
+                                    "branch {} provided both as an explicit array and generated as a counter, and they disagree".format(
                                         repr(kk)
                                     )
                                 )
@@ -621,7 +618,7 @@ class Tree(object):
                 if k in provided:
                     if not numpy.array_equal(v, provided[k]):
                         raise ValueError(
-                            "branch {0} provided both as an explicit array and generated as a counter, and they disagree".format(
+                            "branch {} provided both as an explicit array and generated as a counter, and they disagree".format(
                                 repr(kk)
                             )
                         )
@@ -656,7 +653,7 @@ class Tree(object):
 
                 else:
                     raise ValueError(
-                        "'extend' must be given an array for every branch; missing {0}".format(
+                        "'extend' must be given an array for every branch; missing {}".format(
                             repr(datum["name"])
                         )
                     )
@@ -666,14 +663,14 @@ class Tree(object):
                     actual_branches[datum["fName"]] = provided.pop(datum["fName"])
                 else:
                     raise ValueError(
-                        "'extend' must be given an array for every branch; missing {0}".format(
+                        "'extend' must be given an array for every branch; missing {}".format(
                             repr(datum["fName"])
                         )
                     )
 
         if len(provided) != 0:
             raise ValueError(
-                "'extend' was given data that do not correspond to any branch: {0}".format(
+                "'extend' was given data that do not correspond to any branch: {}".format(
                     ", ".join(repr(x) for x in provided)
                 )
             )
@@ -685,7 +682,7 @@ class Tree(object):
                 num_entries = len(branch_array)
             elif num_entries != len(branch_array):
                 raise ValueError(
-                    "'extend' must fill every branch with the same number of entries; {0} has {1} entries".format(
+                    "'extend' must fill every branch with the same number of entries; {} has {} entries".format(
                         repr(branch_name),
                         len(branch_array),
                     )
@@ -699,7 +696,7 @@ class Tree(object):
                 big_endian = numpy.asarray(branch_array, dtype=datum["dtype"])
                 if big_endian.shape != (len(branch_array),) + datum["shape"]:
                     raise ValueError(
-                        "'extend' must fill branches with a consistent shape: has {0}, trying to fill with {1}".format(
+                        "'extend' must fill branches with a consistent shape: has {}, trying to fill with {}".format(
                             datum["shape"],
                             big_endian.shape[1:],
                         )
@@ -716,7 +713,7 @@ class Tree(object):
                     awkward = uproot.extras.awkward()
                 except ImportError as err:
                     raise TypeError(
-                        "a jagged array was provided (possibly as an iterable), but 'awkward' cannot be imported: {0}: {1}\n\n{2}".format(
+                        "a jagged array was provided (possibly as an iterable), but 'awkward' cannot be imported: {}: {}\n\n{}".format(
                             branch_name, repr(branch_array), str(err)
                         )
                     )
@@ -801,7 +798,7 @@ class Tree(object):
 
                 if shape[1:] != datum["shape"]:
                     raise ValueError(
-                        "'extend' must fill branches with a consistent shape: has {0}, trying to fill with {1}".format(
+                        "'extend' must fill branches with a consistent shape: has {}, trying to fill with {}".format(
                             datum["shape"],
                             shape[1:],
                         )

--- a/src/uproot/writing/_cascadetree.py
+++ b/src/uproot/writing/_cascadetree.py
@@ -128,12 +128,10 @@ class Tree:
                 except TypeError:
                     try:
                         awkward = uproot.extras.awkward()
-                    except ImportError as err:
+                    except ModuleNotFoundError as err:
                         raise TypeError(
-                            "not a NumPy dtype and 'awkward' cannot be imported: {}\n\n{}".format(
-                                repr(branch_type), str(err)
-                            )
-                        )
+                            f"not a NumPy dtype and 'awkward' cannot be imported: {branch_type!r}"
+                        ) from err
                     if isinstance(branch_type, awkward.types.Type):
                         branch_datashape = branch_type
                     else:
@@ -141,9 +139,7 @@ class Tree:
                             branch_datashape = awkward.types.from_datashape(branch_type)
                         except Exception:
                             raise TypeError(
-                                "not a NumPy dtype or an Awkward datashape: {}".format(
-                                    repr(branch_type)
-                                )
+                                f"not a NumPy dtype or an Awkward datashape: {branch_type!r}"
                             )
                     # checking by class name to be Awkward v1/v2 insensitive
                     if type(branch_datashape).__name__ == "ArrayType":
@@ -521,12 +517,11 @@ class Tree:
         if module_name == "awkward" or module_name.startswith("awkward."):
             try:
                 awkward = uproot.extras.awkward()
-            except ImportError as err:
+            except ModuleNotFoundError as err:
                 raise TypeError(
-                    "an Awkward Array was provided, but 'awkward' cannot be imported: {}\n\n{}".format(
-                        repr(data), str(err)
-                    )
-                )
+                    f"an Awkward Array was provided, but 'awkward' cannot be imported: {data!r}"
+                ) from err
+
             if isinstance(data, awkward.Array):
                 if data.ndim > 1 and not data.layout.purelist_isregular:
                     provided = {
@@ -570,35 +565,29 @@ class Tree:
                         except (numpy.VisibleDeprecationWarning, Exception):
                             try:
                                 awkward = uproot.extras.awkward()
-                            except ImportError as err:
+                            except ModuleNotFoundError as err:
                                 raise TypeError(
-                                    "NumPy dtype would be dtype('O'), so we won't use NumPy, but 'awkward' cannot be imported: {}: {}\n\n{}".format(
-                                        k, type(v), str(err)
-                                    )
-                                )
+                                    f"NumPy dtype would be dtype('O'), so we won't use NumPy, but 'awkward' cannot be imported: {k}: {type(v)}"
+                                ) from err
                             v = awkward.from_iter(v)
 
                     if getattr(v, "dtype", None) == numpy.dtype("O"):
                         try:
                             awkward = uproot.extras.awkward()
-                        except ImportError as err:
+                        except ModuleNotFoundError as err:
                             raise TypeError(
-                                "NumPy dtype is dtype('O'), so we won't use NumPy, but 'awkward' cannot be imported: {}: {}\n\n{}".format(
-                                    k, type(v), str(err)
-                                )
-                            )
+                                f"NumPy dtype is dtype('O'), so we won't use NumPy, but 'awkward' cannot be imported: {k}: {type(v)}"
+                            ) from err
                         v = awkward.from_iter(v)
 
                 module_name = type(v).__module__
                 if module_name == "awkward" or module_name.startswith("awkward."):
                     try:
                         awkward = uproot.extras.awkward()
-                    except ImportError as err:
+                    except ModuleNotFoundError as err:
                         raise TypeError(
-                            "an Awkward Array was provided, but 'awkward' cannot be imported: {}: {}\n\n{}".format(
-                                k, type(v), str(err)
-                            )
-                        )
+                            f"an Awkward Array was provided, but 'awkward' cannot be imported: {k}: {type(v)}"
+                        ) from err
                     if (
                         isinstance(v, awkward.Array)
                         and v.ndim > 1
@@ -711,12 +700,10 @@ class Tree:
             else:
                 try:
                     awkward = uproot.extras.awkward()
-                except ImportError as err:
+                except ModuleNotFoundError as err:
                     raise TypeError(
-                        "a jagged array was provided (possibly as an iterable), but 'awkward' cannot be imported: {}: {}\n\n{}".format(
-                            branch_name, repr(branch_array), str(err)
-                        )
-                    )
+                        f"a jagged array was provided (possibly as an iterable), but 'awkward' cannot be imported: {branch_name}: {branch_array!r}"
+                    ) from err
                 layout = branch_array.layout
                 while not isinstance(
                     layout,

--- a/src/uproot/writing/identify.py
+++ b/src/uproot/writing/identify.py
@@ -16,7 +16,6 @@ The (many) other functions in this module construct writable :doc:`uproot.model.
 objects from Python builtins and other writable models.
 """
 
-from __future__ import absolute_import
 
 from collections.abc import Mapping
 
@@ -219,7 +218,7 @@ def to_writable(obj):
             return uproot.pyroot._PyROOTWritable(obj)
         else:
             raise TypeError(
-                "only instances of TObject can be written to files, not {0}".format(
+                "only instances of TObject can be written to files, not {}".format(
                     type(obj).__name__
                 )
             )
@@ -799,7 +798,7 @@ def to_TArray(data):
         cls = uproot.models.TArray.Model_TArrayD
     else:
         raise ValueError(
-            "data to convert to TArray must have signed integer or floating-point type, not {0}".format(
+            "data to convert to TArray must have signed integer or floating-point type, not {}".format(
                 repr(data.dtype)
             )
         )
@@ -1124,9 +1123,7 @@ def to_TH1x(
     elif isinstance(tarray_data, uproot.models.TArray.Model_TArrayD):
         cls = uproot.models.TH.Model_TH1D_v3
     else:
-        raise TypeError(
-            "no TH1* subclasses correspond to {0}".format(tarray_data.classname)
-        )
+        raise TypeError(f"no TH1* subclasses correspond to {tarray_data.classname}")
 
     th1x = cls.empty()
     th1x._bases.append(th1)
@@ -1289,9 +1286,7 @@ def to_TH2x(
     elif isinstance(tarray_data, uproot.models.TArray.Model_TArrayD):
         cls = uproot.models.TH.Model_TH2D_v4
     else:
-        raise TypeError(
-            "no TH2* subclasses correspond to {0}".format(tarray_data.classname)
-        )
+        raise TypeError(f"no TH2* subclasses correspond to {tarray_data.classname}")
 
     th2x = cls.empty()
     th2x._bases.append(th2)
@@ -1468,9 +1463,7 @@ def to_TH3x(
     elif isinstance(tarray_data, uproot.models.TArray.Model_TArrayD):
         cls = uproot.models.TH.Model_TH3D_v4
     else:
-        raise TypeError(
-            "no TH3* subclasses correspond to {0}".format(tarray_data.classname)
-        )
+        raise TypeError(f"no TH3* subclasses correspond to {tarray_data.classname}")
 
     th3x = cls.empty()
     th3x._bases.append(th3)

--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -16,7 +16,6 @@ There is no feature parity between writable and readable versions of each of the
 types. Writing and reading are considered separate projects with different capabilities.
 """
 
-from __future__ import absolute_import
 
 import datetime
 import itertools
@@ -64,7 +63,7 @@ def create(file_path, **options):
         if os.path.exists(file_path):
             raise OSError(
                 "path exists and refusing to overwrite (use 'uproot.recreate' to "
-                "overwrite)\n\nfor path {0}".format(file_path)
+                "overwrite)\n\nfor path {}".format(file_path)
             )
     return recreate(file_path, **options)
 
@@ -213,7 +212,7 @@ class WritableFile(uproot.reading.CommonFileMethods):
         self._trees = {}
 
     def __repr__(self):
-        return "<WritableFile {0} at 0x{1:012x}>".format(repr(self.file_path), id(self))
+        return f"<WritableFile {repr(self.file_path)} at 0x{id(self):012x}>"
 
     @property
     def sink(self):
@@ -504,7 +503,7 @@ class WritableDirectory(MutableMapping):
         self._subdirs = {}
 
     def __repr__(self):
-        return "<WritableDirectory {0} at 0x{1:012x}>".format(
+        return "<WritableDirectory {} at 0x{:012x}>".format(
             repr("/" + "/".join(self._path)), id(self)
         )
 
@@ -614,7 +613,7 @@ class WritableDirectory(MutableMapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return the names of objects directly accessible
@@ -645,7 +644,7 @@ class WritableDirectory(MutableMapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return objects directly accessible in this
@@ -676,7 +675,7 @@ class WritableDirectory(MutableMapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return (name, object) pairs directly accessible
@@ -709,7 +708,7 @@ class WritableDirectory(MutableMapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return the names and classnames of objects
@@ -741,7 +740,7 @@ class WritableDirectory(MutableMapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return the names of objects directly accessible
@@ -764,7 +763,7 @@ class WritableDirectory(MutableMapping):
                 filter_classname is no_filter or filter_classname(classname)
             ):
                 if cycle:
-                    yield "{0};{1}".format(keyname, cyclenum)
+                    yield f"{keyname};{cyclenum}"
                 else:
                     yield keyname
 
@@ -777,7 +776,7 @@ class WritableDirectory(MutableMapping):
                     filter_name=filter_name,
                     filter_classname=filter_classname,
                 ):
-                    k2 = "{0}/{1}".format(keyname, k1)
+                    k2 = f"{keyname}/{k1}"
                     k3 = k2[: k2.index(";")] if ";" in k2 else k2
                     if filter_name is no_filter or filter_name(k3):
                         yield k2
@@ -788,7 +787,7 @@ class WritableDirectory(MutableMapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return objects directly accessible in this
@@ -819,7 +818,7 @@ class WritableDirectory(MutableMapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return (name, object) pairs directly accessible
@@ -854,7 +853,7 @@ class WritableDirectory(MutableMapping):
         filter_name=no_filter,
         filter_classname=no_filter,
     ):
-        u"""
+        """
         Args:
             recursive (bool): If True, descend into any nested subdirectories.
                 If False, only return the names and classnames of objects
@@ -877,7 +876,7 @@ class WritableDirectory(MutableMapping):
                 filter_classname is no_filter or filter_classname(classname)
             ):
                 if cycle:
-                    yield "{0};{1}".format(keyname, cyclenum), classname
+                    yield f"{keyname};{cyclenum}", classname
                 else:
                     yield keyname, classname
 
@@ -890,7 +889,7 @@ class WritableDirectory(MutableMapping):
                     filter_name=filter_name,
                     filter_classname=filter_classname,
                 ):
-                    k2 = "{0}/{1}".format(keyname, k1)
+                    k2 = f"{keyname}/{k1}"
                     k3 = k2[: k2.index(";")] if ";" in k2 else k2
                     if filter_name is no_filter or filter_name(k3):
                         yield k2, c1
@@ -1190,8 +1189,8 @@ class WritableDirectory(MutableMapping):
 
         elif key.classname.string not in ("TDirectory", "TDirectoryFile"):
             raise TypeError(
-                """cannot make a directory named {0} because a {1} already has that name
-in file {2} in directory {3}""".format(
+                """cannot make a directory named {} because a {} already has that name
+in file {} in directory {}""".format(
                     repr(name), key.classname.string, self.file_path, self.path
                 )
             )
@@ -1215,7 +1214,7 @@ in file {2} in directory {3}""".format(
         initial_basket_capacity=10,
         resize_factor=10.0,
     ):
-        u"""
+        """
         Args:
             name (str): Name of the new TTree.
             branch_types (dict or pairs of str \u2192 NumPy dtype/Awkward type): Name
@@ -1309,7 +1308,7 @@ in file {2} in directory {3}""".format(
         rename=no_rename,
         require_matches=True,
     ):
-        u"""
+        """
         Args:
             source (:doc:`uproot.writing.writable.WritableDirectory` or :doc:`uproot.reading.ReadOnlyDirectory`): Directory from which to copy.
             filter_name (None, glob string, regex string in ``"/pattern/i"`` syntax, function of str \u2192 bool, or iterable of the above): A
@@ -1343,8 +1342,8 @@ in file {2} in directory {3}""".format(
         if len(old_names) == 0:
             if require_matches:
                 raise ValueError(
-                    """no objects found with names matching {0}
-in file {1} in directory {2}""".format(
+                    """no objects found with names matching {}
+in file {} in directory {}""".format(
                         repr(filter_name), source.file_path, source.path
                     )
                 )
@@ -1356,7 +1355,7 @@ in file {1} in directory {2}""".format(
         for key in keys:
             if key.fClassName == "TTree" or key.fClassName.split("::")[-1] == "RNTuple":
                 raise NotImplementedError(
-                    "copy_from cannot copy {0} objects yet".format(key.fClassName)
+                    f"copy_from cannot copy {key.fClassName} objects yet"
                 )
 
         rename = uproot._util.regularize_rename(rename)
@@ -1373,7 +1372,7 @@ in file {1} in directory {2}""".format(
         source.file.source.chunks(list(ranges), notifications=notifications)
 
         classversion_pairs = set()
-        for classname in set(x.fClassName for x in keys):
+        for classname in {x.fClassName for x in keys}:
             for streamer in source.file.streamers_named(classname):
                 batch = []
                 streamer._dependencies(source.file.streamers, batch)
@@ -1427,7 +1426,7 @@ in file {1} in directory {2}""".format(
             )
 
     def update(self, pairs=None, **more_pairs):
-        u"""
+        """
         Args:
             pairs (dict or pairs of str \u2192 writable data): Names and data to write.
             more_pairs (dict or pairs of str \u2192 writable data): More names and data to write.
@@ -1463,7 +1462,7 @@ in file {1} in directory {2}""".format(
         self._file._cascading.streamers.update_streamers(self._file.sink, streamers)
 
 
-class WritableTree(object):
+class WritableTree:
     """
     Args:
         path (tuple of str): Path of directory names to this TTree.
@@ -1549,7 +1548,7 @@ class WritableTree(object):
         self._cascading = cascading
 
     def __repr__(self):
-        return "<WritableTree {0} at 0x{1:012x}>".format(
+        return "<WritableTree {} at 0x{:012x}>".format(
             repr("/" + "/".join(self._path)), id(self)
         )
 
@@ -1711,7 +1710,7 @@ class WritableTree(object):
         return self._cascading.num_baskets
 
     def extend(self, data):
-        u"""
+        """
         Args:
             data (dict of str \u2192 arrays): More array data to add to the TTree.
 
@@ -1768,7 +1767,7 @@ class WritableTree(object):
         )
 
 
-class WritableBranch(object):
+class WritableBranch:
     """
     Represents a TBranch from a :doc:`uproot.writing.writable.WritableTree`.
 
@@ -1794,7 +1793,7 @@ class WritableBranch(object):
         self._datum = datum
 
     def __repr__(self):
-        return "<WritableBranch {0} in {1} at 0x{2:012x}>".format(
+        return "<WritableBranch {} in {} at 0x{:012x}>".format(
             repr(self._datum["fName"]), repr("/" + "/".join(self._tree.path)), id(self)
         )
 

--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -212,7 +212,7 @@ class WritableFile(uproot.reading.CommonFileMethods):
         self._trees = {}
 
     def __repr__(self):
-        return f"<WritableFile {repr(self.file_path)} at 0x{id(self):012x}>"
+        return f"<WritableFile {self.file_path!r} at 0x{id(self):012x}>"
 
     @property
     def sink(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/tests/test_0001-source-class.py
+++ b/tests/test_0001-source-class.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import os
 import sys
@@ -110,7 +109,7 @@ def test_http():
     with source as tmp:
         notifications = queue.Queue()
         chunks = tmp.chunks([(0, 100), (50, 55), (200, 400)], notifications)
-        one, two, three = [tobytes(chunk.raw_data) for chunk in chunks]
+        one, two, three = (tobytes(chunk.raw_data) for chunk in chunks)
         assert len(one) == 100
         assert len(two) == 5
         assert len(three) == 200
@@ -147,7 +146,7 @@ def test_http_port():
     with source as tmp:
         notifications = queue.Queue()
         chunks = tmp.chunks([(0, 100), (50, 55), (200, 400)], notifications)
-        one, two, three = [tobytes(chunk.raw_data) for chunk in chunks]
+        one, two, three = (tobytes(chunk.raw_data) for chunk in chunks)
         assert len(one) == 100
         assert len(two) == 5
         assert len(three) == 200
@@ -218,7 +217,7 @@ def test_no_multipart():
         ) as source:
             notifications = queue.Queue()
             chunks = source.chunks([(0, 100), (50, 55), (200, 400)], notifications)
-            one, two, three = [tobytes(chunk.raw_data) for chunk in chunks]
+            one, two, three = (tobytes(chunk.raw_data) for chunk in chunks)
             assert len(one) == 100
             assert len(two) == 5
             assert len(three) == 200
@@ -247,7 +246,7 @@ def test_fallback():
         ) as source:
             notifications = queue.Queue()
             chunks = source.chunks([(0, 100), (50, 55), (200, 400)], notifications)
-            one, two, three = [tobytes(chunk.raw_data) for chunk in chunks]
+            one, two, three = (tobytes(chunk.raw_data) for chunk in chunks)
             assert len(one) == 100
             assert len(two) == 5
             assert len(three) == 200
@@ -268,7 +267,7 @@ def test_xrootd():
     ) as source:
         notifications = queue.Queue()
         chunks = source.chunks([(0, 100), (50, 55), (200, 400)], notifications)
-        one, two, three = [tobytes(chunk.raw_data) for chunk in chunks]
+        one, two, three = (tobytes(chunk.raw_data) for chunk in chunks)
         assert len(one) == 100
         assert len(two) == 5
         assert len(three) == 200
@@ -314,7 +313,7 @@ def test_xrootd_vectorread():
     ) as source:
         notifications = queue.Queue()
         chunks = source.chunks([(0, 100), (50, 55), (200, 400)], notifications)
-        one, two, three = [tobytes(chunk.raw_data) for chunk in chunks]
+        one, two, three = (tobytes(chunk.raw_data) for chunk in chunks)
         assert len(one) == 100
         assert len(two) == 5
         assert len(three) == 200
@@ -337,7 +336,7 @@ def test_xrootd_vectorread_max_element_split():
         notifications = queue.Queue()
         max_element_size = 2097136
         chunks = source.chunks([(0, max_element_size + 1)], notifications)
-        (one,) = [tobytes(chunk.raw_data) for chunk in chunks]
+        (one,) = (tobytes(chunk.raw_data) for chunk in chunks)
         assert len(one) == max_element_size + 1
 
 
@@ -355,7 +354,7 @@ def test_xrootd_vectorread_max_element_split_consistency():
             notifications = queue.Queue()
             max_element_size = 2097136
             chunks = source.chunks([(0, max_element_size + 1)], notifications)
-            (one,) = [tobytes(chunk.raw_data) for chunk in chunks]
+            (one,) = (tobytes(chunk.raw_data) for chunk in chunks)
             return one
 
     chunk1 = get_chunk(

--- a/tests/test_0001-source-class.py
+++ b/tests/test_0001-source-class.py
@@ -2,16 +2,9 @@
 
 
 import os
+import queue
 import sys
-
-try:
-    from io import StringIO
-except ImportError:
-    from StringIO import StringIO
-try:
-    import queue
-except ImportError:
-    import Queue as queue
+from io import StringIO
 
 import numpy
 import pytest

--- a/tests/test_0006-notify-when-downloaded.py
+++ b/tests/test_0006-notify-when-downloaded.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import os
 import sys
@@ -31,7 +30,7 @@ def test_file(tmpdir):
             [(0, 6), (6, 10), (10, 13), (13, 20), (20, 25), (25, 30)],
             notifications=notifications,
         )
-        expected = dict(((chunk.start, chunk.stop), chunk) for chunk in chunks)
+        expected = {(chunk.start, chunk.stop): chunk for chunk in chunks}
         while len(expected) > 0:
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))
@@ -48,7 +47,7 @@ def test_file_workers(tmpdir):
             [(0, 6), (6, 10), (10, 13), (13, 20), (20, 25), (25, 30)],
             notifications=notifications,
         )
-        expected = dict(((chunk.start, chunk.stop), chunk) for chunk in chunks)
+        expected = {(chunk.start, chunk.stop): chunk for chunk in chunks}
         while len(expected) > 0:
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))
@@ -65,7 +64,7 @@ def test_memmap(tmpdir):
             [(0, 6), (6, 10), (10, 13), (13, 20), (20, 25), (25, 30)],
             notifications=notifications,
         )
-        expected = dict(((chunk.start, chunk.stop), chunk) for chunk in chunks)
+        expected = {(chunk.start, chunk.stop): chunk for chunk in chunks}
         while len(expected) > 0:
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))
@@ -80,7 +79,7 @@ def test_http_multipart():
         chunks = source.chunks(
             [(0, 100), (50, 55), (200, 400)], notifications=notifications
         )
-        expected = dict(((chunk.start, chunk.stop), chunk) for chunk in chunks)
+        expected = {(chunk.start, chunk.stop): chunk for chunk in chunks}
         while len(expected) > 0:
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))
@@ -95,7 +94,7 @@ def test_http():
         chunks = source.chunks(
             [(0, 100), (50, 55), (200, 400)], notifications=notifications
         )
-        expected = dict(((chunk.start, chunk.stop), chunk) for chunk in chunks)
+        expected = {(chunk.start, chunk.stop): chunk for chunk in chunks}
         while len(expected) > 0:
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))
@@ -110,7 +109,7 @@ def test_http_workers():
         chunks = source.chunks(
             [(0, 100), (50, 55), (200, 400)], notifications=notifications
         )
-        expected = dict(((chunk.start, chunk.stop), chunk) for chunk in chunks)
+        expected = {(chunk.start, chunk.stop): chunk for chunk in chunks}
         while len(expected) > 0:
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))
@@ -127,7 +126,7 @@ def test_http_fallback():
         chunks = source.chunks(
             [(0, 100), (50, 55), (200, 400)], notifications=notifications
         )
-        expected = dict(((chunk.start, chunk.stop), chunk) for chunk in chunks)
+        expected = {(chunk.start, chunk.stop): chunk for chunk in chunks}
         while len(expected) > 0:
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))
@@ -144,7 +143,7 @@ def test_http_fallback_workers():
         chunks = source.chunks(
             [(0, 100), (50, 55), (200, 400)], notifications=notifications
         )
-        expected = dict(((chunk.start, chunk.stop), chunk) for chunk in chunks)
+        expected = {(chunk.start, chunk.stop): chunk for chunk in chunks}
         while len(expected) > 0:
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))
@@ -166,7 +165,7 @@ def test_xrootd():
         chunks = source.chunks(
             [(0, 100), (50, 55), (200, 400)], notifications=notifications
         )
-        expected = dict(((chunk.start, chunk.stop), chunk) for chunk in chunks)
+        expected = {(chunk.start, chunk.stop): chunk for chunk in chunks}
         while len(expected) > 0:
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))
@@ -188,7 +187,7 @@ def test_xrootd_workers():
         chunks = source.chunks(
             [(0, 100), (50, 55), (200, 400)], notifications=notifications
         )
-        expected = dict(((chunk.start, chunk.stop), chunk) for chunk in chunks)
+        expected = {(chunk.start, chunk.stop): chunk for chunk in chunks}
         while len(expected) > 0:
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))
@@ -211,7 +210,7 @@ def test_xrootd_vectorread():
         chunks = source.chunks(
             [(0, 100), (50, 55), (200, 400)], notifications=notifications
         )
-        expected = dict(((chunk.start, chunk.stop), chunk) for chunk in chunks)
+        expected = {(chunk.start, chunk.stop): chunk for chunk in chunks}
         while len(expected) > 0:
             chunk = notifications.get()
             expected.pop((chunk.start, chunk.stop))

--- a/tests/test_0006-notify-when-downloaded.py
+++ b/tests/test_0006-notify-when-downloaded.py
@@ -2,16 +2,9 @@
 
 
 import os
+import queue
 import sys
-
-try:
-    from io import StringIO
-except ImportError:
-    from StringIO import StringIO
-try:
-    import queue
-except ImportError:
-    import Queue as queue
+from io import StringIO
 
 import numpy
 import pytest

--- a/tests/test_0007-single-chunk-interface.py
+++ b/tests/test_0007-single-chunk-interface.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import os
 import sys

--- a/tests/test_0008-start-interpretation.py
+++ b/tests/test_0008-start-interpretation.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import sys
 

--- a/tests/test_0009-nested-directories.py
+++ b/tests/test_0009-nested-directories.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import sys
 

--- a/tests/test_0010-start-streamers.py
+++ b/tests/test_0010-start-streamers.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys
@@ -1110,7 +1109,7 @@ from_ROOT["TString"] = json.loads(
 
 def drop_fbits(x):
     if isinstance(x, dict):
-        return dict((k, drop_fbits(v)) for k, v in x.items() if k != "fBits")
+        return {k: drop_fbits(v) for k, v in x.items() if k != "fBits"}
     elif isinstance(x, list):
         return list(drop_fbits(v) for v in x)
     else:

--- a/tests/test_0011-generate-classes-from-streamers.py
+++ b/tests/test_0011-generate-classes-from-streamers.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys
@@ -146,11 +145,11 @@ from_ROOT["one"] = json.loads(
 
 def drop_fbits(x):
     if isinstance(x, dict):
-        return dict(
-            (k, drop_fbits(v))
+        return {
+            k: drop_fbits(v)
             for k, v in x.items()
             if k not in ("fBits", "fStatOverflows", "fN", "fArray")
-        )
+        }
     elif isinstance(x, list):
         return list(drop_fbits(v) for v in x)
     else:

--- a/tests/test_0013-rntuple-anchor.py
+++ b/tests/test_0013-rntuple-anchor.py
@@ -2,12 +2,8 @@
 
 
 import json
+import queue
 import sys
-
-try:
-    import queue
-except ImportError:
-    import Queue as queue
 
 import numpy
 import pytest

--- a/tests/test_0013-rntuple-anchor.py
+++ b/tests/test_0013-rntuple-anchor.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys

--- a/tests/test_0014-all-ttree-versions.py
+++ b/tests/test_0014-all-ttree-versions.py
@@ -3,11 +3,7 @@
 
 import json
 import sys
-
-try:
-    from io import StringIO
-except ImportError:
-    from StringIO import StringIO
+from io import StringIO
 
 import numpy
 import pytest

--- a/tests/test_0014-all-ttree-versions.py
+++ b/tests/test_0014-all-ttree-versions.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys

--- a/tests/test_0016-interpretations.py
+++ b/tests/test_0016-interpretations.py
@@ -3,11 +3,7 @@
 
 import json
 import sys
-
-try:
-    from io import StringIO
-except ImportError:
-    from StringIO import StringIO
+from io import StringIO
 
 import numpy
 import pytest

--- a/tests/test_0016-interpretations.py
+++ b/tests/test_0016-interpretations.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys

--- a/tests/test_0017-multi-basket-multi-branch-fetch.py
+++ b/tests/test_0017-multi-basket-multi-branch-fetch.py
@@ -3,11 +3,7 @@
 
 import json
 import sys
-
-try:
-    from io import StringIO
-except ImportError:
-    from StringIO import StringIO
+from io import StringIO
 
 import numpy
 import pytest

--- a/tests/test_0017-multi-basket-multi-branch-fetch.py
+++ b/tests/test_0017-multi-basket-multi-branch-fetch.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys

--- a/tests/test_0018-array-fetching-interface.py
+++ b/tests/test_0018-array-fetching-interface.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys
@@ -129,12 +128,10 @@ def test_compute():
             {"stuff": [24, 26, 28, 30], "i4": 14},
         ]
 
-        assert set(sample.file.array_cache) == set(
-            [
-                "db4be408-93ad-11ea-9027-d201a8c0beef:/sample;1:i4:AsDtype(Bi4(),Li4()):0-30:ak",
-                "db4be408-93ad-11ea-9027-d201a8c0beef:/sample;1:Ai8:AsJagged(AsDtype(Bi8(),Li8()),0):0-30:ak",
-            ]
-        )
+        assert set(sample.file.array_cache) == {
+            "db4be408-93ad-11ea-9027-d201a8c0beef:/sample;1:i4:AsDtype(Bi4(),Li4()):0-30:ak",
+            "db4be408-93ad-11ea-9027-d201a8c0beef:/sample;1:Ai8:AsJagged(AsDtype(Bi8(),Li8()),0):0-30:ak",
+        }
 
 
 def test_arrays():
@@ -188,12 +185,10 @@ def test_arrays():
             {"I4": 14, "F4": 14.100000381469727},
         ]
 
-        assert set(sample.file.array_cache) == set(
-            [
-                "db4be408-93ad-11ea-9027-d201a8c0beef:/sample;1:i4:AsDtype(Bi4(),Li4()):0-30:ak",
-                "db4be408-93ad-11ea-9027-d201a8c0beef:/sample;1:f4:AsDtype(Bf4(),Lf4()):0-30:ak",
-            ]
-        )
+        assert set(sample.file.array_cache) == {
+            "db4be408-93ad-11ea-9027-d201a8c0beef:/sample;1:i4:AsDtype(Bi4(),Li4()):0-30:ak",
+            "db4be408-93ad-11ea-9027-d201a8c0beef:/sample;1:f4:AsDtype(Bf4(),Lf4()):0-30:ak",
+        }
 
         result = sample.arrays({"i4": interp_i4, "f4": interp_f4})
         assert result.tolist() == [

--- a/tests/test_0022-number-of-branches.py
+++ b/tests/test_0022-number-of-branches.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys
@@ -19,31 +18,31 @@ def test_branchname():
         assert sample.arrays("i4", library="np")["i4"].tolist() == list(range(-15, 15))
 
         arrays = sample.arrays(["i4", "i8"], library="np")
-        assert set(arrays.keys()) == set(["i4", "i8"])
+        assert set(arrays.keys()) == {"i4", "i8"}
         assert arrays["i4"].tolist() == list(range(-15, 15))
         assert arrays["i8"].tolist() == list(range(-15, 15))
 
         arrays = sample.arrays(filter_name="/i[48]/", library="np")
-        assert set(arrays.keys()) == set(["i4", "i8"])
+        assert set(arrays.keys()) == {"i4", "i8"}
         assert arrays["i4"].tolist() == list(range(-15, 15))
         assert arrays["i8"].tolist() == list(range(-15, 15))
 
         arrays = sample.arrays(filter_name=["/i[12]/", "/i[48]/"], library="np")
-        assert set(arrays.keys()) == set(["i1", "i2", "i4", "i8"])
+        assert set(arrays.keys()) == {"i1", "i2", "i4", "i8"}
         assert arrays["i1"].tolist() == list(range(-15, 15))
         assert arrays["i2"].tolist() == list(range(-15, 15))
         assert arrays["i4"].tolist() == list(range(-15, 15))
         assert arrays["i8"].tolist() == list(range(-15, 15))
 
         arrays = sample.arrays(filter_name="i*", library="np")
-        assert set(arrays.keys()) == set(["i1", "i2", "i4", "i8"])
+        assert set(arrays.keys()) == {"i1", "i2", "i4", "i8"}
         assert arrays["i1"].tolist() == list(range(-15, 15))
         assert arrays["i2"].tolist() == list(range(-15, 15))
         assert arrays["i4"].tolist() == list(range(-15, 15))
         assert arrays["i8"].tolist() == list(range(-15, 15))
 
         arrays = sample.arrays(["i4", "i8"], filter_name="u*", library="np")
-        assert set(arrays.keys()) == set(["i4", "i8"])
+        assert set(arrays.keys()) == {"i4", "i8"}
         assert arrays["i4"].tolist() == list(range(-15, 15))
         assert arrays["i8"].tolist() == list(range(-15, 15))
 
@@ -72,7 +71,7 @@ def test_interpretation():
         ) + list(range(0, 15))
 
         arrays = sample.arrays({"i1": ">u1", "i2": ">u2"}, library="np")
-        assert set(arrays.keys()) == set(["i1", "i2"])
+        assert set(arrays.keys()) == {"i1", "i2"}
         assert arrays["i1"].tolist() == list(range(241, 256)) + list(range(0, 15))
         assert arrays["i2"].tolist() == list(range(65521, 65536)) + list(range(0, 15))
 
@@ -82,7 +81,7 @@ def test_interpretation():
         assert arrays[1].tolist() == list(range(65521, 65536)) + list(range(0, 15))
 
         arrays = sample.arrays({"i1": ">u1", "i2": None}, library="np")
-        assert set(arrays.keys()) == set(["i1", "i2"])
+        assert set(arrays.keys()) == {"i1", "i2"}
         assert arrays["i1"].tolist() == list(range(241, 256)) + list(range(0, 15))
         assert arrays["i2"].tolist() == list(range(-15, 15))
 
@@ -104,17 +103,17 @@ def test_compute():
         )
 
         arrays = sample.arrays(["i4 + 100", "i8 + 100"], library="np")
-        assert set(arrays.keys()) == set(["i4 + 100", "i8 + 100"])
+        assert set(arrays.keys()) == {"i4 + 100", "i8 + 100"}
         assert arrays["i4 + 100"].tolist() == list(range(85, 115))
         assert arrays["i8 + 100"].tolist() == list(range(85, 115))
 
         arrays = sample.arrays(["i4 + 100", "i4 + 200"], library="np")
-        assert set(arrays.keys()) == set(["i4 + 100", "i4 + 200"])
+        assert set(arrays.keys()) == {"i4 + 100", "i4 + 200"}
         assert arrays["i4 + 100"].tolist() == list(range(85, 115))
         assert arrays["i4 + 200"].tolist() == list(range(185, 215))
 
         arrays = sample.arrays(["i4 + 100", "i4 + 100"], library="np")
-        assert set(arrays.keys()) == set(["i4 + 100"])
+        assert set(arrays.keys()) == {"i4 + 100"}
         assert arrays["i4 + 100"].tolist() == list(range(85, 115))
 
         arrays = sample.arrays(["i4 + 100", "i4 + 100"], library="np", how=tuple)
@@ -132,12 +131,12 @@ def test_cut():
         ].tolist() == list(range(101, 115))
 
         arrays = sample.arrays(["i4 + 100", "i8 + 100"], cut="i4 > 0", library="np")
-        assert set(arrays.keys()) == set(["i4 + 100", "i8 + 100"])
+        assert set(arrays.keys()) == {"i4 + 100", "i8 + 100"}
         assert arrays["i4 + 100"].tolist() == list(range(101, 115))
         assert arrays["i8 + 100"].tolist() == list(range(101, 115))
 
         arrays = sample.arrays(["i4", "i8"], cut="i4 > 0", library="np")
-        assert set(arrays.keys()) == set(["i4", "i8"])
+        assert set(arrays.keys()) == {"i4", "i8"}
         assert arrays["i4"].tolist() == list(range(1, 15))
         assert arrays["i8"].tolist() == list(range(1, 15))
 
@@ -153,14 +152,14 @@ def test_aliases():
         arrays = sample.arrays(
             ["one", "two"], aliases={"one": "i4 + 100", "two": "i8 + 100"}, library="np"
         )
-        assert set(arrays.keys()) == set(["one", "two"])
+        assert set(arrays.keys()) == {"one", "two"}
         assert arrays["one"].tolist() == list(range(85, 115))
         assert arrays["two"].tolist() == list(range(85, 115))
 
         arrays = sample.arrays(
             ["one", "two"], aliases={"one": "i4 + 100", "two": "one"}, library="np"
         )
-        assert set(arrays.keys()) == set(["one", "two"])
+        assert set(arrays.keys()) == {"one", "two"}
         assert arrays["one"].tolist() == list(range(85, 115))
         assert arrays["two"].tolist() == list(range(85, 115))
 
@@ -175,7 +174,7 @@ def test_aliases():
             aliases={"one": "i4 + 100", "two": "i8 + 100"},
             library="np",
         )
-        assert set(arrays.keys()) == set(["one", "two"])
+        assert set(arrays.keys()) == {"one", "two"}
         assert arrays["one"].tolist() == list(range(101, 115))
         assert arrays["two"].tolist() == list(range(101, 115))
 
@@ -185,7 +184,7 @@ def test_aliases():
             aliases={"one": "i4 + 100", "two": "i8 + 100"},
             library="np",
         )
-        assert set(arrays.keys()) == set(["i4"])
+        assert set(arrays.keys()) == {"i4"}
         assert arrays["i4"].tolist() == list(range(1, 15))
 
 

--- a/tests/test_0023-more-interpretations-1.py
+++ b/tests/test_0023-more-interpretations-1.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys
@@ -43,7 +42,7 @@ def test_strings1():
         skhep_testdata.data_path("uproot-sample-6.20.04-uncompressed.root")
     )["sample/str"] as branch:
         result = branch.array(library="np")
-        assert result.tolist() == ["hey-{0}".format(i) for i in range(30)]
+        assert result.tolist() == [f"hey-{i}" for i in range(30)]
 
 
 def test_strings4():
@@ -52,7 +51,7 @@ def test_strings4():
     ] as branch:
         result = branch.array(library="np")
         assert [result.tolist() for x in result] == [
-            ["vec-{0:03d}".format(i)] * (i % 10) for i in range(100)
+            [f"vec-{i:03d}"] * (i % 10) for i in range(100)
         ]
 
 
@@ -62,7 +61,7 @@ def test_strings4():
     ] as branch:
         result = branch.array(library="np")
         assert [result.member("StlVecStr").tolist() for x in result] == [
-            ["vec-{0:03d}".format(i)] * (i % 10) for i in range(100)
+            [f"vec-{i:03d}"] * (i % 10) for i in range(100)
         ]
 
 

--- a/tests/test_0023-ttree-versions.py
+++ b/tests/test_0023-ttree-versions.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest
@@ -1153,7 +1152,7 @@ truth = {
 )
 def test(version):
     with uproot.open(
-        skhep_testdata.data_path("uproot-sample-{0}-uncompressed.root".format(version))
+        skhep_testdata.data_path(f"uproot-sample-{version}-uncompressed.root")
     )["sample"] as sample:
         arrays = sample.arrays(sample.keys(), library="np")
 

--- a/tests/test_0028-fallback-to-read-streamer.py
+++ b/tests/test_0028-fallback-to-read-streamer.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0029-more-string-types.py
+++ b/tests/test_0029-more-string-types.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys
@@ -89,10 +88,10 @@ def test_strings1():
         "tree"
     ] as tree:
         result = tree["Beg"].array(library="np")
-        assert result.tolist() == ["beg-{0:03d}".format(i) for i in range(100)]
+        assert result.tolist() == [f"beg-{i:03d}" for i in range(100)]
 
         result = tree["End"].array(library="np")
-        assert result.tolist() == ["end-{0:03d}".format(i) for i in range(100)]
+        assert result.tolist() == [f"end-{i:03d}" for i in range(100)]
 
 
 def test_map_string_string_in_object():
@@ -181,7 +180,7 @@ def test_strings2():
         "tree/Str"
     ] as branch:
         result = branch.array(library="np")
-        assert result.tolist() == ["evt-{0:03d}".format(i) for i in range(100)]
+        assert result.tolist() == [f"evt-{i:03d}" for i in range(100)]
 
 
 def test_strings3():
@@ -189,4 +188,4 @@ def test_strings3():
         "tree/StdStr"
     ] as branch:
         result = branch.array(library="np")
-        assert result.tolist() == ["std-{0:03d}".format(i) for i in range(100)]
+        assert result.tolist() == [f"std-{i:03d}" for i in range(100)]

--- a/tests/test_0031-test-stl-containers.py
+++ b/tests/test_0031-test-stl-containers.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys
@@ -202,16 +201,16 @@ def test_vector_set_int32():
         "tree"
     ] as tree:
         assert [x.tolist() for x in tree["vector_set_int32"].array(library="np")] == [
-            [set([1])],
-            [set([1]), set([1, 2])],
-            [set([1]), set([1, 2]), set([1, 2, 3])],
-            [set([1]), set([1, 2]), set([1, 2, 3]), set([1, 2, 3, 4])],
+            [{1}],
+            [{1}, {1, 2}],
+            [{1}, {1, 2}, {1, 2, 3}],
+            [{1}, {1, 2}, {1, 2, 3}, {1, 2, 3, 4}],
             [
-                set([1]),
-                set([1, 2]),
-                set([1, 2, 3]),
-                set([1, 2, 3, 4]),
-                set([1, 2, 3, 4, 5]),
+                {1},
+                {1, 2},
+                {1, 2, 3},
+                {1, 2, 3, 4},
+                {1, 2, 3, 4, 5},
             ],
         ]
 
@@ -221,21 +220,21 @@ def test_vector_set_string():
         "tree"
     ] as tree:
         assert [x.tolist() for x in tree["vector_set_string"].array(library="np")] == [
-            [set(["one"])],
-            [set(["one"]), set(["one", "two"])],
-            [set(["one"]), set(["one", "two"]), set(["one", "two", "three"])],
+            [{"one"}],
+            [{"one"}, {"one", "two"}],
+            [{"one"}, {"one", "two"}, {"one", "two", "three"}],
             [
-                set(["one"]),
-                set(["one", "two"]),
-                set(["one", "two", "three"]),
-                set(["one", "two", "three", "four"]),
+                {"one"},
+                {"one", "two"},
+                {"one", "two", "three"},
+                {"one", "two", "three", "four"},
             ],
             [
-                set(["one"]),
-                set(["one", "two"]),
-                set(["one", "two", "three"]),
-                set(["one", "two", "three", "four"]),
-                set(["one", "two", "three", "four", "five"]),
+                {"one"},
+                {"one", "two"},
+                {"one", "two", "three"},
+                {"one", "two", "three", "four"},
+                {"one", "two", "three", "four", "five"},
             ],
         ]
 
@@ -245,11 +244,11 @@ def test_set_int32():
         "tree"
     ] as tree:
         assert [x.tolist() for x in tree["set_int32"].array(library="np")] == [
-            set([1]),
-            set([1, 2]),
-            set([1, 2, 3]),
-            set([1, 2, 3, 4]),
-            set([1, 2, 3, 4, 5]),
+            {1},
+            {1, 2},
+            {1, 2, 3},
+            {1, 2, 3, 4},
+            {1, 2, 3, 4, 5},
         ]
 
 
@@ -258,11 +257,11 @@ def test_set_string():
         "tree"
     ] as tree:
         assert [x.tolist() for x in tree["set_string"].array(library="np")] == [
-            set(["one"]),
-            set(["one", "two"]),
-            set(["one", "two", "three"]),
-            set(["one", "two", "three", "four"]),
-            set(["one", "two", "three", "four", "five"]),
+            {"one"},
+            {"one", "two"},
+            {"one", "two", "three"},
+            {"one", "two", "three", "four"},
+            {"one", "two", "three", "four", "five"},
         ]
 
 
@@ -327,16 +326,16 @@ def test_map_int32_set_int16():
         assert [
             x.tolist() for x in tree["map_int32_set_int16"].array(library="np")
         ] == [
-            {1: set([1])},
-            {1: set([1]), 2: set([1, 2])},
-            {1: set([1]), 2: set([1, 2]), 3: set([1, 2, 3])},
-            {1: set([1]), 2: set([1, 2]), 3: set([1, 2, 3]), 4: set([1, 2, 3, 4])},
+            {1: {1}},
+            {1: {1}, 2: {1, 2}},
+            {1: {1}, 2: {1, 2}, 3: {1, 2, 3}},
+            {1: {1}, 2: {1, 2}, 3: {1, 2, 3}, 4: {1, 2, 3, 4}},
             {
-                1: set([1]),
-                2: set([1, 2]),
-                3: set([1, 2, 3]),
-                4: set([1, 2, 3, 4]),
-                5: set([1, 2, 3, 4, 5]),
+                1: {1},
+                2: {1, 2},
+                3: {1, 2, 3},
+                4: {1, 2, 3, 4},
+                5: {1, 2, 3, 4, 5},
             },
         ]
 
@@ -348,21 +347,21 @@ def test_map_int32_set_string():
         assert [
             x.tolist() for x in tree["map_int32_set_string"].array(library="np")
         ] == [
-            {1: set(["one"])},
-            {1: set(["one"]), 2: set(["one", "two"])},
-            {1: set(["one"]), 2: set(["one", "two"]), 3: set(["one", "two", "three"])},
+            {1: {"one"}},
+            {1: {"one"}, 2: {"one", "two"}},
+            {1: {"one"}, 2: {"one", "two"}, 3: {"one", "two", "three"}},
             {
-                1: set(["one"]),
-                2: set(["one", "two"]),
-                3: set(["one", "two", "three"]),
-                4: set(["one", "two", "three", "four"]),
+                1: {"one"},
+                2: {"one", "two"},
+                3: {"one", "two", "three"},
+                4: {"one", "two", "three", "four"},
             },
             {
-                1: set(["one"]),
-                2: set(["one", "two"]),
-                3: set(["one", "two", "three"]),
-                4: set(["one", "two", "three", "four"]),
-                5: set(["one", "two", "three", "four", "five"]),
+                1: {"one"},
+                2: {"one", "two"},
+                3: {"one", "two", "three"},
+                4: {"one", "two", "three", "four"},
+                5: {"one", "two", "three", "four", "five"},
             },
         ]
 
@@ -434,21 +433,21 @@ def test_map_string_set_int16():
         assert [
             x.tolist() for x in tree["map_string_set_int16"].array(library="np")
         ] == [
-            {"one": set([1])},
-            {"one": set([1]), "two": set([1, 2])},
-            {"one": set([1]), "two": set([1, 2]), "three": set([1, 2, 3])},
+            {"one": {1}},
+            {"one": {1}, "two": {1, 2}},
+            {"one": {1}, "two": {1, 2}, "three": {1, 2, 3}},
             {
-                "one": set([1]),
-                "two": set([1, 2]),
-                "three": set([1, 2, 3]),
-                "four": set([1, 2, 3, 4]),
+                "one": {1},
+                "two": {1, 2},
+                "three": {1, 2, 3},
+                "four": {1, 2, 3, 4},
             },
             {
-                "one": set([1]),
-                "two": set([1, 2]),
-                "three": set([1, 2, 3]),
-                "four": set([1, 2, 3, 4]),
-                "five": set([1, 2, 3, 4, 5]),
+                "one": {1},
+                "two": {1, 2},
+                "three": {1, 2, 3},
+                "four": {1, 2, 3, 4},
+                "five": {1, 2, 3, 4, 5},
             },
         ]
 
@@ -460,25 +459,25 @@ def test_map_string_set_string():
         assert [
             x.tolist() for x in tree["map_string_set_string"].array(library="np")
         ] == [
-            {"one": set(["one"])},
-            {"one": set(["one"]), "two": set(["one", "two"])},
+            {"one": {"one"}},
+            {"one": {"one"}, "two": {"one", "two"}},
             {
-                "one": set(["one"]),
-                "two": set(["one", "two"]),
-                "three": set(["one", "two", "three"]),
+                "one": {"one"},
+                "two": {"one", "two"},
+                "three": {"one", "two", "three"},
             },
             {
-                "one": set(["one"]),
-                "two": set(["one", "two"]),
-                "three": set(["one", "two", "three"]),
-                "four": set(["one", "two", "three", "four"]),
+                "one": {"one"},
+                "two": {"one", "two"},
+                "three": {"one", "two", "three"},
+                "four": {"one", "two", "three", "four"},
             },
             {
-                "one": set(["one"]),
-                "two": set(["one", "two"]),
-                "three": set(["one", "two", "three"]),
-                "four": set(["one", "two", "three", "four"]),
-                "five": set(["one", "two", "three", "four", "five"]),
+                "one": {"one"},
+                "two": {"one", "two"},
+                "three": {"one", "two", "three"},
+                "four": {"one", "two", "three", "four"},
+                "five": {"one", "two", "three", "four", "five"},
             },
         ]
 
@@ -517,30 +516,30 @@ def test_map_int32_vector_set_int16():
         assert [
             x.tolist() for x in tree["map_int32_vector_set_int16"].array(library="np")
         ] == [
-            {1: [set([1])]},
-            {1: [set([1])], 2: [set([1]), set([1, 2])]},
+            {1: [{1}]},
+            {1: [{1}], 2: [{1}, {1, 2}]},
             {
-                1: [set([1])],
-                2: [set([1]), set([1, 2])],
-                3: [set([1]), set([1, 2]), set([1, 2, 3])],
+                1: [{1}],
+                2: [{1}, {1, 2}],
+                3: [{1}, {1, 2}, {1, 2, 3}],
             },
             {
-                1: [set([1])],
-                2: [set([1]), set([1, 2])],
-                3: [set([1]), set([1, 2]), set([1, 2, 3])],
-                4: [set([1]), set([1, 2]), set([1, 2, 3]), set([1, 2, 3, 4])],
+                1: [{1}],
+                2: [{1}, {1, 2}],
+                3: [{1}, {1, 2}, {1, 2, 3}],
+                4: [{1}, {1, 2}, {1, 2, 3}, {1, 2, 3, 4}],
             },
             {
-                1: [set([1])],
-                2: [set([1]), set([1, 2])],
-                3: [set([1]), set([1, 2]), set([1, 2, 3])],
-                4: [set([1]), set([1, 2]), set([1, 2, 3]), set([1, 2, 3, 4])],
+                1: [{1}],
+                2: [{1}, {1, 2}],
+                3: [{1}, {1, 2}, {1, 2, 3}],
+                4: [{1}, {1, 2}, {1, 2, 3}, {1, 2, 3, 4}],
                 5: [
-                    set([1]),
-                    set([1, 2]),
-                    set([1, 2, 3]),
-                    set([1, 2, 3, 4]),
-                    set([1, 2, 3, 4, 5]),
+                    {1},
+                    {1, 2},
+                    {1, 2, 3},
+                    {1, 2, 3, 4},
+                    {1, 2, 3, 4, 5},
                 ],
             },
         ]

--- a/tests/test_0033-more-interpretations-2.py
+++ b/tests/test_0033-more-interpretations-2.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import distutils.version
 import json

--- a/tests/test_0034-generic-objects-in-ttrees.py
+++ b/tests/test_0034-generic-objects-in-ttrees.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import json
 import sys

--- a/tests/test_0035-datatype-generality.py
+++ b/tests/test_0035-datatype-generality.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0038-memberwise-serialization.py
+++ b/tests/test_0038-memberwise-serialization.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 import skhep_testdata

--- a/tests/test_0043-iterate-function.py
+++ b/tests/test_0043-iterate-function.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest
@@ -150,8 +149,7 @@ def test_iterate_report_2():
 
 def test_function_iterate():
     files = [
-        skhep_testdata.data_path("uproot-sample-{0}-uncompressed.root".format(x))
-        + ":sample"
+        skhep_testdata.data_path(f"uproot-sample-{x}-uncompressed.root") + ":sample"
         for x in [
             "5.23.02",
             "5.24.00",
@@ -180,8 +178,7 @@ def test_function_iterate():
 def test_function_iterate_pandas():
     pandas = pytest.importorskip("pandas")
     files = [
-        skhep_testdata.data_path("uproot-sample-{0}-uncompressed.root".format(x))
-        + ":sample"
+        skhep_testdata.data_path(f"uproot-sample-{x}-uncompressed.root") + ":sample"
         for x in [
             "5.23.02",
             "5.24.00",

--- a/tests/test_0044-concatenate-function.py
+++ b/tests/test_0044-concatenate-function.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest
@@ -25,7 +24,7 @@ def test_concatenate_awkward():
     )
     arrays = uproot.concatenate({files: "sample"}, ["i8", "f8"], library="ak")
     assert isinstance(arrays, awkward.Array)
-    assert set(awkward.fields(arrays)) == set(["i8", "f8"])
+    assert set(awkward.fields(arrays)) == {"i8", "f8"}
     assert len(arrays) == 420
 
 
@@ -36,5 +35,5 @@ def test_concatenate_pandas():
     )
     arrays = uproot.concatenate({files: "sample"}, ["i8", "f8"], library="pd")
     assert isinstance(arrays, pandas.DataFrame)
-    assert set(arrays.columns.tolist()) == set(["i8", "f8"])
+    assert set(arrays.columns.tolist()) == {"i8", "f8"}
     assert len(arrays) == 420

--- a/tests/test_0045-lazy-arrays-1.py
+++ b/tests/test_0045-lazy-arrays-1.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0046-histograms-bh-hist.py
+++ b/tests/test_0046-histograms-bh-hist.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0053-parents-should-not-be-bases.py
+++ b/tests/test_0053-parents-should-not-be-bases.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0058-detach-model-objects-from-files.py
+++ b/tests/test_0058-detach-model-objects-from-files.py
@@ -59,10 +59,6 @@ def test_pickle():
         assert original_file_path == reconstituted_file_path
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 0),
-    reason="boost_histogram is wrapped with pybind11, which can't be pickled in Python 2.7.",
-)
 def test_pickle_boost():
     boost_histogram = pytest.importorskip("boost_histogram")
     with uproot.open(skhep_testdata.data_path("uproot-hepdata-example.root")) as f:

--- a/tests/test_0058-detach-model-objects-from-files.py
+++ b/tests/test_0058-detach-model-objects-from-files.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import copy
 import os

--- a/tests/test_0066-fix-http-fallback-freeze.py
+++ b/tests/test_0066-fix-http-fallback-freeze.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0067-common-entry-offsets.py
+++ b/tests/test_0067-common-entry-offsets.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 import skhep_testdata

--- a/tests/test_0081-dont-parse-colons.py
+++ b/tests/test_0081-dont-parse-colons.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 import skhep_testdata

--- a/tests/test_0087-memberwise-splitting-not-implemented-messages.py
+++ b/tests/test_0087-memberwise-splitting-not-implemented-messages.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 import skhep_testdata

--- a/tests/test_0088-read-with-http.py
+++ b/tests/test_0088-read-with-http.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/tests/test_0099-read-from-file-object.py
+++ b/tests/test_0099-read-from-file-object.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 import skhep_testdata

--- a/tests/test_0112-fix-pandas-with-cut.py
+++ b/tests/test_0112-fix-pandas-with-cut.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0118-fix-name-fetch-again.py
+++ b/tests/test_0118-fix-name-fetch-again.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 import skhep_testdata

--- a/tests/test_0123-atlas-issues.py
+++ b/tests/test_0123-atlas-issues.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 import skhep_testdata

--- a/tests/test_0126-turn-unknown-emptyarrays-into-known-types.py
+++ b/tests/test_0126-turn-unknown-emptyarrays-into-known-types.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0167-use-the-common-histogram-interface.py
+++ b/tests/test_0167-use-the-common-histogram-interface.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0172-allow-allocators-in-vector-typenames.py
+++ b/tests/test_0172-allow-allocators-in-vector-typenames.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 import skhep_testdata

--- a/tests/test_0173-empty-and-multiprocessing-bugs.py
+++ b/tests/test_0173-empty-and-multiprocessing-bugs.py
@@ -26,10 +26,6 @@ def readone(filename):
         b.array(library="np")
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 0),
-    reason="multiprocessing is only a context manager in Python 3",
-)
 def test_multiprocessing():
     with multiprocessing.Pool(1) as pool:
         out = pool.map(

--- a/tests/test_0173-empty-and-multiprocessing-bugs.py
+++ b/tests/test_0173-empty-and-multiprocessing-bugs.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import multiprocessing
 import sys

--- a/tests/test_0182-complain-about-missing-files.py
+++ b/tests/test_0182-complain-about-missing-files.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0194-fix-lost-cuts-in-iterate.py
+++ b/tests/test_0194-fix-lost-cuts-in-iterate.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0220-contiguous-byte-ranges-in-http.py
+++ b/tests/test_0220-contiguous-byte-ranges-in-http.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0240-read_TGraphAsymmErrors.py
+++ b/tests/test_0240-read_TGraphAsymmErrors.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0302-pickle.py
+++ b/tests/test_0302-pickle.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import os
 import pickle

--- a/tests/test_0325-fix-windows-file-uris.py
+++ b/tests/test_0325-fix-windows-file-uris.py
@@ -73,7 +73,7 @@ def test_escaped_uri_codes():
         uproot._util.file_path_to_source_class(
             "file:///my%E2%80%92file.root", uproot.reading.open.defaults
         )[1]
-        == u"/my\u2012file.root"
+        == "/my\u2012file.root"
     )
 
     # Otherwise, no we should not.

--- a/tests/test_0341-manipulate-streamer-info.py
+++ b/tests/test_0341-manipulate-streamer-info.py
@@ -17,72 +17,68 @@ def test_volley(tmp_path):
     f1 = ROOT.TFile(filename, "recreate")
     f1.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set([])
+    assert set(uproot.open(filename).file.streamers) == set()
 
     with uproot.writing.update(filename) as f2:
         f2.file._cascading.streamers.write(f2.file.sink)
 
-    assert set(uproot.open(filename).file.streamers) == set([])
+    assert set(uproot.open(filename).file.streamers) == set()
 
     f3 = ROOT.TFile(filename, "update")
     x = ROOT.TObjString("hello")
     x.Write()
     f3.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set(["TObjString"])
+    assert set(uproot.open(filename).file.streamers) == {"TObjString"}
 
     with uproot.writing.update(filename) as f4:
         f4.file._cascading.streamers.write(f4.file.sink)
 
-    assert set(uproot.open(filename).file.streamers) == set(["TObjString"])
+    assert set(uproot.open(filename).file.streamers) == {"TObjString"}
 
     f5 = ROOT.TFile(filename, "update")
     y = ROOT.TH1F("hey", "there", 100, -5, 5)
     y.Write()
     f5.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-            "TObjString",
-        ]
-    )
+    assert set(uproot.open(filename).file.streamers) == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+        "TObjString",
+    }
 
     with uproot.writing.update(filename) as f6:
         f6.file._cascading.streamers.write(f6.file.sink)
 
-    assert set(uproot.open(filename).file.streamers) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-            "TObjString",
-        ]
-    )
+    assert set(uproot.open(filename).file.streamers) == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+        "TObjString",
+    }
 
 
 def test_with_mkdir(tmp_path):
@@ -91,12 +87,12 @@ def test_with_mkdir(tmp_path):
     f1 = ROOT.TFile(filename, "recreate")
     f1.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set([])
+    assert set(uproot.open(filename).file.streamers) == set()
 
     with uproot.writing.update(filename) as f2:
         f2.mkdir("one")
 
-    assert set(uproot.open(filename).file.streamers) == set([])
+    assert set(uproot.open(filename).file.streamers) == set()
 
     f3 = ROOT.TFile(filename, "update")
     f3.cd("one")
@@ -104,60 +100,56 @@ def test_with_mkdir(tmp_path):
     x.Write()
     f3.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set(["TObjString"])
+    assert set(uproot.open(filename).file.streamers) == {"TObjString"}
 
     with uproot.writing.update(filename) as f4:
         f4.mkdir("two")
 
-    assert set(uproot.open(filename).file.streamers) == set(["TObjString"])
+    assert set(uproot.open(filename).file.streamers) == {"TObjString"}
 
     f5 = ROOT.TFile(filename, "update")
     y = ROOT.TH1F("hey", "there", 100, -5, 5)
     y.Write()
     f5.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-            "TObjString",
-        ]
-    )
+    assert set(uproot.open(filename).file.streamers) == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+        "TObjString",
+    }
 
     with uproot.writing.update(filename) as f6:
         f6.mkdir("three")
 
-    assert set(uproot.open(filename).file.streamers) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-            "TObjString",
-        ]
-    )
+    assert set(uproot.open(filename).file.streamers) == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+        "TObjString",
+    }
 
 
 def test_add_streamers1(tmp_path):
@@ -175,24 +167,24 @@ def test_add_streamers1(tmp_path):
     f1 = ROOT.TFile(filename, "recreate")
     f1.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set([])
+    assert set(uproot.open(filename).file.streamers) == set()
 
     with uproot.writing.update(filename) as f2:
         f2.file.update_streamers(streamers)
 
-    assert set(uproot.open(filename).file.streamers) == set(["TObjString"])
+    assert set(uproot.open(filename).file.streamers) == {"TObjString"}
 
     f3 = ROOT.TFile(filename, "update")
     y = ROOT.TObjString("there")
     y.Write()
     f3.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set(["TObjString"])
+    assert set(uproot.open(filename).file.streamers) == {"TObjString"}
 
     with uproot.writing.update(filename) as f3:
         pass
 
-    assert set(uproot.open(filename).file.streamers) == set(["TObjString"])
+    assert set(uproot.open(filename).file.streamers) == {"TObjString"}
 
     f4 = ROOT.TFile(filename, "update")
     z = ROOT.TH1F("histogram", "", 100, -5, 5)
@@ -219,74 +211,68 @@ def test_add_streamers2(tmp_path):
     f1 = ROOT.TFile(filename, "recreate")
     f1.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set([])
+    assert set(uproot.open(filename).file.streamers) == set()
 
     with uproot.writing.update(filename) as f2:
         f2.file.update_streamers(streamers)
 
-    assert set(uproot.open(filename).file.streamers) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-        ]
-    )
+    assert set(uproot.open(filename).file.streamers) == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+    }
 
     f3 = ROOT.TFile(filename, "update")
     y = ROOT.TH1F("margotsih", "", 100, -5, 5)
     f3.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-        ]
-    )
+    assert set(uproot.open(filename).file.streamers) == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+    }
 
     with uproot.writing.update(filename) as f3:
         pass
 
-    assert set(uproot.open(filename).file.streamers) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-        ]
-    )
+    assert set(uproot.open(filename).file.streamers) == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+    }
 
     f3 = ROOT.TFile(filename, "update")
     z = ROOT.TObjString("there")
@@ -311,110 +297,100 @@ def test_add_streamers3(tmp_path):
     y.Write()
     f1.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-        ]
-    )
+    assert set(uproot.open(filename).file.streamers) == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+    }
 
     with uproot.writing.update(filename) as f2:
         f2.file.update_streamers(streamers)
 
-    assert set(uproot.open(filename).file.streamers) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-            "TObjString",
-        ]
-    )
+    assert set(uproot.open(filename).file.streamers) == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+        "TObjString",
+    }
 
     f2 = ROOT.TFile(filename, "update")
-    assert set([z.GetName() for z in f2.GetStreamerInfoList()]) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-            "TObjString",
-        ]
-    )
+    assert {z.GetName() for z in f2.GetStreamerInfoList()} == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+        "TObjString",
+    }
     w = ROOT.TObjString("wow")
     w.Write()
     f2.Close()
 
-    assert set(uproot.open(filename).file.streamers) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-            "TObjString",
-        ]
-    )
+    assert set(uproot.open(filename).file.streamers) == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+        "TObjString",
+    }
 
     f3 = ROOT.TFile(filename, "update")
-    assert set([z.GetName() for z in f3.GetStreamerInfoList()]) == set(
-        [
-            "TObject",
-            "TNamed",
-            "TH1F",
-            "TH1",
-            "TAttLine",
-            "TAttFill",
-            "TAttMarker",
-            "TAxis",
-            "TAttAxis",
-            "THashList",
-            "TList",
-            "TSeqCollection",
-            "TCollection",
-            "TString",
-            "TObjString",
-        ]
-    )
+    assert {z.GetName() for z in f3.GetStreamerInfoList()} == {
+        "TObject",
+        "TNamed",
+        "TH1F",
+        "TH1",
+        "TAttLine",
+        "TAttFill",
+        "TAttMarker",
+        "TAxis",
+        "TAttAxis",
+        "THashList",
+        "TList",
+        "TSeqCollection",
+        "TCollection",
+        "TString",
+        "TObjString",
+    }
     f3.Close()

--- a/tests/test_0345-bulk-copy-method.py
+++ b/tests/test_0345-bulk-copy-method.py
@@ -52,6 +52,8 @@ def test_bulk_copy(tmp_path):
     y.Write()
     f2.Close()
 
-    assert set(uproot.open(dest_filename).keys()) == set(
-        ["subdir;1", "subdir/hist;1", "hello;1"]
-    )
+    assert set(uproot.open(dest_filename).keys()) == {
+        "subdir;1",
+        "subdir/hist;1",
+        "hello;1",
+    }

--- a/tests/test_0350-read-RooCurve-RooHist.py
+++ b/tests/test_0350-read-RooCurve-RooHist.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0398-dimensions-in-leaflist.py
+++ b/tests/test_0398-dimensions-in-leaflist.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0402-remove-at-fields-from-lazy-forms.py
+++ b/tests/test_0402-remove-at-fields-from-lazy-forms.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0407-read-TDatime.py
+++ b/tests/test_0407-read-TDatime.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import datetime
 

--- a/tests/test_0416-writing-compressed-data.py
+++ b/tests/test_0416-writing-compressed-data.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import os
 

--- a/tests/test_0418-read-TTable.py
+++ b/tests/test_0418-read-TTable.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 import skhep_testdata
@@ -58,7 +57,5 @@ def geant_branch(datafile, custom_classes):
 
 
 def test_geant_dot_root(geant_branch):
-    items = dict(
-        (obj.all_members["fName"], obj) for obj in geant_branch.members["fObj"]
-    )
+    items = {obj.all_members["fName"]: obj for obj in geant_branch.members["fObj"]}
     assert items["g2t_pythia"].data["subprocess_id"] == 1

--- a/tests/test_0442-regular-TClonesArray.py
+++ b/tests/test_0442-regular-TClonesArray.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 import skhep_testdata

--- a/tests/test_0472-tstreamerinfo-for-ttree.py
+++ b/tests/test_0472-tstreamerinfo-for-ttree.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import io
 import os

--- a/tests/test_0487-implement-asdtypeinplace.py
+++ b/tests/test_0487-implement-asdtypeinplace.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import numpy
 import pytest

--- a/tests/test_0519-remove-memmap-copy.py
+++ b/tests/test_0519-remove-memmap-copy.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
-from __future__ import absolute_import
 
 import pytest
 import skhep_testdata

--- a/tests/test_0520-dynamic-classes-cant-be-abc-subclasses.py
+++ b/tests/test_0520-dynamic-classes-cant-be-abc-subclasses.py
@@ -1,16 +1,15 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
 
 import pickle
+import sys
 
 import numpy as np
 import pytest
 import skhep_testdata
 
-import uproot
-
 
 @pytest.mark.skipif(
-    uproot._util.py36,
+    sys.version_info < (3, 7),
     reason="Dynamic types depend on module __getattr__, a Python 3.7+ feature.",
 )
 def test():


### PR DESCRIPTION
First commit is mostly automated, second commend is hand cleanup for things the first one didn't catch. Many `.format`'s are left, this is just the easy ones that clearly are simpler as f-strings. Manual comparisons with sys.version_info are always preferred, and can be automatically cleaned up, so I had to look around for the try/catch ones. I'll note some cleanups inline.