### PR TITLE
Put an upper limit on the time KeyInFileError takes to print itself

### DIFF
--- a/src/uproot/exceptions.py
+++ b/src/uproot/exceptions.py
@@ -49,8 +49,13 @@ class KeyInFileError(KeyError):
         with_keys = ""
         if self.keys is not None:
             to_show = None
+            keys = self.keys
+            cut = 1
+            while len(keys) > 1000 and cut < len(self.key):
+                keys = [x for x in keys if x[:cut] == self.key[:cut]]
+                cut += 1
             sorted_keys = sorted(
-                self.keys, key=lambda x: uproot._util.damerau_levenshtein(self.key, x)
+                keys, key=lambda x: uproot._util.damerau_levenshtein(self.key, x)
             )
             for key in sorted_keys:
                 if to_show is None:


### PR DESCRIPTION
(about 20 ms) by limiting damerau_levenshtein to 1000 strings.

I seem to remember this being an issue for you, @kratsg, because something was using `try`-`except KeyInFileError` to determine whether a key exists in files with _lots_ of keys. The damerau_levenshtein algorithm is for helping users find a mistyped key, but we don't want it hurting automated processes.