### PR TITLE
fix: missing hist flow bins handling

### DIFF
--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -14,6 +14,15 @@ boost_metadata = {"name": "fName", "label": "fTitle"}
 boost_axis_metadata = {"name": "fName", "label": "fTitle"}
 
 
+def _remove_nan_dims(array):
+    mask_axes = [
+        numpy.isnan(array).all(axis=tuple(numpy.delete(numpy.arange(array.ndim), i)))
+        for i in range(array.ndim)
+    ]
+    reshape_dim = [len(axis) - numpy.sum(axis) for axis in mask_axes]
+    return numpy.ma.masked_invalid(array).compressed().reshape(reshape_dim)
+
+
 def _boost_axis(axis, metadata):
     boost_histogram = uproot.extras.boost_histogram()
 
@@ -245,7 +254,7 @@ class TH1(Histogram):
             self._values = values
 
         if flow:
-            return values
+            return _remove_nan_dims(values)
         else:
             return values[1:-1]
 
@@ -268,7 +277,7 @@ class TH1(Histogram):
             self._variances = variances
 
         if flow:
-            return values, variances
+            return _remove_nan_dims(values), _remove_nan_dims(variances)
         else:
             return values[1:-1], variances[1:-1]
 

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -15,12 +15,15 @@ boost_axis_metadata = {"name": "fName", "label": "fTitle"}
 
 
 def _remove_nan_dims(array):
-    mask_axes = [
+    nan_axes = [
         numpy.isnan(array).all(axis=tuple(numpy.delete(numpy.arange(array.ndim), i)))
         for i in range(array.ndim)
     ]
-    reshape_dim = [len(axis) - numpy.sum(axis) for axis in mask_axes]
-    return numpy.ma.masked_invalid(array).compressed().reshape(reshape_dim)
+    del_ixes = [[i for i, ix in enumerate(axis) if ix and i in [0, len(axis) - 1]]
+                for axis in nan_axes]
+    for i, ix in enumerate(del_ixes):
+        array = numpy.delete(array, ix, i)
+    return array
 
 
 def _boost_axis(axis, metadata):

--- a/src/uproot/behaviors/TH1.py
+++ b/src/uproot/behaviors/TH1.py
@@ -19,8 +19,10 @@ def _remove_nan_dims(array):
         numpy.isnan(array).all(axis=tuple(numpy.delete(numpy.arange(array.ndim), i)))
         for i in range(array.ndim)
     ]
-    del_ixes = [[i for i, ix in enumerate(axis) if ix and i in [0, len(axis) - 1]]
-                for axis in nan_axes]
+    del_ixes = [
+        [i for i, ix in enumerate(axis) if ix and i in [0, len(axis) - 1]]
+        for axis in nan_axes
+    ]
     for i, ix in enumerate(del_ixes):
         array = numpy.delete(array, ix, i)
     return array

--- a/src/uproot/behaviors/TH2.py
+++ b/src/uproot/behaviors/TH2.py
@@ -9,7 +9,7 @@ This module defines the behaviors of ``TH2`` and its subclasses (not including
 import numpy
 
 import uproot
-from uproot.behaviors.TH1 import boost_axis_metadata, boost_metadata
+from uproot.behaviors.TH1 import boost_axis_metadata, boost_metadata, _remove_nan_dims
 
 
 class TH2(uproot.behaviors.TH1.Histogram):
@@ -53,7 +53,7 @@ class TH2(uproot.behaviors.TH1.Histogram):
             self._values = values
 
         if flow:
-            return values
+            return _remove_nan_dims(values)
         else:
             return values[1:-1, 1:-1]
 
@@ -76,7 +76,7 @@ class TH2(uproot.behaviors.TH1.Histogram):
             self._variances = variances
 
         if flow:
-            return values, variances
+            return _remove_nan_dims(values), _remove_nan_dims(variances)
         else:
             return values[1:-1, 1:-1], variances[1:-1, 1:-1]
 

--- a/src/uproot/behaviors/TH2.py
+++ b/src/uproot/behaviors/TH2.py
@@ -9,7 +9,7 @@ This module defines the behaviors of ``TH2`` and its subclasses (not including
 import numpy
 
 import uproot
-from uproot.behaviors.TH1 import boost_axis_metadata, boost_metadata, _remove_nan_dims
+from uproot.behaviors.TH1 import _remove_nan_dims, boost_axis_metadata, boost_metadata
 
 
 class TH2(uproot.behaviors.TH1.Histogram):

--- a/src/uproot/behaviors/TH3.py
+++ b/src/uproot/behaviors/TH3.py
@@ -9,7 +9,7 @@ This module defines the behaviors of ``TH3`` and its subclasses (not including
 import numpy
 
 import uproot
-from uproot.behaviors.TH1 import boost_axis_metadata, boost_metadata
+from uproot.behaviors.TH1 import boost_axis_metadata, boost_metadata, _remove_nan_dims
 
 
 class TH3(uproot.behaviors.TH1.Histogram):
@@ -61,7 +61,8 @@ class TH3(uproot.behaviors.TH1.Histogram):
             self._values = values
 
         if flow:
-            return values
+            # return values
+            return _remove_nan_dims(values)
         else:
             return values[1:-1, 1:-1, 1:-1]
 
@@ -84,7 +85,7 @@ class TH3(uproot.behaviors.TH1.Histogram):
             self._variances = variances
 
         if flow:
-            return values, variances
+            return _remove_nan_dims(values), _remove_nan_dims(variances)
         else:
             return values[1:-1, 1:-1, 1:-1], variances[1:-1, 1:-1, 1:-1]
 

--- a/src/uproot/behaviors/TH3.py
+++ b/src/uproot/behaviors/TH3.py
@@ -9,7 +9,7 @@ This module defines the behaviors of ``TH3`` and its subclasses (not including
 import numpy
 
 import uproot
-from uproot.behaviors.TH1 import boost_axis_metadata, boost_metadata, _remove_nan_dims
+from uproot.behaviors.TH1 import _remove_nan_dims, boost_axis_metadata, boost_metadata
 
 
 class TH3(uproot.behaviors.TH1.Histogram):

--- a/src/uproot/writing/identify.py
+++ b/src/uproot/writing/identify.py
@@ -263,12 +263,19 @@ def to_writable(obj):
             data = obj.values(flow=True)
             fSumw2 = obj.variances(flow=True)
             # pad flow bins
-            pad_dim = numpy.array([[1 - int(axis.traits.underflow) for axis in obj.axes],
-                                   [1 - int(axis.traits.overflow)
-                                    for axis in obj.axes]]).T
+            pad_dim = numpy.array(
+                [
+                    [1 - int(axis.traits.underflow) for axis in obj.axes],
+                    [1 - int(axis.traits.overflow) for axis in obj.axes],
+                ]
+            ).T
             if numpy.sum(pad_dim) != 0:
-                data = numpy.pad(data, pad_dim, mode='constant', constant_values=numpy.nan)
-                fSumw2 = numpy.pad(fSumw2, pad_dim, mode='constant', constant_values=numpy.nan)
+                data = numpy.pad(
+                    data, pad_dim, mode="constant", constant_values=numpy.nan
+                )
+                fSumw2 = numpy.pad(
+                    fSumw2, pad_dim, mode="constant", constant_values=numpy.nan
+                )
 
         except TypeError:
             # flow=True is not supported, fallback to allocate-and-fill
@@ -314,7 +321,7 @@ def to_writable(obj):
         if ndim == 1:
             assert len(data) == len(obj.axes[0].edges) + 1
         else:
-            assert data.shape == tuple([len(axis.edges) + 1 for axis in obj.axes])
+            assert data.shape == tuple(len(axis.edges) + 1 for axis in obj.axes)
 
         # data are stored in transposed order for 2D and 3D
         data = data.T.reshape(-1)

--- a/tests/test_0422-hist-integration.py
+++ b/tests/test_0422-hist-integration.py
@@ -163,11 +163,9 @@ def test_regular_3d(tmp_path):
 @pytest.mark.parametrize("underflow", [True, False])
 def test_flow_bin_writing(tmp_path, underflow, overflow):
     newfile = os.path.join(tmp_path, "newfile.root")
-    tmp = (
-        hist.new.Reg(3, 1, 4, name="x", underflow=underflow, overflow=overflow)
-        .Weight()
-        .fill([0, 1, 2, 3, 4])
-    )
+    tmp = hist.new.Reg(3, 1, 4, name='x', underflow=underflow,
+                       overflow=overflow).Weight().fill([0, 1, 2, 3, 4],
+                                                        weight=[1, 1, np.nan, 1, 1])
 
     with uproot.recreate(newfile) as fout:
         fout["h1"] = tmp
@@ -175,8 +173,8 @@ def test_flow_bin_writing(tmp_path, underflow, overflow):
     with uproot.open(newfile) as fin:
         h1 = fin["h1"]
 
-    assert np.allclose(tmp.values(), h1.values())
-    assert np.allclose(tmp.values(flow=True), h1.values(flow=True))
+    assert np.allclose(tmp.values(), h1.values(), equal_nan=True)
+    assert np.allclose(tmp.values(flow=True), h1.values(flow=True), equal_nan=True)
 
 
 @pytest.mark.parametrize("under1", [True, False])
@@ -188,9 +186,10 @@ def test_flow_bin_writing(tmp_path, underflow, overflow):
 def test_flow_bin_writing_3d(tmp_path, under1, under2, under3, over1, over2, over3):
     newfile = os.path.join(tmp_path, "newfile.root")
     tmp = (
-        hist.Hist.new.Reg(3, 1, 4, name="x", underflow=under1, overflow=over1)
-        .Reg(3, 1, 4, name="y", underflow=under2, overflow=over2)
-        .Reg(3, 1, 4, name="z", underflow=under3, overflow=over3)
+        hist.Hist.new
+        .Reg(3, 1, 4, name='x', underflow=under1, overflow=over1)
+        .Reg(3, 1, 4, name='y', underflow=under2, overflow=over2)
+        .Reg(3, 1, 4, name='z', underflow=under3, overflow=over3)
         .Weight()
         .fill(
             [0, 1, 2, 3, 4],

--- a/tests/test_0422-hist-integration.py
+++ b/tests/test_0422-hist-integration.py
@@ -163,8 +163,11 @@ def test_regular_3d(tmp_path):
 @pytest.mark.parametrize("underflow", [True, False])
 def test_flow_bin_writing(tmp_path, underflow, overflow):
     newfile = os.path.join(tmp_path, "newfile.root")
-    tmp = hist.new.Reg(3, 1, 4, name='x', underflow=underflow,
-                       overflow=overflow).Weight().fill([0, 1, 2, 3, 4])
+    tmp = (
+        hist.new.Reg(3, 1, 4, name="x", underflow=underflow, overflow=overflow)
+        .Weight()
+        .fill([0, 1, 2, 3, 4])
+    )
 
     with uproot.recreate(newfile) as fout:
         fout["h1"] = tmp
@@ -185,10 +188,9 @@ def test_flow_bin_writing(tmp_path, underflow, overflow):
 def test_flow_bin_writing_3d(tmp_path, under1, under2, under3, over1, over2, over3):
     newfile = os.path.join(tmp_path, "newfile.root")
     tmp = (
-        hist.Hist.new
-        .Reg(3, 1, 4, name='x', underflow=under1, overflow=over1)
-        .Reg(3, 1, 4, name='y', underflow=under2, overflow=over2)
-        .Reg(3, 1, 4, name='z', underflow=under3, overflow=over3)
+        hist.Hist.new.Reg(3, 1, 4, name="x", underflow=under1, overflow=over1)
+        .Reg(3, 1, 4, name="y", underflow=under2, overflow=over2)
+        .Reg(3, 1, 4, name="z", underflow=under3, overflow=over3)
         .Weight()
         .fill(
             [0, 1, 2, 3, 4],

--- a/tests/test_0422-hist-integration.py
+++ b/tests/test_0422-hist-integration.py
@@ -163,9 +163,11 @@ def test_regular_3d(tmp_path):
 @pytest.mark.parametrize("underflow", [True, False])
 def test_flow_bin_writing(tmp_path, underflow, overflow):
     newfile = os.path.join(tmp_path, "newfile.root")
-    tmp = hist.new.Reg(3, 1, 4, name='x', underflow=underflow,
-                       overflow=overflow).Weight().fill([0, 1, 2, 3, 4],
-                                                        weight=[1, 1, np.nan, 1, 1])
+    tmp = (
+        hist.new.Reg(3, 1, 4, name="x", underflow=underflow, overflow=overflow)
+        .Weight()
+        .fill([0, 1, 2, 3, 4], weight=[1, 1, np.nan, 1, 1])
+    )
 
     with uproot.recreate(newfile) as fout:
         fout["h1"] = tmp
@@ -186,10 +188,9 @@ def test_flow_bin_writing(tmp_path, underflow, overflow):
 def test_flow_bin_writing_3d(tmp_path, under1, under2, under3, over1, over2, over3):
     newfile = os.path.join(tmp_path, "newfile.root")
     tmp = (
-        hist.Hist.new
-        .Reg(3, 1, 4, name='x', underflow=under1, overflow=over1)
-        .Reg(3, 1, 4, name='y', underflow=under2, overflow=over2)
-        .Reg(3, 1, 4, name='z', underflow=under3, overflow=over3)
+        hist.Hist.new.Reg(3, 1, 4, name="x", underflow=under1, overflow=over1)
+        .Reg(3, 1, 4, name="y", underflow=under2, overflow=over2)
+        .Reg(3, 1, 4, name="z", underflow=under3, overflow=over3)
         .Weight()
         .fill(
             [0, 1, 2, 3, 4],


### PR DESCRIPTION
Currently, when `uproot` writes `hist` histograms without flow bins, the property isn't checked and regular edge bins get written as flow bins causing weird issues with reading. 

```
import uproot
import hist
import numpy as np
import mplhep as hep

h = hist.new.Reg(20, 0, 20, name='msd', flow=False).Weight().fill(np.random.normal(10, 6, 1000))

fout = uproot.recreate('test.root')
fout['test'] = h
fout.close()

fin = uproot.open('test.root')
h_read = fin['test']
fin.close()

len(h.values()), len(h_read.values()), len(h.axes[0].edges)

>>> (20, 18, 21)
```

This PR materializes the empty flow bins as Nans when writing and filters them out again when reading to match the current expected behaviour. The caveat is that when only one flow bin exists when storing, it won't be obvious which one it is when reading the TH1 with `values(flow=True)` Possibly this should return a masked array instead to be clearer, but I didn't want to change the return type here. 
