### PR TITLE
Add the uproot4.num_entries function

### DIFF
--- a/src/uproot/__init__.py
+++ b/src/uproot/__init__.py
@@ -174,6 +174,7 @@ from uproot.containers import AsMap
 default_library = "ak"
 
 from uproot.behaviors.TTree import TTree
+from uproot.behaviors.TTree import num_entries
 from uproot.behaviors.TBranch import TBranch
 from uproot.behaviors.TBranch import iterate
 from uproot.behaviors.TBranch import concatenate

--- a/src/uproot/__init__.py
+++ b/src/uproot/__init__.py
@@ -144,6 +144,7 @@ import uproot.models.TBasket
 import uproot.models.RNTuple
 import uproot.models.TH
 import uproot.models.TGraph
+from uproot.models.TTree import num_entries
 
 from uproot.containers import STLVector
 from uproot.containers import STLSet
@@ -174,7 +175,6 @@ from uproot.containers import AsMap
 default_library = "ak"
 
 from uproot.behaviors.TTree import TTree
-from uproot.behaviors.TTree import num_entries
 from uproot.behaviors.TBranch import TBranch
 from uproot.behaviors.TBranch import iterate
 from uproot.behaviors.TBranch import concatenate

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -12,15 +12,11 @@ objects themselves.
 """
 
 
-import glob
-import itertools
-import os
 import queue
 import re
 import sys
 import threading
 from collections.abc import Iterable, Mapping, MutableMapping
-from urllib.parse import urlparse
 
 import numpy
 
@@ -176,7 +172,7 @@ def iterate(
     * :doc:`uproot.behaviors.TBranch.lazy`: returns a lazily read array from
       ``TTrees``.
     """
-    files = _regularize_files(files)
+    files = uproot._util.regularize_files(files)
     decompression_executor, interpretation_executor = _regularize_executors(
         decompression_executor, interpretation_executor, None
     )
@@ -184,7 +180,7 @@ def iterate(
 
     global_offset = 0
     for file_path, object_path in files:
-        hasbranches = _regularize_object_path(
+        hasbranches = uproot._util.regularize_object_path(
             file_path, object_path, custom_classes, allow_missing, options
         )
 
@@ -340,7 +336,7 @@ def concatenate(
     * :doc:`uproot.behaviors.TBranch.lazy`: returns a lazily read array from
       ``TTrees``.
     """
-    files = _regularize_files(files)
+    files = uproot._util.regularize_files(files)
     decompression_executor, interpretation_executor = _regularize_executors(
         decompression_executor, interpretation_executor, None
     )
@@ -349,7 +345,7 @@ def concatenate(
     all_arrays = []
     global_start = 0
     for file_path, object_path in files:
-        hasbranches = _regularize_object_path(
+        hasbranches = uproot._util.regularize_object_path(
             file_path, object_path, custom_classes, allow_missing, options
         )
         if hasbranches is not None:
@@ -506,7 +502,7 @@ def lazy(
       read array from ``TTrees``.
     """
     awkward = uproot.extras.awkward()
-    files = _regularize_files(files)
+    files = uproot._util.regularize_files(files)
     decompression_executor, interpretation_executor = _regularize_executors(
         decompression_executor, interpretation_executor, None
     )
@@ -537,7 +533,7 @@ def lazy(
 
     count = 0
     for file_path, object_path in files:
-        obj = _regularize_object_path(
+        obj = uproot._util.regularize_object_path(
             file_path, object_path, custom_classes, allow_missing, real_options
         )
 
@@ -777,7 +773,7 @@ def dask(
     * :doc:`uproot.behaviors.TBranch.lazy` (this function): returns a lazily
       read array from ``TTrees``.
     """
-    files = _regularize_files(files)
+    files = uproot._util.regularize_files(files)
     library = uproot.interpretation.library._regularize_library(library)
     if library.name != "np":
         raise NotImplementedError()
@@ -2980,145 +2976,6 @@ def _keys_deep(hasbranches):
     return out
 
 
-_regularize_files_braces = re.compile(r"{([^}]*,)*([^}]*)}")
-_regularize_files_isglob = re.compile(r"[\*\?\[\]{}]")
-
-
-def _regularize_files_inner(files, parse_colon, counter):
-    files2 = uproot._util.regularize_path(files)
-
-    if uproot._util.isstr(files2) and not uproot._util.isstr(files):
-        parse_colon = False
-        files = files2
-
-    if uproot._util.isstr(files):
-        if parse_colon:
-            file_path, object_path = uproot._util.file_object_path_split(files)
-        else:
-            file_path, object_path = files, None
-
-        parsed_url = urlparse(file_path)
-
-        if parsed_url.scheme.upper() in uproot._util._remote_schemes:
-            yield file_path, object_path
-
-        else:
-            expanded = os.path.expanduser(file_path)
-            if _regularize_files_isglob.search(expanded) is None:
-                yield file_path, object_path
-
-            else:
-                matches = list(_regularize_files_braces.finditer(expanded))
-                if len(matches) == 0:
-                    results = [expanded]
-                else:
-                    results = []
-                    for combination in itertools.product(
-                        *[match.group(0)[1:-1].split(",") for match in matches]
-                    ):
-                        tmp = expanded
-                        for c, m in list(zip(combination, matches))[::-1]:
-                            tmp = tmp[: m.span()[0]] + c + tmp[m.span()[1] :]
-                        results.append(tmp)
-
-                seen = set()
-                for result in results:
-                    for match in glob.glob(result):
-                        if match not in seen:
-                            yield match, object_path
-                            seen.add(match)
-
-    elif isinstance(files, HasBranches):
-        yield files, None
-
-    elif isinstance(files, dict):
-        for key, object_path in files.items():
-            for file_path, _ in _regularize_files_inner(key, False, counter):
-                yield file_path, object_path
-
-    elif isinstance(files, Iterable):
-        for file in files:
-            counter[0] += 1
-            for file_path, object_path in _regularize_files_inner(
-                file, parse_colon, counter
-            ):
-                yield file_path, object_path
-
-    else:
-        raise TypeError(
-            "'files' must be a file path/URL (string or Path), possibly with "
-            "a glob pattern (for local files), a dict of "
-            "{{path/URL: TTree/TBranch name}}, actual TTree/TBranch objects, or "
-            "an iterable of such things, not {0}".format(repr(files))
-        )
-
-
-def _regularize_files(files):
-    out = []
-    seen = set()
-    counter = [0]
-    for file_path, object_path in _regularize_files_inner(files, True, counter):
-        if uproot._util.isstr(file_path):
-            key = (counter[0], file_path, object_path)
-            if key not in seen:
-                out.append((file_path, object_path))
-                seen.add(key)
-        else:
-            out.append((file_path, object_path))
-
-    if len(out) == 0:
-        raise uproot._util._file_not_found(files)
-
-    return out
-
-
-def _regularize_object_path(
-    file_path, object_path, custom_classes, allow_missing, options
-):
-    if isinstance(file_path, HasBranches):
-        return _NoClose(file_path)
-
-    else:
-        file = uproot.reading.ReadOnlyFile(
-            file_path,
-            object_cache=None,
-            array_cache=None,
-            custom_classes=custom_classes,
-            **options,  # NOTE: a comma after **options breaks Python 2
-        ).root_directory
-        if object_path is None:
-            trees = file.keys(filter_classname="TTree", cycle=False)
-            if len(trees) == 0:
-                if allow_missing:
-                    return None
-                else:
-                    raise ValueError(
-                        """no TTrees found
-in file {}""".format(
-                            file_path
-                        )
-                    )
-            elif len(trees) == 1:
-                return file[trees[0]]
-            else:
-                raise ValueError(
-                    """TTree object paths must be specified in the 'files' """
-                    """as {{\"filenames*.root\": \"path\"}} if any files have """
-                    """more than one TTree
-
-    TTrees: {0}
-
-in file {1}""".format(
-                        ", ".join(repr(x) for x in trees), file_path
-                    )
-                )
-
-        else:
-            if allow_missing and object_path not in file:
-                return None
-            return file[object_path]
-
-
 def _get_recursive(hasbranches, where):
     for branch in hasbranches.branches:
         if branch.name == where:
@@ -3716,7 +3573,7 @@ def _get_dask_array(
 
     count = 0
     for file_path, object_path in files:
-        obj = _regularize_object_path(
+        obj = uproot._util.regularize_object_path(
             file_path, object_path, custom_classes, allow_missing, real_options
         )
 
@@ -3835,7 +3692,7 @@ def _get_dask_array_delay_open(
 ):
     dask, da = uproot.extras.dask()
     ffile_path, fobject_path = files[0]
-    obj = _regularize_object_path(
+    obj = uproot._util.regularize_object_path(
         ffile_path, fobject_path, custom_classes, allow_missing, real_options
     )
     common_keys = obj.keys(
@@ -3847,7 +3704,7 @@ def _get_dask_array_delay_open(
     )
 
     dask_dict = {}
-    delayed_open_fn = dask.delayed(_regularize_object_path)
+    delayed_open_fn = dask.delayed(uproot._util.regularize_object_path)
 
     @dask.delayed
     def delayed_get_array(ttree, key):

--- a/src/uproot/behaviors/TTree.py
+++ b/src/uproot/behaviors/TTree.py
@@ -6,8 +6,6 @@ functions in :doc:`uproot.behaviors.TBranch`.
 """
 
 
-import struct
-
 import uproot
 
 
@@ -161,78 +159,3 @@ class TTree(uproot.behaviors.TBranch.HasBranches):
         self._chunk = chunk
         self._lookup = {}
         return self
-
-
-def num_entries(paths):
-    if not isinstance(paths, list):
-        paths = [paths]
-
-    fEntriesStruct = struct.Struct(">q")
-
-    class Model_Numentries(uproot.model.Model):
-        def read_members(self, chunk, cursor, context, file):
-            if self.is_memberwise:
-                raise NotImplementedError(
-                    """memberwise serialization of {}
-    in file {}""".format(
-                        type(self).__name__, self.file.file_path
-                    )
-                )
-            tnamed = file.class_named("TNamed", 1).read(
-                chunk,
-                cursor,
-                context,
-                file,
-                self._file,
-                self._parent,
-                concrete=self.concrete,
-            )
-            tattline = file.class_named("TAttLine", 1).read(
-                chunk,
-                cursor,
-                context,
-                file,
-                self._file,
-                self._parent,
-                concrete=self.concrete,
-            )
-            tattfill = file.class_named("TAttFill", 1).read(
-                chunk,
-                cursor,
-                context,
-                file,
-                self._file,
-                self._parent,
-                concrete=self.concrete,
-            )
-            tattmarker = file.class_named("TAttMarker", 2).read(
-                chunk,
-                cursor,
-                context,
-                file,
-                self._file,
-                self._parent,
-                concrete=self.concrete,
-            )
-            self._members["fEntries"] = cursor.fields(chunk, fEntriesStruct, context)
-            cursor.skip_after(self)
-
-        @property
-        def member_names(self):
-            return ["fEntries"]
-
-        base_names_versions = [
-            ("TNamed", 1),
-            ("TAttLine", 1),
-            ("TAttFill", 1),
-            ("TAttMarker", 2),
-        ]
-
-    uproot.classes.update({"TTree": Model_Numentries})
-
-    out = [None] * len(paths)
-    for i, path in enumerate(paths):
-        out[i] = uproot.open(path).all_members["fEntries"]
-    uproot.reset_classes()
-
-    return out

--- a/src/uproot/models/TTree.py
+++ b/src/uproot/models/TTree.py
@@ -964,10 +964,17 @@ def num_entries(paths):
     Returns an iterator over the number of entries over each TTree in the input.
     This is a shortcut method and reads lesser data than normal file opening.
     """
-    paths = _regularize_files(paths)
+    paths2 = _regularize_files(paths)
 
-    for file_path, object_path in paths.items():
-        yield uproot.open(
+    if isinstance(paths, dict):
+        paths = list(paths.items())
+    elif not uproot._util.isstr(paths):
+        paths = [(uproot._util.file_object_path_split(path)) for path in paths]
+    else:
+        paths = [uproot._util.file_object_path_split(paths)]
+
+    for i, (file_path, object_path) in enumerate(paths2.items()):
+        yield paths[i][0], paths[i][1], uproot.open(
             {file_path: object_path}, custom_classes={"TTree": Model_TTree_NumEntries}
         ).all_members["fEntries"][0]
 

--- a/src/uproot/models/TTree.py
+++ b/src/uproot/models/TTree.py
@@ -8,7 +8,13 @@ functions.
 """
 
 
+import glob
+import itertools
+import os
+import re
 import struct
+from collections.abc import Iterable
+from urllib.parse import urlparse
 
 import numpy
 
@@ -905,3 +911,154 @@ in file {}""".format(
 
 uproot.classes["TTree"] = Model_TTree
 uproot.classes["ROOT::TIOFeatures"] = Model_ROOT_3a3a_TIOFeatures
+
+
+fEntriesStruct = struct.Struct(">q")
+
+
+class Model_TTree_NumEntries(uproot.model.Model):
+    """
+    A helper :doc:`uproot.model.Model` for :doc:`uproot.num_entries`.
+    """
+
+    def read_members(self, chunk, cursor, context, file):
+        if self.is_memberwise:
+            raise NotImplementedError(
+                """memberwise serialization of {}
+in file {}""".format(
+                    type(self).__name__, self.file.file_path
+                )
+            )
+        cursor.skip_over(chunk, context)
+        cursor.skip_over(chunk, context)
+        cursor.skip_over(chunk, context)
+        cursor.skip_over(chunk, context)
+        self._members["fEntries"] = cursor.fields(chunk, fEntriesStruct, context)
+        cursor.skip_after(self)
+
+    @property
+    def member_names(self):
+        return ["fEntries"]
+
+    base_names_versions = [
+        ("TNamed", 1),
+        ("TAttLine", 1),
+        ("TAttFill", 1),
+        ("TAttMarker", 2),
+    ]
+
+
+def num_entries(paths):
+    """
+    Args:
+        paths (str): The filesystem path or remote URL of
+            the TTree to find the number of entries in. It must have a file path
+            as well as an object path which points to the location of the TTree
+            inside the file. If the file names have colons in them, you can also
+            pass in a dictionary in the format of { file_path : object_path }.
+            Other examples: ``"rel/file.root:ttree"``, ``"C:\\abs\\file.root:ttree"``,
+            ``"http://where/what.root:ttree"``,
+            ``"https://username:password@where/secure.root:ttree"``,
+            ``"rel/file.root:tdirectory/ttree"``, iterables of the previous examples.
+
+    Returns an iterator over the number of entries over each TTree in the input.
+    This is a shortcut method and reads lesser data than normal file opening.
+    """
+    paths = _regularize_files(paths)
+
+    for file_path, object_path in paths.items():
+        yield uproot.open(
+            {file_path: object_path}, custom_classes={"TTree": Model_TTree_NumEntries}
+        ).all_members["fEntries"][0]
+
+
+_regularize_files_braces = re.compile(r"{([^}]*,)*([^}]*)}")
+_regularize_files_isglob = re.compile(r"[\*\?\[\]{}]")
+
+
+def _regularize_files_inner(files, parse_colon, counter):
+    files2 = uproot._util.regularize_path(files)
+
+    if uproot._util.isstr(files2) and not uproot._util.isstr(files):
+        parse_colon = False
+        files = files2
+
+    if uproot._util.isstr(files):
+        if parse_colon:
+            file_path, object_path = uproot._util.file_object_path_split(files)
+        else:
+            file_path, object_path = files, None
+
+        parsed_url = urlparse(file_path)
+
+        if parsed_url.scheme.upper() in uproot._util._remote_schemes:
+            yield file_path, object_path
+
+        else:
+            expanded = os.path.expanduser(file_path)
+            if _regularize_files_isglob.search(expanded) is None:
+                yield file_path, object_path
+
+            else:
+                matches = list(_regularize_files_braces.finditer(expanded))
+                if len(matches) == 0:
+                    results = [expanded]
+                else:
+                    results = []
+                    for combination in itertools.product(
+                        *[match.group(0)[1:-1].split(",") for match in matches]
+                    ):
+                        tmp = expanded
+                        for c, m in list(zip(combination, matches))[::-1]:
+                            tmp = tmp[: m.span()[0]] + c + tmp[m.span()[1] :]
+                        results.append(tmp)
+
+                seen = set()
+                for result in results:
+                    for match in glob.glob(result):
+                        if match not in seen:
+                            yield match, object_path
+                            seen.add(match)
+
+    elif isinstance(files, uproot.behaviors.TBranch.HasBranches):
+        yield files, None
+
+    elif isinstance(files, dict):
+        for key, object_path in files.items():
+            for file_path, _ in _regularize_files_inner(key, False, counter):
+                yield file_path, object_path
+
+    elif isinstance(files, Iterable):
+        for file in files:
+            counter[0] += 1
+            for file_path, object_path in _regularize_files_inner(
+                file, parse_colon, counter
+            ):
+                yield file_path, object_path
+
+    else:
+        raise TypeError(
+            "'files' must be a file path/URL (string or Path), possibly with "
+            "a glob pattern (for local files), a dict of "
+            "{{path/URL: TTree/TBranch name}}, actual TTree/TBranch objects, or "
+            "an iterable of such things, not {0}".format(repr(files))
+        )
+
+
+def _regularize_files(files):
+    out = {}
+    seen = set()
+    counter = [0]
+    for file_path, object_path in _regularize_files_inner(files, True, counter):
+        if uproot._util.isstr(file_path):
+            key = (counter[0], file_path, object_path)
+            if key not in seen:
+                out[file_path] = object_path
+                seen.add(key)
+        else:
+            out[file_path] = object_path
+
+    if len(out) == 0:
+        raise uproot._util._file_not_found(files)
+
+    return out

--- a/src/uproot/models/TTree.py
+++ b/src/uproot/models/TTree.py
@@ -923,10 +923,10 @@ in file {}""".format(
                     type(self).__name__, self.file.file_path
                 )
             )
-        cursor.skip_over(chunk, context)
-        cursor.skip_over(chunk, context)
-        cursor.skip_over(chunk, context)
-        cursor.skip_over(chunk, context)
+        cursor.skip_over(chunk, context)  # TNamed
+        cursor.skip_over(chunk, context)  # TAttLine
+        cursor.skip_over(chunk, context)  # TAttFill
+        cursor.skip_over(chunk, context)  # TAttMarker
         self._members["fEntries"] = cursor.fields(chunk, fEntriesStruct, context)
         cursor.skip_after(self)
 

--- a/tests/test_0609-num-enteries-func.py
+++ b/tests/test_0609-num-enteries-func.py
@@ -1,71 +1,57 @@
-import numpy
 import skhep_testdata
 
 import uproot
 
 
 def test_num_entries_single():
-    file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
-    assert list(uproot.num_entries(file1)) == [
-        ("/home/kmk/.local/skhepdata/uproot-Zmumu.root", "events", 2304)
-    ]
+    file1 = skhep_testdata.data_path("uproot-Zmumu.root")
+    ttree1 = file1 + ":events"
+    assert list(uproot.num_entries(ttree1)) == [(file1, "events", 2304)]
 
 
 def test_num_entries_multiple():
-    file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
-    file2 = skhep_testdata.data_path("uproot-HZZ.root") + ":events"
-    file3 = (
-        skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root") + ":sample"
-    )
+    file1 = skhep_testdata.data_path("uproot-Zmumu.root")
+    ttree1 = file1 + ":events"
+    file2 = skhep_testdata.data_path("uproot-HZZ.root")
+    ttree2 = file2 + ":events"
+    file3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root")
+    ttree3 = file3 + ":sample"
 
-    assert list(uproot.num_entries([file1, file2, file3])) == [
-        ("/home/kmk/.local/skhepdata/uproot-Zmumu.root", "events", 2304),
-        ("/home/kmk/.local/skhepdata/uproot-HZZ.root", "events", 2421),
-        (
-            "/home/kmk/.local/skhepdata/uproot-sample-6.08.04-uncompressed.root",
-            "sample",
-            30,
-        ),
+    assert list(uproot.num_entries([ttree1, ttree2, ttree3])) == [
+        (file1, "events", 2304),
+        (file2, "events", 2421),
+        (file3, "sample", 30),
     ]
 
 
 def test_num_entries_as_iterator():
-    file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
-    file2 = skhep_testdata.data_path("uproot-HZZ.root") + ":events"
-    file3 = (
-        skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root") + ":sample"
-    )
+    file1 = skhep_testdata.data_path("uproot-Zmumu.root")
+    ttree1 = file1 + ":events"
+    file2 = skhep_testdata.data_path("uproot-HZZ.root")
+    ttree2 = file2 + ":events"
+    file3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root")
+    ttree3 = file3 + ":sample"
 
     vals = [
-        ("/home/kmk/.local/skhepdata/uproot-Zmumu.root", "events", 2304),
-        ("/home/kmk/.local/skhepdata/uproot-HZZ.root", "events", 2421),
-        (
-            "/home/kmk/.local/skhepdata/uproot-sample-6.08.04-uncompressed.root",
-            "sample",
-            30,
-        ),
+        (file1, "events", 2304),
+        (file2, "events", 2421),
+        (file3, "sample", 30),
     ]
-    for i, num in enumerate(uproot.num_entries([file1, file2, file3])):
+    for i, num in enumerate(uproot.num_entries([ttree1, ttree2, ttree3])):
         assert num == vals[i]
 
 
 def test_dict_input():
-    file_name1 = skhep_testdata.data_path("uproot-Zmumu.root")
-    file_name2 = skhep_testdata.data_path("uproot-HZZ.root")
-    file_name3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root")
+    file1 = skhep_testdata.data_path("uproot-Zmumu.root")
+    file2 = skhep_testdata.data_path("uproot-HZZ.root")
+    file3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root")
 
     vals = [
-        ("/home/kmk/.local/skhepdata/uproot-Zmumu.root", "events", 2304),
-        ("/home/kmk/.local/skhepdata/uproot-HZZ.root", "events", 2421),
-        (
-            "/home/kmk/.local/skhepdata/uproot-sample-6.08.04-uncompressed.root",
-            "sample",
-            30,
-        ),
+        (file1, "events", 2304),
+        (file2, "events", 2421),
+        (file3, "sample", 30),
     ]
     for i, num in enumerate(
-        uproot.num_entries(
-            {file_name1: "events", file_name2: "events", file_name3: "sample"}
-        )
+        uproot.num_entries({file1: "events", file2: "events", file3: "sample"})
     ):
         assert num == vals[i]

--- a/tests/test_0609-num-enteries-func.py
+++ b/tests/test_0609-num-enteries-func.py
@@ -1,36 +1,46 @@
 import numpy
-import uproot
 import skhep_testdata
+
+import uproot
 
 
 def test_num_entries_single():
     file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
     assert list(uproot.num_entries(file1)) == [2304]
 
+
 def test_num_entries_multiple():
     file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
     file2 = skhep_testdata.data_path("uproot-HZZ.root") + ":events"
-    file3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root") + ":sample"
-    assert list(uproot.num_entries([file1,file2,file3])) == [2304, 2421, 30]
+    file3 = (
+        skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root") + ":sample"
+    )
+    assert list(uproot.num_entries([file1, file2, file3])) == [2304, 2421, 30]
+
 
 def test_num_entries_as_iterator():
     file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
     file2 = skhep_testdata.data_path("uproot-HZZ.root") + ":events"
-    file3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root") + ":sample"
+    file3 = (
+        skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root") + ":sample"
+    )
 
-    i=0
-    vals = [2304,2421,30]
-    for num in uproot.num_entries([file1,file2,file3]):
+    i = 0
+    vals = [2304, 2421, 30]
+    for num in uproot.num_entries([file1, file2, file3]):
         assert num == vals[i]
-        i+=1
+        i += 1
+
 
 def test_dict_input():
     file_name1 = skhep_testdata.data_path("uproot-Zmumu.root")
     file_name2 = skhep_testdata.data_path("uproot-HZZ.root")
     file_name3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root")
 
-    i=0
-    vals = [2304,2421,30]
-    for num in uproot.num_entries({file_name1:"events",file_name2:"events",file_name3:"sample"}):
+    i = 0
+    vals = [2304, 2421, 30]
+    for num in uproot.num_entries(
+        {file_name1: "events", file_name2: "events", file_name3: "sample"}
+    ):
         assert num == vals[i]
-        i+=1
+        i += 1

--- a/tests/test_0609-num-enteries-func.py
+++ b/tests/test_0609-num-enteries-func.py
@@ -6,7 +6,10 @@ import uproot
 
 def test_num_entries_single():
     file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
-    assert list(uproot.num_entries(file1)) == [2304]
+    assert list(uproot.num_entries(file1)) == [
+        ("/home/kmk/.local/skhepdata/uproot-Zmumu.root", "events", 2304)
+    ]
+
 
 
 def test_num_entries_multiple():
@@ -15,7 +18,16 @@ def test_num_entries_multiple():
     file3 = (
         skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root") + ":sample"
     )
-    assert list(uproot.num_entries([file1, file2, file3])) == [2304, 2421, 30]
+
+    assert list(uproot.num_entries([file1, file2, file3])) == [
+        ("/home/kmk/.local/skhepdata/uproot-Zmumu.root", "events", 2304),
+        ("/home/kmk/.local/skhepdata/uproot-HZZ.root", "events", 2421),
+        (
+            "/home/kmk/.local/skhepdata/uproot-sample-6.08.04-uncompressed.root",
+            "sample",
+            30,
+        ),
+    ]
 
 
 def test_num_entries_as_iterator():
@@ -25,11 +37,19 @@ def test_num_entries_as_iterator():
         skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root") + ":sample"
     )
 
-    i = 0
-    vals = [2304, 2421, 30]
-    for num in uproot.num_entries([file1, file2, file3]):
+
+    vals = [
+        ("/home/kmk/.local/skhepdata/uproot-Zmumu.root", "events", 2304),
+        ("/home/kmk/.local/skhepdata/uproot-HZZ.root", "events", 2421),
+        (
+            "/home/kmk/.local/skhepdata/uproot-sample-6.08.04-uncompressed.root",
+            "sample",
+            30,
+        ),
+    ]
+    for i, num in enumerate(uproot.num_entries([file1, file2, file3])):
         assert num == vals[i]
-        i += 1
+
 
 
 def test_dict_input():
@@ -37,10 +57,19 @@ def test_dict_input():
     file_name2 = skhep_testdata.data_path("uproot-HZZ.root")
     file_name3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root")
 
-    i = 0
-    vals = [2304, 2421, 30]
-    for num in uproot.num_entries(
-        {file_name1: "events", file_name2: "events", file_name3: "sample"}
+
+    vals = [
+        ("/home/kmk/.local/skhepdata/uproot-Zmumu.root", "events", 2304),
+        ("/home/kmk/.local/skhepdata/uproot-HZZ.root", "events", 2421),
+        (
+            "/home/kmk/.local/skhepdata/uproot-sample-6.08.04-uncompressed.root",
+            "sample",
+            30,
+        ),
+    ]
+    for i, num in enumerate(
+        uproot.num_entries(
+            {file_name1: "events", file_name2: "events", file_name3: "sample"}
+        )
     ):
         assert num == vals[i]
-        i += 1

--- a/tests/test_0609-num-enteries-func.py
+++ b/tests/test_0609-num-enteries-func.py
@@ -11,7 +11,6 @@ def test_num_entries_single():
     ]
 
 
-
 def test_num_entries_multiple():
     file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
     file2 = skhep_testdata.data_path("uproot-HZZ.root") + ":events"
@@ -37,7 +36,6 @@ def test_num_entries_as_iterator():
         skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root") + ":sample"
     )
 
-
     vals = [
         ("/home/kmk/.local/skhepdata/uproot-Zmumu.root", "events", 2304),
         ("/home/kmk/.local/skhepdata/uproot-HZZ.root", "events", 2421),
@@ -51,12 +49,10 @@ def test_num_entries_as_iterator():
         assert num == vals[i]
 
 
-
 def test_dict_input():
     file_name1 = skhep_testdata.data_path("uproot-Zmumu.root")
     file_name2 = skhep_testdata.data_path("uproot-HZZ.root")
     file_name3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root")
-
 
     vals = [
         ("/home/kmk/.local/skhepdata/uproot-Zmumu.root", "events", 2304),

--- a/tests/test_0609-num-enteries-func.py
+++ b/tests/test_0609-num-enteries-func.py
@@ -1,0 +1,36 @@
+import numpy
+import uproot
+import skhep_testdata
+
+
+def test_num_entries_single():
+    file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
+    assert list(uproot.num_entries(file1)) == [2304]
+
+def test_num_entries_multiple():
+    file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
+    file2 = skhep_testdata.data_path("uproot-HZZ.root") + ":events"
+    file3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root") + ":sample"
+    assert list(uproot.num_entries([file1,file2,file3])) == [2304, 2421, 30]
+
+def test_num_entries_as_iterator():
+    file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
+    file2 = skhep_testdata.data_path("uproot-HZZ.root") + ":events"
+    file3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root") + ":sample"
+
+    i=0
+    vals = [2304,2421,30]
+    for num in uproot.num_entries([file1,file2,file3]):
+        assert num == vals[i]
+        i+=1
+
+def test_dict_input():
+    file_name1 = skhep_testdata.data_path("uproot-Zmumu.root")
+    file_name2 = skhep_testdata.data_path("uproot-HZZ.root")
+    file_name3 = skhep_testdata.data_path("uproot-sample-6.08.04-uncompressed.root")
+
+    i=0
+    vals = [2304,2421,30]
+    for num in uproot.num_entries({file_name1:"events",file_name2:"events",file_name3:"sample"}):
+        assert num == vals[i]
+        i+=1


### PR DESCRIPTION
Usage commands:

```python
import uproot
import skhep_testdata
from pprint import pprint as pp

file1 = skhep_testdata.data_path("uproot-Zmumu.root") + ":events"
file2 = skhep_testdata.data_path("uproot-HZZ.root") + ":events"
```

Outputs:
```python
>>> pp(uproot.num_entries(file1))
[(2304,)]
>>> pp(uproot.num_entries([file1,file2]))
[(2304,), (2421,)]
```

Tests, docstring and cleanup: WIP