### PR TITLE
fix: update minio interface to be compatible with future versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ test = [
   "deflate",
   "fsspec-xrootd>=0.5.0",
   "isal",
-  "minio<=7.2.18",
+  "minio",
   "paramiko",
   "pytest-rerunfailures",
   "rangehttpserver",


### PR DESCRIPTION
Minio is preparing to release v8.0.0 with some breaking changes. They already (seemingly accidentally) released v7.2.19 with some of those breaking changes. So I'm pinning it to v7.2.18 for now, and we'll move on to v8 once it's been out for a little while.

Here are some relevant links:
https://github.com/minio/minio-py/issues/1532
https://github.com/minio/minio-py/issues/1533
https://github.com/minio/minio-py/pull/1505#issuecomment-3569935445
https://github.com/minio/minio-py/issues/1531