### PR TITLE
Adjust for ROOT TStreamerInfo change.

### DIFF
--- a/tests/test_0341-manipulate-streamer-info.py
+++ b/tests/test_0341-manipulate-streamer-info.py
@@ -41,44 +41,8 @@ def test_volley(tmp_path):
     y.Write()
     f5.Close()
 
-    assert set(uproot.open(filename).file.streamers) == {
-        "TObject",
-        "TNamed",
-        "TH1F",
-        "TH1",
-        "TAttLine",
-        "TAttFill",
-        "TAttMarker",
-        "TAxis",
-        "TAttAxis",
-        "THashList",
-        "TList",
-        "TSeqCollection",
-        "TCollection",
-        "TString",
-        "TObjString",
-    }
-
     with uproot.writing.update(filename) as f6:
         f6.file._cascading.streamers.write(f6.file.sink)
-
-    assert set(uproot.open(filename).file.streamers) == {
-        "TObject",
-        "TNamed",
-        "TH1F",
-        "TH1",
-        "TAttLine",
-        "TAttFill",
-        "TAttMarker",
-        "TAxis",
-        "TAttAxis",
-        "THashList",
-        "TList",
-        "TSeqCollection",
-        "TCollection",
-        "TString",
-        "TObjString",
-    }
 
 
 def test_with_mkdir(tmp_path):
@@ -112,44 +76,8 @@ def test_with_mkdir(tmp_path):
     y.Write()
     f5.Close()
 
-    assert set(uproot.open(filename).file.streamers) == {
-        "TObject",
-        "TNamed",
-        "TH1F",
-        "TH1",
-        "TAttLine",
-        "TAttFill",
-        "TAttMarker",
-        "TAxis",
-        "TAttAxis",
-        "THashList",
-        "TList",
-        "TSeqCollection",
-        "TCollection",
-        "TString",
-        "TObjString",
-    }
-
     with uproot.writing.update(filename) as f6:
         f6.mkdir("three")
-
-    assert set(uproot.open(filename).file.streamers) == {
-        "TObject",
-        "TNamed",
-        "TH1F",
-        "TH1",
-        "TAttLine",
-        "TAttFill",
-        "TAttMarker",
-        "TAxis",
-        "TAttAxis",
-        "THashList",
-        "TList",
-        "TSeqCollection",
-        "TCollection",
-        "TString",
-        "TObjString",
-    }
 
 
 def test_add_streamers1(tmp_path):


### PR DESCRIPTION
This PR just removes 2 tests.

The tests used to be:

   1. put a TObjString in the ROOT file along with a TObjString streamer
   2. update the file in ROOT (adding a histogram)
   3. see that ROOT has added the histogram streamers in addition to the TObjString

Now ROOT adds the histogram streamers, but removes the TObjString streamer. This is probably not considered an error because TObjString is a fundamental, built-in type. But still, we can't do our test now.