### PR TITLE
fix: Revert "fix: Remove spaces in `fParentName` and `fClassName` when matching streamer"

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -2449,10 +2449,6 @@ in file {self._file.file_path}"""
             fParentName = self.member("fParentName", none_if_missing=True)
             fClassName = self.member("fClassName", none_if_missing=True)
 
-            # Remove spaces
-            fParentName = fParentName.replace(" ", "") if fParentName else fParentName
-            fClassName = fClassName.replace(" ", "") if fClassName else fClassName
-
             if fParentName is not None and fParentName != "":
                 matches = self._file.streamers.get(fParentName)
 


### PR DESCRIPTION
Reverts scikit-hep/uproot5#1505

This created issues with Coffea. Also, I think it's better to stick with the class name that was written to the ROOT file. ROOT has some strict name normalization, so it's good to stick with that. Also, historically the spaces were necessary for proper parsing, even though now they are not necessary for modern C++ versions.