### PR TITLE
Allow reading and writing from/to already opened files

### DIFF
--- a/src/uproot/sink/file.py
+++ b/src/uproot/sink/file.py
@@ -57,6 +57,7 @@ class FileSink:
     * that has 'read', 'write', 'seek', and 'tell' methods
     * is 'readable() and writable() and seekable()'"""
             )
+        return self
 
     def __init__(self, file_path):
         self._file_path = file_path

--- a/src/uproot/writing/writable.py
+++ b/src/uproot/writing/writable.py
@@ -39,7 +39,8 @@ from uproot._util import no_filter, no_rename
 def create(file_path, **options):
     """
     Args:
-        file_path (str or ``pathlib.Path``): The filesystem path of the file to open.
+        file_path (str, ``pathlib.Path`` or file-like object): The filesystem path of the
+            file to open or an open file.
         compression (:doc:`uproot.compression.Compression` or None): Compression algorithm
             and level for new objects added to the file. Can be updated after creating
             the :doc:`uproot.writing.writable.WritableFile`. Default is ``uproot.ZLIB(1)``.
@@ -71,7 +72,8 @@ def create(file_path, **options):
 def recreate(file_path, **options):
     """
     Args:
-        file_path (str or ``pathlib.Path``): The filesystem path of the file to open.
+        file_path (str, ``pathlib.Path`` or file-like object): The filesystem path of the
+            file to open or an open file.
         compression (:doc:`uproot.compression.Compression` or None): Compression algorithm
             and level for new objects added to the file. Can be updated after creating
             the :doc:`uproot.writing.writable.WritableFile`. Default is ``uproot.ZLIB(1)``.
@@ -128,7 +130,8 @@ def recreate(file_path, **options):
 def update(file_path, **options):
     """
     Args:
-        file_path (str or ``pathlib.Path``): The filesystem path of the file to open.
+        file_path (str, ``pathlib.Path`` or file-like object): The filesystem path of the
+            file to open or an open file.
         options: See below.
 
     Opens a local file for writing. Like ROOT's ``"UPDATE"`` option, this function


### PR DESCRIPTION
`FileSink` seems to be designed such that it can also handle file objects. The only thing that is blocking this functionality is that `FileSink.from_object` does not return anything, which I assume is a mistake.
This change adds the missing return statement and a bit of documentation to open/recreate/update.