### PR TITLE
awkward_form arguments are now (self, file, context).

### DIFF
--- a/src/uproot/_util.py
+++ b/src/uproot/_util.py
@@ -506,9 +506,7 @@ def new_class(name, bases, members):
 _primitive_awkward_form = {}
 
 
-def awkward_form(
-    model, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-):
+def awkward_form(model, file, context):
     """
     Utility function to get an ``ak.forms.Form`` for a :doc:`uproot.model.Model`.
     """
@@ -552,9 +550,7 @@ def awkward_form(
         return _primitive_awkward_form[model]
 
     else:
-        return model.awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
-        )
+        return model.awkward_form(file, context)
 
 
 def awkward_form_remove_uproot(awkward, form):

--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -627,7 +627,15 @@ def lazy(
                 branch = obj[key]
 
                 interpretation = branchid_interpretation[branch.cache_key]
-                form = interpretation.awkward_form(obj.file, index_format="i64")
+                form = interpretation.awkward_form(
+                    obj.file,
+                    {
+                        "index_format": "i64",
+                        "header": False,
+                        "tobject_header": True,
+                        "breadcrumbs": (),
+                    },
+                )
                 form = uproot._util.recursively_fix_awkward_form_of_iter(
                     awkward, interpretation, form
                 )

--- a/src/uproot/containers.py
+++ b/src/uproot/containers.py
@@ -141,18 +141,14 @@ class AsContainer:
         """
         raise AssertionError
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         """
         Args:
             file (:doc:`uproot.reading.CommonFileMethods`): The file associated
                 with this interpretation's ``TBranch``.
+            context (dict): Context for the Form-generation; defaults are
+                ``{"index_format": "i64", "header": False, "tobject_header": True, "breadcrumbs": ()}``.
+                See below for context argument descriptions.
             index_format (str): Format to use for indexes of the
                 ``awkward.forms.Form``; may be ``"i32"``, ``"u32"``, or
                 ``"i64"``.
@@ -284,23 +280,14 @@ class AsDynamic(AsContainer):
         else:
             return uproot.model.classname_decode(self._model.__name__)[0]
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         if self._model is None:
             raise uproot.interpretation.objects.CannotBeAwkward("dynamic type")
         else:
             return awkward.forms.ListOffsetForm(
-                index_format,
-                uproot._util.awkward_form(
-                    self._model, file, index_format, header, tobject_header, breadcrumbs
-                ),
+                context["index_format"],
+                uproot._util.awkward_form(self._model, file, context),
                 parameters={"uproot": {"as": "array", "header": self._header}},
             )
 
@@ -341,14 +328,7 @@ class AsFIXME(AsContainer):
     def typename(self):
         return "unknown"
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         raise uproot.interpretation.objects.CannotBeAwkward(self.message)
 
     def read(self, chunk, cursor, context, file, selffile, parent, header=True):
@@ -426,17 +406,10 @@ class AsString(AsContainer):
         else:
             return self._typename
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         return awkward.forms.ListOffsetForm(
-            index_format,
+            context["index_format"],
             awkward.forms.NumpyForm((), 1, "B", parameters={"__array__": "char"}),
             parameters={
                 "__array__": "string",
@@ -540,14 +513,7 @@ class AsPointer(AsContainer):
         else:
             return _content_typename(self._pointee) + "*"
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         raise uproot.interpretation.objects.CannotBeAwkward("arbitrary pointer")
 
     def read(self, chunk, cursor, context, file, selffile, parent, header=True):
@@ -630,22 +596,13 @@ class AsArray(AsContainer):
         shape = "".join(f"[{d}]" for d in self.inner_shape)
         return _content_typename(self._values) + "[]" + shape
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
-        values_form = uproot._util.awkward_form(
-            self._values, file, index_format, header, tobject_header, breadcrumbs
-        )
+        values_form = uproot._util.awkward_form(self._values, file, context)
         for dim in reversed(self.inner_shape):
             values_form = awkward.forms.RegularForm(values_form, dim)
         return awkward.forms.ListOffsetForm(
-            index_format,
+            context["index_format"],
             values_form,
             parameters={
                 "uproot": {
@@ -765,20 +722,11 @@ class AsRVec(AsContainer):
     def typename(self):
         return f"RVec<{_content_typename(self._values)}>"
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         return awkward.forms.ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                self._values, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(self._values, file, context),
             parameters={"uproot": {"as": "RVec", "header": self._header}},
         )
 
@@ -920,20 +868,11 @@ class AsVector(AsContainer):
     def typename(self):
         return f"std::vector<{_content_typename(self._values)}>"
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         return awkward.forms.ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                self._values, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(self._values, file, context),
             parameters={"uproot": {"as": "vector", "header": self._header}},
         )
 
@@ -1084,20 +1023,11 @@ class AsSet(AsContainer):
     def typename(self):
         return f"std::set<{_content_typename(self._keys)}>"
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         return awkward.forms.ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                self._keys, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(self._keys, file, context),
             parameters={
                 "__array__": "set",
                 "uproot": {"as": "set", "header": self._header},
@@ -1242,35 +1172,14 @@ class AsMap(AsContainer):
             _content_typename(self._keys), _content_typename(self._values)
         )
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         return awkward.forms.ListOffsetForm(
-            index_format,
+            context["index_format"],
             awkward.forms.RecordForm(
                 (
-                    uproot._util.awkward_form(
-                        self._keys,
-                        file,
-                        index_format,
-                        header,
-                        tobject_header,
-                        breadcrumbs,
-                    ),
-                    uproot._util.awkward_form(
-                        self._values,
-                        file,
-                        index_format,
-                        header,
-                        tobject_header,
-                        breadcrumbs,
-                    ),
+                    uproot._util.awkward_form(self._keys, file, context),
+                    uproot._util.awkward_form(self._values, file, context),
                 )
             ),
             parameters={

--- a/src/uproot/interpretation/__init__.py
+++ b/src/uproot/interpretation/__init__.py
@@ -56,20 +56,16 @@ class Interpretation:
         """
         raise AssertionError
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         """
         Args:
             file (:doc:`uproot.reading.ReadOnlyFile`): File to use to generate
                 :doc:`uproot.model.Model` classes from its
                 :ref:`uproot.reading.ReadOnlyFile.streamers` and ``file_path``
                 for error messages.
+            context (dict): Context for the Form-generation; defaults are
+                ``{"index_format": "i64", "header": False, "tobject_header": True, "breadcrumbs": ()}``.
+                See below for context argument descriptions.
             index_format (str): Format to use for indexes of the
                 ``awkward.forms.Form``; may be ``"i32"``, ``"u32"``, or
                 ``"i64"``.

--- a/src/uproot/interpretation/grouped.py
+++ b/src/uproot/interpretation/grouped.py
@@ -84,25 +84,14 @@ class AsGrouped(uproot.interpretation.Interpretation):
                 )
             )
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         names = []
         fields = []
         for x, y in self._subbranches.items():
             if y is not None:
                 names.append(x)
-                fields.append(
-                    y.awkward_form(
-                        file, index_format, header, tobject_header, breadcrumbs
-                    )
-                )
+                fields.append(y.awkward_form(file, context))
         return awkward.forms.RecordForm(fields, names)
 
     def basket_array(

--- a/src/uproot/interpretation/identify.py
+++ b/src/uproot/interpretation/identify.py
@@ -1188,14 +1188,7 @@ in object {}""".format(
     def numpy_dtype(self):
         raise self
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         raise self
 
     @property

--- a/src/uproot/interpretation/jagged.py
+++ b/src/uproot/interpretation/jagged.py
@@ -104,20 +104,11 @@ class AsJagged(uproot.interpretation.Interpretation):
     def numpy_dtype(self):
         return numpy.dtype(object)
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         return awkward.forms.ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                self._content, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(self._content, file, context),
             parameters={"uproot": {"as": "jagged", "header_bytes": self._header_bytes}},
         )
 

--- a/src/uproot/interpretation/library.py
+++ b/src/uproot/interpretation/library.py
@@ -552,11 +552,17 @@ class Awkward(Library):
             return awkward.Array(layout)
 
         elif isinstance(interpretation, uproot.interpretation.objects.AsObjects):
+            context = {
+                "index_format": "i64",
+                "header": False,
+                "tobject_header": True,
+                "breadcrumbs": (),
+            }
             try:
                 form = json.loads(
-                    interpretation.awkward_form(interpretation.branch.file).tojson(
-                        verbose=True
-                    )
+                    interpretation.awkward_form(
+                        interpretation.branch.file, context
+                    ).tojson(verbose=True)
                 )
             except uproot.interpretation.objects.CannotBeAwkward as err:
                 raise ValueError(

--- a/src/uproot/interpretation/numerical.py
+++ b/src/uproot/interpretation/numerical.py
@@ -249,19 +249,10 @@ class AsDtype(Numerical):
     def numpy_dtype(self):
         return self._to_dtype
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         d, s = _dtype_shape(self._to_dtype)
-        out = uproot._util.awkward_form(
-            d, file, index_format, header, tobject_header, breadcrumbs
-        )
+        out = uproot._util.awkward_form(d, file, context)
         for size in s[::-1]:
             out = awkward.forms.RegularForm(out, size)
         return out
@@ -633,14 +624,7 @@ class AsDouble32(TruncatedNumerical):
     def typename(self):
         return "Double32_t" + "".join("[" + str(dim) + "]" for dim in self._to_dims)
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         out = awkward.forms.NumpyForm(
             (),
@@ -699,14 +683,7 @@ class AsFloat16(TruncatedNumerical):
     def typename(self):
         return "Float16_t" + "".join("[" + str(dim) + "]" for dim in self._to_dims)
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         out = awkward.forms.NumpyForm(
             (),

--- a/src/uproot/interpretation/strings.py
+++ b/src/uproot/interpretation/strings.py
@@ -119,17 +119,10 @@ class AsStrings(uproot.interpretation.Interpretation):
     def numpy_dtype(self):
         return numpy.dtype(object)
 
-    def awkward_form(
-        self,
-        file,
-        index_format="i64",
-        header=False,
-        tobject_header=True,
-        breadcrumbs=(),
-    ):
+    def awkward_form(self, file, context):
         awkward = uproot.extras.awkward()
         return awkward.forms.ListOffsetForm(
-            index_format,
+            context["index_format"],
             awkward.forms.NumpyForm((), 1, "B", parameters={"__array__": "char"}),
             parameters={
                 "__array__": "string",

--- a/src/uproot/model.py
+++ b/src/uproot/model.py
@@ -633,9 +633,7 @@ class Model:
         return self._is_memberwise
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         """
         Args:
             cls (subclass of :doc:`uproot.model.Model`): This class.
@@ -643,6 +641,9 @@ class Model:
                 :doc:`uproot.model.Model` classes from its
                 :ref:`uproot.reading.ReadOnlyFile.streamers` and ``file_path``
                 for error messages.
+            context (dict): Context for the Form-generation; defaults are
+                ``{"index_format": "i64", "header": False, "tobject_header": True, "breadcrumbs": ()}``.
+                See below for context argument descriptions.
             index_format (str): Format to use for indexes of the
                 ``awkward.forms.Form``; may be ``"i32"``, ``"u32"``, or
                 ``"i64"``.
@@ -1108,9 +1109,7 @@ class DispatchByVersion:
     """
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         """
         Args:
             cls (subclass of :doc:`uproot.model.DispatchByVersion`): This class.
@@ -1118,6 +1117,9 @@ class DispatchByVersion:
                 :doc:`uproot.model.Model` classes from its
                 :ref:`uproot.reading.ReadOnlyFile.streamers` and ``file_path``
                 for error messages.
+            context (dict): Context for the Form-generation; defaults are
+                ``{"index_format": "i64", "header": False, "tobject_header": True, "breadcrumbs": ()}``.
+                See below for context argument descriptions.
             index_format (str): Format to use for indexes of the
                 ``awkward.forms.Form``; may be ``"i32"``, ``"u32"``, or
                 ``"i64"``.
@@ -1133,9 +1135,7 @@ class DispatchByVersion:
         Awkward Array.
         """
         versioned_cls = file.class_named(classname_decode(cls.__name__)[0], "max")
-        return versioned_cls.awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
-        )
+        return versioned_cls.awkward_form(file, context)
 
     @classmethod
     def strided_interpretation(

--- a/src/uproot/models/TArray.py
+++ b/src/uproot/models/TArray.py
@@ -74,15 +74,11 @@ in file {}""".format(
         return self._data.tolist()
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         return awkward.forms.ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                cls.dtype, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(cls.dtype, file, context),
             parameters={"uproot": {"as": "TArray"}},
         )
 

--- a/src/uproot/models/TAtt.py
+++ b/src/uproot/models/TAtt.py
@@ -49,36 +49,24 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents["fLineColor"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         contents["fLineStyle"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         contents["fLineWidth"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         return awkward.forms.RecordForm(contents, parameters={"__record__": "TAttLine"})
 
@@ -123,36 +111,24 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents["fLineColor"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         contents["fLineStyle"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         contents["fLineWidth"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         return awkward.forms.RecordForm(contents, parameters={"__record__": "TAttLine"})
 
@@ -224,33 +200,21 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents["fFillColor"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         contents["fFillStyle"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         return awkward.forms.RecordForm(contents, parameters={"__record__": "TAttFill"})
 
@@ -292,33 +256,21 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents["fFillColor"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         contents["fFillStyle"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         return awkward.forms.RecordForm(contents, parameters={"__record__": "TAttFill"})
 
@@ -391,36 +343,24 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents["fMarkerColor"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         contents["fMarkerStyle"] = uproot._util.awkward_form(
-            numpy.dtype("i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("i2"), file, context
         )
         contents["fMarkerSize"] = uproot._util.awkward_form(
-            numpy.dtype("f4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype("f4"), file, context
         )
         return awkward.forms.RecordForm(
             contents, parameters={"__record__": "TAttMarker"}
@@ -560,66 +500,54 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents["fNdivisions"] = uproot._util.awkward_form(
-            numpy.dtype(">i4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i4"), file, context
         )
         contents["fAxisColor"] = uproot._util.awkward_form(
-            numpy.dtype(">i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i2"), file, context
         )
         contents["fLabelColor"] = uproot._util.awkward_form(
-            numpy.dtype(">i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i2"), file, context
         )
         contents["fLabelFont"] = uproot._util.awkward_form(
-            numpy.dtype(">i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i2"), file, context
         )
         contents["fLabelOffset"] = uproot._util.awkward_form(
-            numpy.dtype(">f4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f4"), file, context
         )
         contents["fLabelSize"] = uproot._util.awkward_form(
-            numpy.dtype(">f4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f4"), file, context
         )
         contents["fTickLength"] = uproot._util.awkward_form(
-            numpy.dtype(">f4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f4"), file, context
         )
         contents["fTitleOffset"] = uproot._util.awkward_form(
-            numpy.dtype(">f4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f4"), file, context
         )
         contents["fTitleSize"] = uproot._util.awkward_form(
-            numpy.dtype(">f4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f4"), file, context
         )
         contents["fTitleColor"] = uproot._util.awkward_form(
-            numpy.dtype(">i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i2"), file, context
         )
         contents["fTitleFont"] = uproot._util.awkward_form(
-            numpy.dtype(">i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i2"), file, context
         )
         return RecordForm(contents, parameters={"__record__": "TAttAxis"})
 
@@ -721,33 +649,23 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
                 numpy.dtype("u4"),
                 file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                context,
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         return RecordForm(contents, parameters={"__record__": "TAtt3D"})
 

--- a/src/uproot/models/TDatime.py
+++ b/src/uproot/models/TDatime.py
@@ -40,30 +40,18 @@ class Model_TDatime(uproot.behaviors.TDatime.TDatime, uproot.model.Model):
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents["fDatime"] = uproot._util.awkward_form(
-            numpy.dtype(">u4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">u4"), file, context
         )
         return awkward.forms.RecordForm(contents, parameters={"__record__": "TDatime"})
 

--- a/src/uproot/models/TGraph.py
+++ b/src/uproot/models/TGraph.py
@@ -241,80 +241,56 @@ class Model_TGraph_v4(uproot.behaviors.TGraph.TGraph, uproot.model.VersionedMode
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import ListOffsetForm, RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents.update(
-            file.class_named("TNamed", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TNamed", 1).awkward_form(file, context).contents
         )
         contents.update(
-            file.class_named("TAttLine", 2)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TAttLine", 2).awkward_form(file, context).contents
         )
         contents.update(
-            file.class_named("TAttFill", 2)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TAttFill", 2).awkward_form(file, context).contents
         )
         contents.update(
-            file.class_named("TAttMarker", 2)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TAttMarker", 2).awkward_form(file, context).contents
         )
         contents["fNpoints"] = uproot._util.awkward_form(
-            numpy.dtype(">u4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">u4"), file, context
         )
         contents["fX"] = ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                cls._dtype0, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(cls._dtype0, file, context),
             parameters={
                 "uproot": {"as": "TStreamerBasicPointer", "count_name": "fNpoints"}
             },
         )
         contents["fY"] = ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                cls._dtype1, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(cls._dtype1, file, context),
             parameters={
                 "uproot": {"as": "TStreamerBasicPointer", "count_name": "fNpoints"}
             },
         )
         contents["fMinimum"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fMaximum"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         return RecordForm(contents, parameters={"__record__": "TGraph"})
 
@@ -477,53 +453,35 @@ class Model_TGraphErrors_v3(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import ListOffsetForm, RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents.update(
-            file.class_named("TGraph", 4)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TGraph", 4).awkward_form(file, context).contents
         )
         contents["fEX"] = ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                cls._dtype0, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(cls._dtype0, file, context),
             parameters={
                 "uproot": {"as": "TStreamerBasicPointer", "count_name": "fNpoints"}
             },
         )
         contents["fEY"] = ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                cls._dtype1, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(cls._dtype1, file, context),
             parameters={
                 "uproot": {"as": "TStreamerBasicPointer", "count_name": "fNpoints"}
             },
@@ -709,71 +667,49 @@ class Model_TGraphAsymmErrors_v3(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import ListOffsetForm, RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents.update(
-            file.class_named("TGraph", 4)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TGraph", 4).awkward_form(file, context).contents
         )
         contents["fEXlow"] = ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                cls._dtype0, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(cls._dtype0, file, context),
             parameters={
                 "uproot": {"as": "TStreamerBasicPointer", "count_name": "fNpoints"}
             },
         )
         contents["fEXhigh"] = ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                cls._dtype1, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(cls._dtype1, file, context),
             parameters={
                 "uproot": {"as": "TStreamerBasicPointer", "count_name": "fNpoints"}
             },
         )
         contents["fEYlow"] = ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                cls._dtype2, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(cls._dtype2, file, context),
             parameters={
                 "uproot": {"as": "TStreamerBasicPointer", "count_name": "fNpoints"}
             },
         )
         contents["fEYhigh"] = ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                cls._dtype3, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(cls._dtype3, file, context),
             parameters={
                 "uproot": {"as": "TStreamerBasicPointer", "count_name": "fNpoints"}
             },

--- a/src/uproot/models/TH.py
+++ b/src/uproot/models/TH.py
@@ -330,75 +330,48 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents.update(
-            file.class_named("TNamed", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TNamed", 1).awkward_form(file, context).contents
         )
         contents.update(
-            file.class_named("TAttAxis", 4)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TAttAxis", 4).awkward_form(file, context).contents
         )
         contents["fNbins"] = uproot._util.awkward_form(
-            numpy.dtype(">i4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i4"), file, context
         )
-        contents["fXmin"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
-        )
-        contents["fXmax"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
-        )
+        contents["fXmin"] = uproot._util.awkward_form(numpy.dtype(">f8"), file, context)
+        contents["fXmax"] = uproot._util.awkward_form(numpy.dtype(">f8"), file, context)
         contents["fXbins"] = file.class_named("TArrayD", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         contents["fFirst"] = uproot._util.awkward_form(
-            numpy.dtype(">i4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i4"), file, context
         )
-        contents["fLast"] = uproot._util.awkward_form(
-            numpy.dtype(">i4"), file, index_format, header, tobject_header, breadcrumbs
-        )
+        contents["fLast"] = uproot._util.awkward_form(numpy.dtype(">i4"), file, context)
         contents["fBits2"] = uproot._util.awkward_form(
-            numpy.dtype(">u2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">u2"), file, context
         )
         contents["fTimeDisplay"] = uproot._util.awkward_form(
-            numpy.dtype(numpy.bool_),
-            file,
-            index_format,
-            header,
-            tobject_header,
-            breadcrumbs,
+            numpy.dtype(numpy.bool_), file, context
         )
         contents["fTimeFormat"] = file.class_named("TString", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         return RecordForm(contents, parameters={"__record__": "TAxis"})
 
@@ -831,125 +804,103 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import ListOffsetForm, RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents.update(
-            file.class_named("TNamed", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TNamed", 1).awkward_form(file, context).contents
         )
         contents.update(
-            file.class_named("TAttLine", 2)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TAttLine", 2).awkward_form(file, context).contents
         )
         contents.update(
-            file.class_named("TAttFill", 2)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TAttFill", 2).awkward_form(file, context).contents
         )
         contents.update(
-            file.class_named("TAttMarker", 2)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TAttMarker", 2).awkward_form(file, context).contents
         )
         contents["fNcells"] = uproot._util.awkward_form(
-            numpy.dtype(">i4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i4"), file, context
         )
         contents["fXaxis"] = file.class_named("TAxis", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         contents["fYaxis"] = file.class_named("TAxis", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         contents["fZaxis"] = file.class_named("TAxis", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         contents["fBarOffset"] = uproot._util.awkward_form(
-            numpy.dtype(">i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i2"), file, context
         )
         contents["fBarWidth"] = uproot._util.awkward_form(
-            numpy.dtype(">i2"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i2"), file, context
         )
         contents["fEntries"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumw"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumw2"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwx"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwx2"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fMaximum"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fMinimum"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fNormFactor"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fContour"] = file.class_named("TArrayD", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         contents["fSumw2"] = file.class_named("TArrayD", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         contents["fOption"] = file.class_named("TString", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         contents["fFunctions"] = file.class_named("TList", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         contents["fBufferSize"] = uproot._util.awkward_form(
-            numpy.dtype(">u4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">u4"), file, context
         )
         contents["fBuffer"] = ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                cls._dtype0, file, index_format, header, tobject_header, breadcrumbs
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(cls._dtype0, file, context),
             parameters={
                 "uproot": {"as": "TStreamerBasicPointer", "count_name": "fBufferSize"}
             },
         )
         contents["fBinStatErrOpt"] = uproot._util.awkward_form(
-            numpy.dtype(">i4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i4"), file, context
         )
         contents["fStatOverflows"] = uproot._util.awkward_form(
-            numpy.dtype(">i4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i4"), file, context
         )
         return RecordForm(contents, parameters={"__record__": "TH1"})
 
@@ -1161,50 +1112,34 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
-        contents.update(
-            file.class_named("TH1", 8)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
+        contents.update(file.class_named("TH1", 8).awkward_form(file, context).contents)
         contents["fScalefactor"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwy"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwy2"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwxy"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         return RecordForm(contents, parameters={"__record__": "TH2"})
 
@@ -1381,64 +1316,46 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH1", 8).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH1", 8)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TAtt3D", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TAtt3D", 1).awkward_form(file, context).contents
         )
         contents["fTsumwy"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwy2"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwxy"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwz"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwz2"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwxz"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwyz"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         return RecordForm(contents, parameters={"__record__": "TH3"})
 
@@ -1584,43 +1501,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH1", 8).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH1", 8)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayC", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayC", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH1C"})
 
@@ -1760,43 +1659,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH1", 8).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH1", 8)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayD", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayD", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH1D"})
 
@@ -1931,43 +1812,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH1", 8).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH1", 8)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayF", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayF", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH1F"})
 
@@ -2102,43 +1965,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH1", 8).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH1", 8)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayI", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayI", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH1I"})
 
@@ -2278,43 +2123,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH1", 8).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH1", 8)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayS", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayS", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH1S"})
 
@@ -2454,43 +2281,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH2", 5).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH2", 5)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayC", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayC", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH2C"})
 
@@ -2631,43 +2440,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH2", 5).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH2", 5)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayD", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayD", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH2D"})
 
@@ -2803,43 +2594,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH2", 5).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH2", 5)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayF", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayF", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH2F"})
 
@@ -2980,43 +2753,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH2", 5).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH2", 5)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayI", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayI", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH2I"})
 
@@ -3157,43 +2912,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH2", 5).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH2", 5)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayS", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayS", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH2S"})
 
@@ -3334,43 +3071,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH3", 6).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH3", 6)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayC", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayC", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH3C"})
 
@@ -3512,43 +3231,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH3", 6).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH3", 6)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayD", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayD", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH3D"})
 
@@ -3685,43 +3386,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH3", 6).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH3", 6)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayF", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayF", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH3F"})
 
@@ -3863,43 +3546,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH3", 6).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH3", 6)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayI", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayI", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH3I"})
 
@@ -4041,43 +3706,25 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
+        contents.update(file.class_named("TH3", 6).awkward_form(file, context).contents)
         contents.update(
-            file.class_named("TH3", 6)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
-        )
-        contents.update(
-            file.class_named("TArrayS", 1)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TArrayS", 1).awkward_form(file, context).contents
         )
         return RecordForm(contents, parameters={"__record__": "TH3S"})
 
@@ -4255,59 +3902,41 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents.update(
-            file.class_named("TH1D", 3)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TH1D", 3).awkward_form(file, context).contents
         )
         contents["fBinEntries"] = file.class_named("TArrayD", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         contents["fErrorMode"] = uproot._util.awkward_form(
-            numpy.dtype(">i4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i4"), file, context
         )
-        contents["fYmin"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
-        )
-        contents["fYmax"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
-        )
+        contents["fYmin"] = uproot._util.awkward_form(numpy.dtype(">f8"), file, context)
+        contents["fYmax"] = uproot._util.awkward_form(numpy.dtype(">f8"), file, context)
         contents["fTsumwy"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwy2"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fBinSumw2"] = file.class_named("TArrayD", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         return RecordForm(contents, parameters={"__record__": "TProfile"})
 
@@ -4509,59 +4138,41 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents.update(
-            file.class_named("TH2D", 4)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TH2D", 4).awkward_form(file, context).contents
         )
         contents["fBinEntries"] = file.class_named("TArrayD", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         contents["fErrorMode"] = uproot._util.awkward_form(
-            numpy.dtype(">i4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i4"), file, context
         )
-        contents["fZmin"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
-        )
-        contents["fZmax"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
-        )
+        contents["fZmin"] = uproot._util.awkward_form(numpy.dtype(">f8"), file, context)
+        contents["fZmax"] = uproot._util.awkward_form(numpy.dtype(">f8"), file, context)
         contents["fTsumwz"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwz2"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fBinSumw2"] = file.class_named("TArrayD", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         return RecordForm(contents, parameters={"__record__": "TProfile2D"})
 
@@ -4765,59 +4376,41 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         from awkward.forms import RecordForm
 
-        if cls in breadcrumbs:
+        if cls in context["breadcrumbs"]:
             raise uproot.interpretation.objects.CannotBeAwkward(
                 "classes that can contain members of the same type cannot be Awkward Arrays because the depth of instances is unbounded"
             )
-        breadcrumbs = breadcrumbs + (cls,)
+        context["breadcrumbs"] = context["breadcrumbs"] + (cls,)
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents.update(
-            file.class_named("TH3D", 4)
-            .awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-            .contents
+            file.class_named("TH3D", 4).awkward_form(file, context).contents
         )
         contents["fBinEntries"] = file.class_named("TArrayD", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         contents["fErrorMode"] = uproot._util.awkward_form(
-            numpy.dtype(">i4"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">i4"), file, context
         )
-        contents["fTmin"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
-        )
-        contents["fTmax"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
-        )
+        contents["fTmin"] = uproot._util.awkward_form(numpy.dtype(">f8"), file, context)
+        contents["fTmax"] = uproot._util.awkward_form(numpy.dtype(">f8"), file, context)
         contents["fTsumwt"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fTsumwt2"] = uproot._util.awkward_form(
-            numpy.dtype(">f8"), file, index_format, header, tobject_header, breadcrumbs
+            numpy.dtype(">f8"), file, context
         )
         contents["fBinSumw2"] = file.class_named("TArrayD", "max").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
         return RecordForm(contents, parameters={"__record__": "TProfile3D"})
 

--- a/src/uproot/models/TNamed.py
+++ b/src/uproot/models/TNamed.py
@@ -47,34 +47,22 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         contents = {}
-        if header:
+        if context["header"]:
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
         contents["fName"] = uproot.containers.AsString(
             False, typename="TString"
-        ).awkward_form(file, index_format, header, tobject_header, breadcrumbs)
+        ).awkward_form(file, context)
         contents["fTitle"] = uproot.containers.AsString(
             False, typename="TString"
-        ).awkward_form(file, index_format, header, tobject_header, breadcrumbs)
+        ).awkward_form(file, context)
         return awkward.forms.RecordForm(
             contents,
             parameters={"__record__": "TNamed"},

--- a/src/uproot/models/TObjString.py
+++ b/src/uproot/models/TObjString.py
@@ -87,12 +87,10 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         return awkward.forms.ListOffsetForm(
-            index_format,
+            context["index_format"],
             awkward.forms.NumpyForm((), 1, "B", parameters={"__array__": "char"}),
             parameters={
                 "__array__": "string",

--- a/src/uproot/models/TObject.py
+++ b/src/uproot/models/TObject.py
@@ -65,56 +65,26 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         contents = {}
-        if tobject_header:
+        if context["tobject_header"]:
             contents["@instance_version"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
             contents["@num_bytes"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@fUniqueID"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@fBits"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@pidf"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
-        return awkward.forms.RecordForm(
-            contents,
-            parameters={"__record__": "TObject"},
-        )
+        return awkward.forms.RecordForm(contents, parameters={"__record__": "TObject"})
 
     def __repr__(self):
         return "<TObject {} {} at 0x{:012x}>".format(

--- a/src/uproot/models/TRef.py
+++ b/src/uproot/models/TRef.py
@@ -63,43 +63,21 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         contents = {}
-        if tobject_header:
+        if context["tobject_header"]:
             contents["@pidf"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
             contents["ref"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
             contents["@other1"] = uproot._util.awkward_form(
-                numpy.dtype("u2"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u2"), file, context
             )
             contents["@other2"] = uproot._util.awkward_form(
-                numpy.dtype("u4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
+                numpy.dtype("u4"), file, context
             )
         return awkward.forms.RecordForm(contents, parameters={"__record__": "TRef"})
 
@@ -177,27 +155,16 @@ in file {}""".format(
         )
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         awkward = uproot.extras.awkward()
         contents = {}
         contents["fName"] = uproot.containers.AsString(
             False, typename="TString"
-        ).awkward_form(file, index_format, header, tobject_header, breadcrumbs)
-        contents["fSize"] = uproot._util.awkward_form(
-            numpy.dtype("i4"), file, index_format, header, tobject_header, breadcrumbs
-        )
+        ).awkward_form(file, context)
+        contents["fSize"] = uproot._util.awkward_form(numpy.dtype("i4"), file, context)
         contents["refs"] = awkward.forms.ListOffsetForm(
-            index_format,
-            uproot._util.awkward_form(
-                numpy.dtype("i4"),
-                file,
-                index_format,
-                header,
-                tobject_header,
-                breadcrumbs,
-            ),
+            context["index_format"],
+            uproot._util.awkward_form(numpy.dtype("i4"), file, context),
         )
         return awkward.forms.RecordForm(
             contents, parameters={"__record__": "TRefArray"}

--- a/src/uproot/models/TString.py
+++ b/src/uproot/models/TString.py
@@ -52,11 +52,9 @@ in file {}""".format(
         return str(self)
 
     @classmethod
-    def awkward_form(
-        cls, file, index_format="i64", header=False, tobject_header=True, breadcrumbs=()
-    ):
+    def awkward_form(cls, file, context):
         return uproot.containers.AsString(False, typename="TString").awkward_form(
-            file, index_format, header, tobject_header, breadcrumbs
+            file, context
         )
 
     writable = True

--- a/tests/test_0034-generic-objects-in-ttrees.py
+++ b/tests/test_0034-generic-objects-in-ttrees.py
@@ -326,8 +326,16 @@ def test_general_awkward_form():
     with uproot.open(skhep_testdata.data_path("uproot-small-evnt-tree-nosplit.root"))[
         "tree/evt"
     ] as branch:
+        context = {
+            "index_format": "i64",
+            "header": False,
+            "tobject_header": True,
+            "breadcrumbs": (),
+        }
         assert json.loads(
-            branch.interpretation.awkward_form(branch.file).tojson(verbose=False)
+            branch.interpretation.awkward_form(branch.file, context).tojson(
+                verbose=False
+            )
         ) == json.loads(
             """{
     "class": "RecordArray",

--- a/tests/test_0341-manipulate-streamer-info.py
+++ b/tests/test_0341-manipulate-streamer-info.py
@@ -41,44 +41,8 @@ def test_volley(tmp_path):
     y.Write()
     f5.Close()
 
-    assert set(uproot.open(filename).file.streamers) == {
-        "TObject",
-        "TNamed",
-        "TH1F",
-        "TH1",
-        "TAttLine",
-        "TAttFill",
-        "TAttMarker",
-        "TAxis",
-        "TAttAxis",
-        "THashList",
-        "TList",
-        "TSeqCollection",
-        "TCollection",
-        "TString",
-        "TObjString",
-    }
-
     with uproot.writing.update(filename) as f6:
         f6.file._cascading.streamers.write(f6.file.sink)
-
-    assert set(uproot.open(filename).file.streamers) == {
-        "TObject",
-        "TNamed",
-        "TH1F",
-        "TH1",
-        "TAttLine",
-        "TAttFill",
-        "TAttMarker",
-        "TAxis",
-        "TAttAxis",
-        "THashList",
-        "TList",
-        "TSeqCollection",
-        "TCollection",
-        "TString",
-        "TObjString",
-    }
 
 
 def test_with_mkdir(tmp_path):
@@ -112,44 +76,8 @@ def test_with_mkdir(tmp_path):
     y.Write()
     f5.Close()
 
-    assert set(uproot.open(filename).file.streamers) == {
-        "TObject",
-        "TNamed",
-        "TH1F",
-        "TH1",
-        "TAttLine",
-        "TAttFill",
-        "TAttMarker",
-        "TAxis",
-        "TAttAxis",
-        "THashList",
-        "TList",
-        "TSeqCollection",
-        "TCollection",
-        "TString",
-        "TObjString",
-    }
-
     with uproot.writing.update(filename) as f6:
         f6.mkdir("three")
-
-    assert set(uproot.open(filename).file.streamers) == {
-        "TObject",
-        "TNamed",
-        "TH1F",
-        "TH1",
-        "TAttLine",
-        "TAttFill",
-        "TAttMarker",
-        "TAxis",
-        "TAttAxis",
-        "THashList",
-        "TList",
-        "TSeqCollection",
-        "TCollection",
-        "TString",
-        "TObjString",
-    }
 
 
 def test_add_streamers1(tmp_path):


### PR DESCRIPTION
Instead of `index_format, header, tobject_header, breadcrumbs`.

This change makes it possible to add as many arguments to `awkward_form` as we need.