### PR TITLE
Add explicit interpreter for ROOT::VecOps::RVec.

### DIFF
--- a/src/uproot/__init__.py
+++ b/src/uproot/__init__.py
@@ -166,6 +166,7 @@ from uproot.containers import AsString
 from uproot.containers import AsPointer
 from uproot.containers import AsArray
 from uproot.containers import AsDynamic
+from uproot.containers import AsRVec
 from uproot.containers import AsVector
 from uproot.containers import AsSet
 from uproot.containers import AsMap

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -269,7 +269,11 @@ class AsObjects(uproot.interpretation.Interpretation):
 
         if isinstance(
             self._model,
-            (uproot.containers.AsArray, uproot.containers.AsRVec, uproot.containers.AsVector),
+            (
+                uproot.containers.AsArray,
+                uproot.containers.AsRVec,
+                uproot.containers.AsVector,
+            ),
         ):
             header_bytes = 0
             if (
@@ -278,7 +282,9 @@ class AsObjects(uproot.interpretation.Interpretation):
             ):
                 header_bytes += 1
             if (
-                isinstance(self._model, (uproot.containers.AsRVec, uproot.containers.AsVector))
+                isinstance(
+                    self._model, (uproot.containers.AsRVec, uproot.containers.AsVector)
+                )
                 and self._model.header
             ):
                 header_bytes += 10

--- a/src/uproot/interpretation/objects.py
+++ b/src/uproot/interpretation/objects.py
@@ -269,7 +269,7 @@ class AsObjects(uproot.interpretation.Interpretation):
 
         if isinstance(
             self._model,
-            (uproot.containers.AsArray, uproot.containers.AsVector),
+            (uproot.containers.AsArray, uproot.containers.AsRVec, uproot.containers.AsVector),
         ):
             header_bytes = 0
             if (
@@ -278,7 +278,7 @@ class AsObjects(uproot.interpretation.Interpretation):
             ):
                 header_bytes += 1
             if (
-                isinstance(self._model, uproot.containers.AsVector)
+                isinstance(self._model, (uproot.containers.AsRVec, uproot.containers.AsVector))
                 and self._model.header
             ):
                 header_bytes += 10

--- a/tests/test_0589-explicitly-interpret-RVec-type.py
+++ b/tests/test_0589-explicitly-interpret-RVec-type.py
@@ -1,0 +1,26 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot4/blob/main/LICENSE
+
+import os
+
+import numpy as np
+import pytest
+import skhep_testdata
+
+import uproot
+
+
+def test_numpy():
+    with uproot.open(skhep_testdata.data_path("uproot-issue-589.root")) as file:
+        array = file["events"]["MC_px"].array(library="np", entry_stop=2)
+        assert array[0][7] == 30.399463653564453
+        assert array[1][11] == 42.04872131347656
+
+
+pytest.importorskip("awkward")
+
+
+def test_awkward():
+    with uproot.open(skhep_testdata.data_path("uproot-issue-589.root")) as file:
+        array = file["events"]["MC_px"].array(library="ak", entry_stop=2)
+        assert array[0][7] == 30.399463653564453
+        assert array[1][11] == 42.04872131347656


### PR DESCRIPTION
It's just like the one for `std::vector`, but I didn't see any differences in how the two are encoded. If there are such differences, we should modify the new `RVec` code.