### PR TITLE
Fixed one memory leak in complex objects

### DIFF
--- a/src/uproot/model.py
+++ b/src/uproot/model.py
@@ -1172,7 +1172,10 @@ class DispatchByVersion:
         If not, this classmethod returns None. No attempt is made to create a
         missing class.
         """
-        return cls.known_versions.get(version)
+        out = cls.known_versions.get(version)
+        if out is None and version == 0 and len(cls.known_versions) != 0:
+            out = cls.known_versions[max(cls.known_versions)]
+        return out
 
     @classmethod
     def has_version(cls, version):
@@ -1267,7 +1270,7 @@ class DispatchByVersion:
             is_memberwise,
         ) = uproot.deserialization.numbytes_version(chunk, cursor, context, move=False)
 
-        versioned_cls = cls.known_versions.get(version)
+        versioned_cls = cls.class_of_version(version)
 
         if versioned_cls is not None:
             pass


### PR DESCRIPTION
There are actually two memory leaks: one is in Uproot. This one is due to the fact that ROOT instance versions can sometimes be `0` while the class version is something else, and Uproot was repeatedly redefining the class, which was both slow and contributed to global memory (because they're new classes). The commit in this PR fixes that (checks for instance version `0` and no matching `known_version`, tries maximum `known_version` instead).

The other memory leak is in NumPy: https://github.com/numpy/numpy/issues/6581#issuecomment-1012678379

If you follow the thread back, people have been talking about it since 2009 (SciPy ticket 1003, ported to GitHub in 2012, superceded by the above issue in 2015, and there's an open PR https://github.com/numpy/numpy/pull/15065, last touched in 2021).

We have NumPy object arrays with cyclic dependencies because (at least) `STLVector` and friends have NumPy `values`, which can sometimes be objects (because it's ROOT data), and those objects can point to themselves through `_parent`. I don't like the idea of the STL collections sometimes being NumPy (when they're numbers) and sometimes not (when they're objects), and a quick attempt at implementation led to instant test failures, so no. Too many design decisions were based on the idea that a NumPy object array is just a fancy Python list (including not having memory leaks, like a Python list). Maybe some of these objects don't need to have `_parent`? What about cyclic references through the Cursor's `refs`? Either way, it's getting messy quick.

Of course, if NumPy's bug gets fixed, no changes would be needed in Uproot. Ideally, that's what ought to happen.