### PR TITLE
chore: only use canonical forms for RNTuple reading

### DIFF
--- a/src/uproot/behaviors/RNTuple.py
+++ b/src/uproot/behaviors/RNTuple.py
@@ -1791,8 +1791,8 @@ def _fill_container_dict(container_dict, content, key, dtype_byte):
             indices = _cupy_insert(indices, missing, -1)
         container_dict[f"{key}-index"] = indices
     elif dtype_byte == uproot.const.rntuple_col_type_to_num_dict["switch"]:
-        kindex, tags = uproot.models.RNTuple._split_switch_bits(content)
-        tags += 1
+        tags = content["tag"].astype(numpy.int8)
+        kindex = content["index"]
         # Find invalid variants and adjust buffers accordingly
         invalid = numpy.flatnonzero(tags == 0)
         kindex[invalid] = 0  # Might not be necessary, but safer

--- a/src/uproot/models/RNTuple.py
+++ b/src/uproot/models/RNTuple.py
@@ -1134,13 +1134,6 @@ def _extract_bits(packed, nbits):
     return result
 
 
-# Supporting function and classes
-def _split_switch_bits(content):
-    tags = content["tag"].astype(numpy.dtype("int8")) - 1
-    kindex = content["index"]
-    return kindex, tags
-
-
 # https://github.com/root-project/root/blob/8cd9eed6f3a32e55ef1f0f1df8e5462e753c735d/tree/ntuple/v7/doc/BinaryFormatSpecification.md#page-locations
 class PageDescription:
     def read(self, chunk, cursor, context):


### PR DESCRIPTION
This is a small tweak to make sure that non-canonical forms are never used. This will be helpful when using virtual arrays.