### PR TITLE
Restore performance hack for AsArray(True, False, AsVector(False, dtype)).

### DIFF
--- a/src/uproot/containers.py
+++ b/src/uproot/containers.py
@@ -652,7 +652,6 @@ class AsArray(AsContainer):
                     "as": "array",
                     "header": self._header,
                     "speedbump": self._speedbump,
-                    "inner_shape": list(self._inner_shape),
                 }
             },
         )


### PR DESCRIPTION
Please test, @tamasgal.