### PR TITLE
test: add test for issue 1054 (newer fsspec failing to parse files with colons in name)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,9 +65,6 @@ jobs:
       - name: Pip install the package
         run: python -m pip install .[test,dev]
 
-      - name: DELETE ME DEBUG ONLY
-        run: python -m pip install git+https://github.com/lobis/filesystem_spec@master
-
       - name: Run pytest
         run: |
           python -m pytest -vv tests --reruns 3 --reruns-delay 30 --only-rerun "(?i)http|timeout|connection|socket"
@@ -91,9 +88,6 @@ jobs:
 
       - name: Pip install the package
         run: python -m pip install .[test,dev]
-
-      - name: DELETE ME DEBUG ONLY
-        run: python -m pip install git+https://github.com/lobis/filesystem_spec@master
 
       - name: Run pytest
         run: |

--- a/tests/test_0692_fsspec_reading.py
+++ b/tests/test_0692_fsspec_reading.py
@@ -177,7 +177,9 @@ def test_open_fsspec_xrootd(handler):
         None,
     ],
 )
-@pytest.mark.skipif(is_windows, reason="Windows does not support : in filenames")
+@pytest.mark.skipif(
+    is_windows, reason="Windows does not support colons (':') in filenames"
+)
 def test_issue_1054_filename_colons(handler):
     root_filename = "uproot-issue121.root"
     local_path = str(skhep_testdata.data_path(root_filename))


### PR DESCRIPTION
I add an explicit test for this issue. This is currently also catched by other tests in the `main-fsspec` branch but I wouldn't be caught if we didn't make the switch to use fsspec for default local files (which is not clear yet).

Closes https://github.com/scikit-hep/uproot5/issues/1054

I will use this PR to fix this issue in case it needs some code change. I am hoping that https://github.com/fsspec/filesystem_spec/issues/1447 will address this (I assume it's a bug on fsspec part).

Currently this PR is failing until either fsspec publishes a new release with a fix, we set an upper limit for supported fsspec versions, or we modify how we handle paths with colons in our code. This should be handled before the next release.

I also added an explicit test for windows since colons cannot be part of a filename in windows.