### PR TITLE
In hist, flow=True only has flow bins if the histogram object has them.

### DIFF
--- a/src/uproot/writing/identify.py
+++ b/src/uproot/writing/identify.py
@@ -263,6 +263,13 @@ def to_writable(obj):
             data = obj.values(flow=True)
             fSumw2 = obj.variances(flow=True)
 
+            # and flow=True is different from flow=False (obj actually has flow bins)
+            if (
+                data.shape == obj.values(flow=False).shape
+                and fSumw2.shape == obj.variances(flow=True).shape
+            ):
+                raise TypeError
+
         except TypeError:
             # flow=True is not supported, fallback to allocate-and-fill
 

--- a/tests/test_0580-round-trip-for-no-flow-histograms.py
+++ b/tests/test_0580-round-trip-for-no-flow-histograms.py
@@ -14,11 +14,10 @@ hist = pytest.importorskip("hist")
 def test_no_flow(tmp_path):
     filename = os.path.join(tmp_path, "whatever.root")
 
-    h = (
-        hist.new.Reg(20, 0, 20, name="msd", flow=False)
-        .Weight()
-        .fill(np.random.normal(10, 6, 1000))
+    h = hist.Hist(hist.axis.Regular(20, 0, 20, flow=False)).fill(
+        np.random.normal(10, 6, 1000)
     )
+
     with uproot.recreate(filename) as fout:
         fout["test"] = h
 
@@ -32,11 +31,10 @@ def test_no_flow(tmp_path):
 def test_yes_flow(tmp_path):
     filename = os.path.join(tmp_path, "whatever.root")
 
-    h = (
-        hist.new.Reg(20, 0, 20, name="msd", flow=True)
-        .Weight()
-        .fill(np.random.normal(10, 6, 1000))
+    h = hist.Hist(hist.axis.Regular(20, 0, 20, flow=True)).fill(
+        np.random.normal(10, 6, 1000)
     )
+
     with uproot.recreate(filename) as fout:
         fout["test"] = h
 

--- a/tests/test_0580-round-trip-for-no-flow-histograms.py
+++ b/tests/test_0580-round-trip-for-no-flow-histograms.py
@@ -1,0 +1,48 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+import os
+
+import numpy as np
+import pytest
+import skhep_testdata
+
+import uproot
+
+hist = pytest.importorskip("hist")
+
+
+def test_no_flow(tmp_path):
+    filename = os.path.join(tmp_path, "whatever.root")
+
+    h = (
+        hist.new.Reg(20, 0, 20, name="msd", flow=False)
+        .Weight()
+        .fill(np.random.normal(10, 6, 1000))
+    )
+    with uproot.recreate(filename) as fout:
+        fout["test"] = h
+
+    with uproot.open(filename) as fin:
+        h_read = fin["test"]
+
+    assert np.array_equal(h.axes[0].edges, h_read.axes[0].edges())
+    assert np.array_equal(h.values(flow=False), h_read.values(flow=False))
+
+
+def test_yes_flow(tmp_path):
+    filename = os.path.join(tmp_path, "whatever.root")
+
+    h = (
+        hist.new.Reg(20, 0, 20, name="msd", flow=True)
+        .Weight()
+        .fill(np.random.normal(10, 6, 1000))
+    )
+    with uproot.recreate(filename) as fout:
+        fout["test"] = h
+
+    with uproot.open(filename) as fin:
+        h_read = fin["test"]
+
+    assert np.array_equal(h.axes[0].edges, h_read.axes[0].edges())
+    assert np.array_equal(h.values(flow=False), h_read.values(flow=False))
+    assert np.array_equal(h.values(flow=True), h_read.values(flow=True))


### PR DESCRIPTION
This should replace #580.

Instead of padding and removing padded bins, this PR just corrects Uproot's understanding of what hist means by `flow=True` on histograms with no built-in flow bins. It removes a bug in histogram-writing, but everything else stays the same.

This PR also doesn't address Uproot's and hist's disagreement about whether `axes[0].edges` is a property or a method, but that would be an API breaking change. This PR also changes behavior, but it's unequivocally a bug fix. Uproot was previously assuming something wrong about how hist behaves and was writing corrupted ROOT files as a result. If anyone finds this PR, searching for an explanation for the change in behavior, the old behavior was wrong and you should re-write your files of histograms.

This PR _does not_ need to be coordinated with any particular version of hist. hist's behavior is not changing.