### PR TITLE
fix: Remove spaces in class names when TBranch matching streamer

### DIFF
--- a/src/uproot/behaviors/TBranch.py
+++ b/src/uproot/behaviors/TBranch.py
@@ -2490,7 +2490,7 @@ in file {self._file.file_path}"""
                         "fClonesName", none_if_missing=True
                     ) == self.member(
                         "fParentName"
-                    ):  # Use `self.member("fParentName")` since `fClassName` could contain spaces between brackets.
+                    ):  # Use `self.member("fParentName")` since `fClonesName` could contain spaces between brackets.
                         self._streamer_isTClonesArray = True
 
             elif fClassName is not None and fClassName != "":


### PR DESCRIPTION
Hi,

This PR has checked the whole `TBranch.property` method and made variables consistent before comparisons.

#1505 didn't take subsequent comparison into account, which leads to a wrong value for attribute `_streamer_isTClonesArray`:

https://github.com/scikit-hep/uproot5/blob/fcb1333eccd65b61c9629749ab67859a0d71c221/src/uproot/behaviors/TBranch.py#L2484-L2489

And finally results in a wrong interpretation for the branch:

> The program is supposed to entry the if statement at line 554 (gives an `AsArray` ), but the incorrect `branch._streamer_isTClonesArray` value takes it to line 568 (gies an `AsObjects` instead).

https://github.com/scikit-hep/uproot5/blob/fcb1333eccd65b61c9629749ab67859a0d71c221/src/uproot/interpretation/identify.py#L554-L569
