### PR TITLE
fBits is 4 bytes

### DIFF
--- a/src/uproot/interpretation/identify.py
+++ b/src/uproot/interpretation/identify.py
@@ -378,13 +378,7 @@ def interpretation_of(branch, context, simplify=True):
                 out = _float16_or_double32(branch, context, leaf, is_float16, dims)
 
             else:
-                if (
-                    branch.member("fClassName", none_if_missing=True) == "TObject"
-                    and branch.name.split(".")[-1] == "fBits"
-                ):
-                    from_dtype = numpy.dtype(">u1")
-                else:
-                    from_dtype = _leaf_to_dtype(leaf, getdims=False).newbyteorder(">")
+                from_dtype = _leaf_to_dtype(leaf, getdims=False).newbyteorder(">")
 
                 if context.get("swap_bytes", True):
                     to_dtype = from_dtype.newbyteorder("=")

--- a/tests/test_0569-fBits-is-4-bytes.py
+++ b/tests/test_0569-fBits-is-4-bytes.py
@@ -1,0 +1,14 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+import numpy as np
+import pytest
+import skhep_testdata
+
+import uproot
+
+
+def test():
+    with uproot.open(skhep_testdata.data_path("uproot-issue-569.root")) as f:
+        assert f["MCTruthTree/MCTruthEvent/TObject/fBits"].array(
+            library="np"
+        ).tolist() == [50331648]


### PR DESCRIPTION
This PR _reverses_ the second "fix" in #454, which was motivated by issue #438, raised by @kratsg.

Reading the text of PR #454, it's clear that I didn't believe `fBits` is actually 1 byte, I did it as an expedient because the file from Delphes had sometimes 4 bytes, sometimes 6 bytes, and at least assuming it's 1 byte would prevent it from raising error messages in `AsGrouped`. Reverting that may break @kratsg's workflow, but it didn't actually need the `fBits`—they were just coming along for the ride in `AsGrouped`. Would it be possible to instead avoid `AsGrouped`?

The file that this PR is based on, from @tfruth, demonstrates that the `fBits` really is 4 bytes. Maybe the Delphes ROOT writer is just wrong here. Anyway, the code can only be one way (PR #454 shows that I tried and failed to find any indicator for "4 bytes" vs "6 bytes") and this appears to be the correct one.

Both of you are affected by this. If it matters, please test against this PR!